### PR TITLE
[Feat] move services to entities core

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { client } from "@src/services";
+import { client } from "@src/entities/core/services";
 import type { Schema } from "@/amplify/data/resource";
 import "@aws-amplify/ui-react/styles.css";
 import "./../app/app.css";

--- a/app/todo/TodosWithCommentsPage.tsx
+++ b/app/todo/TodosWithCommentsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import type { Schema } from "@/amplify/data/resource";
-import { client } from "@src/services";
+import { client } from "@src/entities/core/services";
 import "@aws-amplify/ui-react/styles.css";
 import { getCurrentUser } from "aws-amplify/auth";
 

--- a/scripts/generator/generator.config.ts
+++ b/scripts/generator/generator.config.ts
@@ -10,8 +10,8 @@ export const GEN = {
     paths: {
         myTypes: "@myTypes/amplifyBaseTypes",
         createModelForm: "@src/entities/core/createModelForm",
-        crudService: "@src/services",
-        relationService: "@src/entities/core/services/relationService",
+        crudService: "@src/entities/core/services",
+        relationService: "@src/entities/core/services",
         createEntityHooks: "@src/entities/core/createEntityHooks",
         customTypeFormDir: (refType: string) =>
             `@src/entities/customTypes/${refType.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase()}/form`,

--- a/src/entities/core/services/amplifyClient.ts
+++ b/src/entities/core/services/amplifyClient.ts
@@ -1,4 +1,4 @@
-// @src/services/amplifyClient.ts
+// src/entities/core/services/amplifyClient.ts
 
 import { Amplify } from "aws-amplify";
 import { generateClient } from "aws-amplify/data";

--- a/src/entities/core/services/crudService.ts
+++ b/src/entities/core/services/crudService.ts
@@ -1,4 +1,4 @@
-// @src/services/crudService.ts
+// src/entities/core/services/crudService.ts
 import { client, Schema } from "./amplifyClient";
 
 // 🔧 Types dynamiques

--- a/src/entities/core/services/index.ts
+++ b/src/entities/core/services/index.ts
@@ -1,0 +1,3 @@
+export { client, type Schema } from "./amplifyClient";
+export { crudService } from "./crudService";
+export { relationService } from "./relationService";

--- a/src/entities/core/services/relationService.ts
+++ b/src/entities/core/services/relationService.ts
@@ -1,4 +1,4 @@
-// src/services/relationService.ts
+// src/entities/core/services/relationService.ts
 import { client, Schema } from "./amplifyClient";
 
 type ModelKey = keyof typeof client.models;

--- a/src/entities/models/author/service.ts
+++ b/src/entities/models/author/service.ts
@@ -1,3 +1,3 @@
-import { crudService } from "@src/services";
+import { crudService } from "@src/entities/core/services";
 
 export const authorService = crudService("Author");

--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -1,3 +1,3 @@
-import { crudService } from "@src/services";
+import { crudService } from "@src/entities/core/services";
 
 export const postService = crudService("Post");

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -1,3 +1,3 @@
-import { crudService } from "@src/services";
+import { crudService } from "@src/entities/core/services";
 
 export const sectionService = crudService("Section");

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,3 +1,3 @@
-import { crudService } from "@src/services";
+import { crudService } from "@src/entities/core/services";
 
 export const tagService = crudService("Tag");

--- a/src/entities/models/userName/service.ts
+++ b/src/entities/models/userName/service.ts
@@ -1,5 +1,5 @@
 // src/entities/models/userName/service.ts
-import { client } from "@src/services";
+import { client } from "@src/entities/core/services";
 import type { UserNameType } from "./types";
 /**
  * Crée un nouveau record UserName pour l'utilisateur

--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -1,6 +1,6 @@
 // src/lib/userProfileService.ts
 
-import { type Schema, client } from "@src/services";
+import { type Schema, client } from "@src/entities/core/services";
 
 /** CREATE */
 export async function createUserProfile(

--- a/src/entities/relations/postTag/service.ts
+++ b/src/entities/relations/postTag/service.ts
@@ -1,3 +1,3 @@
-import { relationService } from "@src/services";
+import { relationService } from "@src/entities/core/services";
 
 export const postTagService = relationService("PostTag", "postId", "tagId");

--- a/src/entities/relations/sectionPost/service.ts
+++ b/src/entities/relations/sectionPost/service.ts
@@ -1,4 +1,4 @@
-// services/sectionPostService.ts
-import { relationService } from "@services/relationService";
+// src/entities/relations/sectionPost/service.ts
+import { relationService } from "@src/entities/core/services";
 
 export const sectionPostService = relationService("SectionPost", "sectionId", "postId");

--- a/src/services/blogDataService.ts
+++ b/src/services/blogDataService.ts
@@ -1,4 +1,4 @@
-import { client } from "@src/services";
+import { client } from "@src/entities/core/services";
 import type { BlogData, Author, Post, Section } from "@src/types/blog";
 
 export async function fetchBlogData(): Promise<BlogData> {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,1 @@
-export { client, type Schema } from "./amplifyClient";
-export { crudService } from "./crudService";
-export { relationService } from "./relationService";
 export { fetchBlogData } from "./blogDataService";
-


### PR DESCRIPTION
## Description
- move amplifyClient, crudService and relationService into `src/entities/core/services`
- update imports and generator configuration

## Tests
- `yarn install`
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689889a097148324bf5d98e59b476111