### PR TITLE
[Feat] documenter les services core

### DIFF
--- a/src/entities/core/services/doc.md
+++ b/src/entities/core/services/doc.md
@@ -1,0 +1,43 @@
+# Services de base Amplify
+
+## Configuration `amplifyClient`
+
+Le fichier `amplifyClient.ts` configure Amplify avec les sorties générées par `amplify pull` et crée un client typé :
+
+```ts
+import { Amplify } from "aws-amplify";
+import { generateClient } from "aws-amplify/data";
+import outputs from "@/amplify_outputs.json";
+import type { Schema } from "@/amplify/data/resource";
+
+Amplify.configure(outputs);
+export const client = generateClient<Schema>();
+```
+
+Cette configuration permet de générer un client fortement typé (`Schema`) pour accéder aux modèles et opérations GraphQL.
+
+## `crudService`
+
+`crudService` fournit des opérations CRUD génériques pour n'importe quel modèle défini dans `client.models`.
+
+```ts
+import { crudService } from "@src/entities/core/services";
+
+const posts = crudService("Post");
+await posts.create({ title: "Hello" });
+const { data } = await posts.list();
+```
+
+## `relationService`
+
+`relationService` facilite la gestion des tables de relation (many-to-many).
+
+```ts
+import { relationService } from "@src/entities/core/services";
+
+const postsTags = relationService("PostsTags", "postId", "tagId");
+await postsTags.create("post-1", "tag-1");
+const tagIds = await postsTags.listByParent("post-1");
+```
+
+Chaque service expose des méthodes `create`, `delete` et `list` adaptées aux relations spécifiées.


### PR DESCRIPTION
## Objectif
- ajouter `doc.md` pour détailler la configuration d`amplifyClient` ainsi que les services `crudService` et `relationService`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : `You're importing a component that needs useEffect`)*

------
https://chatgpt.com/codex/tasks/task_e_6898a38930a88324b7c69acf7161c013