### PR TITLE
[Feat] prise en charge des pivots relationnels

### DIFF
--- a/scripts/generator/render/renderPivot.ts
+++ b/scripts/generator/render/renderPivot.ts
@@ -3,16 +3,36 @@ import { safeWrite, GEN } from "./common";
 import type { ModelMeta } from "../types";
 
 export function renderPivot(m: ModelMeta) {
-  const dir = path.join(process.cwd(), GEN.out.models, m.name.charAt(0).toLowerCase() + m.name.slice(1));
-  const low = m.name.charAt(0).toLowerCase() + m.name.slice(1);
-  const serviceTs = `// AUTO-GENERATED – DO NOT EDIT
-import { relationService } from "@src/services/relationService";
-export const ${low}Service = relationService("${m.name}");
-`;
-  const indexTs = `// AUTO-GENERATED – DO NOT EDIT
-export * from "./service";
-`;
-  safeWrite(path.join(dir, "service.ts"), serviceTs);
-  safeWrite(path.join(dir, "index.ts"), indexTs);
-}
+    const dir = path.join(
+        process.cwd(),
+        GEN.out.relations,
+        m.name.charAt(0).toLowerCase() + m.name.slice(1)
+    );
+    const low = m.name.charAt(0).toLowerCase() + m.name.slice(1);
 
+    const [assocA, assocB] = m.assocs.filter((a) => a.kind === "belongsTo") as any[];
+    const k1 = assocA?.fk ?? "parentId";
+    const k2 = assocB?.fk ?? "childId";
+
+    const typesTs = `// AUTO-GENERATED – DO NOT EDIT
+export type ${m.name}Type = {
+  id: string;
+  ${k1}: string;
+  ${k2}: string;
+};
+`;
+
+    const serviceTs = `// AUTO-GENERATED – DO NOT EDIT
+import { relationService } from "${GEN.paths.relationService}";
+export const ${low}Service = relationService("${m.name}", "${k1}", "${k2}");
+`;
+
+    const indexTs = `// AUTO-GENERATED – DO NOT EDIT
+export * from "./types";
+export { ${low}Service } from "./service";
+`;
+
+    safeWrite(path.join(dir, "types.ts"), typesTs);
+    safeWrite(path.join(dir, "service.ts"), serviceTs);
+    safeWrite(path.join(dir, "index.ts"), indexTs);
+}


### PR DESCRIPTION
## Description
- génère les fichiers de relation (types, service, index) via `renderPivot`
- utilise `GEN.out.relations` et `GEN.paths.relationService`

## Tests effectués
- `yarn prettier --write scripts/generator/render/renderPivot.ts`
- `yarn lint` *(échec : Unexpected any dans createEntityHooks.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68970adf1ca48324896b5c87bce0ddb1