### PR TITLE
[Feat] Ajoute types de configuration d'entité

### DIFF
--- a/src/entities/core/index.ts
+++ b/src/entities/core/index.ts
@@ -1,3 +1,4 @@
+export * from "./hooks";
 export * from "./services";
 export * from "./utils";
 export * from "./types";

--- a/src/entities/core/types/config.ts
+++ b/src/entities/core/types/config.ts
@@ -1,0 +1,44 @@
+// src/entities/core/types/config.ts
+
+/**
+ * Règles d'authentification appliquées à une entité.
+ */
+export type AuthRule =
+    | { allow: "owner"; ownerField?: string }
+    | { allow: "groups"; groups: string[] }
+    | { allow: "public" }
+    | { allow: "private" };
+
+/**
+ * Nature d'un champ au sein d'une entité.
+ */
+export type FieldKind = "scalar" | "relation" | "identifier";
+
+interface BaseField {
+    type: string;
+    required?: boolean;
+    isArray?: boolean;
+}
+
+export interface FieldDef extends BaseField {
+    kind: "scalar";
+}
+
+export interface RelationDef extends BaseField {
+    kind: "relation";
+    target: string;
+    many?: boolean;
+}
+
+export interface IdentifierDef extends BaseField {
+    kind: "identifier";
+    strategy?: "auto" | "uuid";
+}
+
+export type EntityFields = Record<string, FieldDef | RelationDef | IdentifierDef>;
+
+export interface EntityConfig {
+    name: string;
+    fields: EntityFields;
+    auth?: AuthRule[];
+}

--- a/src/entities/core/types/form.ts
+++ b/src/entities/core/types/form.ts
@@ -1,0 +1,10 @@
+// src/entities/core/types/form.ts
+
+import type { EntityConfig } from "@entities/core/types/config";
+
+/**
+ * Représentation générique d'un formulaire basé sur une configuration d'entité.
+ */
+export type EntityForm<C extends EntityConfig> = {
+    [K in keyof C["fields"]]?: unknown;
+};

--- a/src/entities/core/types/index.ts
+++ b/src/entities/core/types/index.ts
@@ -1,1 +1,4 @@
 export * from "./amplifyBaseTypes";
+export * from "./config";
+export * from "./form";
+export * from "./model";

--- a/src/entities/core/types/model.ts
+++ b/src/entities/core/types/model.ts
@@ -1,0 +1,10 @@
+// src/entities/core/types/model.ts
+
+import type { EntityConfig } from "@entities/core/types/config";
+
+/**
+ * Modèle typé dérivé d'une configuration d'entité.
+ */
+export type EntityModel<C extends EntityConfig> = {
+    [K in keyof C["fields"]]: unknown;
+};


### PR DESCRIPTION
## Description
- ajoute les types de configuration d'entité et leurs exports
- expose des types génériques pour formulaires et modèles

## Tests effectués
- `yarn lint`
- `yarn build` *(échoué: Property 'posts' is missing in type...)*

------
https://chatgpt.com/codex/tasks/task_e_6898e75007788324b0162cf722f910cd