### PR TITLE
[Feat] centralisation des types de profil

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -5,7 +5,7 @@ import "@aws-amplify/ui-react/styles.css";
 import EntitySection from "./shared/EntitySection";
 import PersonIcon from "@mui/icons-material/Person";
 import { useUserNameManager } from "@src/entities";
-import { MinimalUserName } from "./utilsUserName";
+import { MinimalUserName } from "@src/entities/models/userName";
 
 export default function UserNameManager() {
     const { user } = useAuthenticator();

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import "@aws-amplify/ui-react/styles.css";
 import EntitySection from "./shared/EntitySection";
-import { label as fieldLabel, MinimalProfile } from "./utilsProfile";
+import { fieldLabel, MinimalProfile } from "@src/entities/models/userProfile";
 import PhoneIcon from "@mui/icons-material/Phone";
 import PersonIcon from "@mui/icons-material/Person";
 import HomeIcon from "@mui/icons-material/Home";

--- a/src/components/Profile/utilsProfile.tsx
+++ b/src/components/Profile/utilsProfile.tsx
@@ -1,3 +1,5 @@
+import { fieldLabel, type MinimalProfile } from "@src/entities/models/userProfile";
+
 export type Profile = {
     firstName: string | null;
     familyName: string | null;
@@ -6,37 +8,6 @@ export type Profile = {
     city: string | null;
     country: string | null;
     phoneNumber: string | null;
-};
-
-export const label = (field: keyof Profile): string => {
-    switch (field) {
-        case "firstName":
-            return "Prénom";
-        case "familyName":
-            return "Nom";
-        case "address":
-            return "Adresse";
-        case "postalCode":
-            return "Code postal";
-        case "city":
-            return "Ville";
-        case "country":
-            return "Pays";
-        case "phoneNumber":
-            return "Téléphone";
-        default:
-            return field;
-    }
-};
-
-export type MinimalProfile = {
-    firstName: string;
-    familyName: string;
-    address: string;
-    postalCode: string;
-    city: string;
-    country: string;
-    phoneNumber: string;
 };
 
 export const normalizeFormData = (data: Partial<MinimalProfile>) => ({
@@ -48,3 +19,5 @@ export const normalizeFormData = (data: Partial<MinimalProfile>) => ({
     country: data.country ?? "",
     phoneNumber: data.phoneNumber ?? "",
 });
+
+export { fieldLabel };

--- a/src/components/Profile/utilsUserName.ts
+++ b/src/components/Profile/utilsUserName.ts
@@ -1,4 +1,4 @@
-export type MinimalUserName = { userName: string };
+import { fieldLabel, type MinimalUserName } from "@src/entities/models/userName";
 
 export type SingleFieldUserName = {
     field: keyof MinimalUserName;
@@ -10,8 +10,5 @@ export const normalizeUserName = (d: Partial<MinimalUserName> = {}): MinimalUser
 });
 
 export const userNameLabel = (): string => fieldLabel("userName");
-const labels: Record<keyof MinimalUserName, string> = {
-    userName: "Pseudo public",
-};
 
-export const fieldLabel = (k: keyof MinimalUserName): string => labels[k];
+export { fieldLabel };

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -5,5 +5,38 @@ export * from "./relations/sectionPost";
 export * from "./models/tag";
 export * from "./models/author";
 export * from "./customTypes/seo";
-export * from "./models/userName";
-export * from "./models/userProfile";
+export {
+    useUserNameManager,
+    initialUserNameForm,
+    toUserNameForm,
+    createUserName,
+    updateUserName,
+    getUserName,
+    deleteUserName,
+    observeUserName,
+    userNameService,
+    userNameConfig,
+    fieldLabel as userNameFieldLabel,
+    type MinimalUserName,
+    type UserNameType,
+    type UserNameTypeOmit,
+    type UserNameTypeUpdateInput,
+    type UserNameFormType,
+} from "./models/userName";
+export {
+    useUserProfileManager,
+    initialUserProfileForm,
+    toUserProfileForm,
+    createUserProfile,
+    updateUserProfile,
+    deleteUserProfile,
+    getUserProfile,
+    observeUserProfile,
+    userProfileConfig,
+    fieldLabel as userProfileFieldLabel,
+    type MinimalProfile,
+    type UserProfileType,
+    type UserProfileTypeOmit,
+    type UserProfileTypeUpdateInput,
+    type UserProfileFormType,
+} from "./models/userProfile";

--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { useEntityManager, type FieldConfig } from "@src/entities/core/hooks";
-import { fieldLabel, type MinimalUserName } from "@src/components/Profile/utilsUserName";
+import { fieldLabel, type MinimalUserName } from "@src/entities/models/userName";
 import {
     getUserName,
     createUserName,

--- a/src/entities/models/userName/types.ts
+++ b/src/entities/models/userName/types.ts
@@ -8,3 +8,13 @@ export type UserNameFormType = ModelForm<
     "owner" | "comments" | "postComments",
     "comments" | "postComments"
 >;
+
+export type MinimalUserName = {
+    userName: string;
+};
+
+const labels: Record<keyof MinimalUserName, string> = {
+    userName: "Pseudo public",
+};
+
+export const fieldLabel = (k: keyof MinimalUserName): string => labels[k];

--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { useEntityManager, type FieldConfig } from "@src/entities/core/hooks";
-import { label as fieldLabel, type MinimalProfile } from "@src/components/Profile/utilsProfile";
+import { fieldLabel, type MinimalProfile } from "@src/entities/models/userProfile";
 import {
     getUserProfile,
     createUserProfile,

--- a/src/entities/models/userProfile/types.ts
+++ b/src/entities/models/userProfile/types.ts
@@ -4,3 +4,34 @@ export type UserProfileType = BaseModel<"UserProfile">;
 export type UserProfileTypeOmit = CreateOmit<"UserProfile">;
 export type UserProfileTypeUpdateInput = UpdateInput<"UserProfile">;
 export type UserProfileFormType = ModelForm<"UserProfile">;
+
+export type MinimalProfile = {
+    firstName: string;
+    familyName: string;
+    address: string;
+    postalCode: string;
+    city: string;
+    country: string;
+    phoneNumber: string;
+};
+
+export const fieldLabel = (field: keyof MinimalProfile): string => {
+    switch (field) {
+        case "firstName":
+            return "Prénom";
+        case "familyName":
+            return "Nom";
+        case "address":
+            return "Adresse";
+        case "postalCode":
+            return "Code postal";
+        case "city":
+            return "Ville";
+        case "country":
+            return "Pays";
+        case "phoneNumber":
+            return "Téléphone";
+        default:
+            return field;
+    }
+};


### PR DESCRIPTION
## Description
- déplace `fieldLabel`, `MinimalUserName` et `MinimalProfile` vers les fichiers `types.ts` des entités
- adapte les hooks et composants pour importer depuis `src/entities`
- clarifie les exports globaux des entités (`userNameFieldLabel`, `userProfileFieldLabel`)

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6899d3e1e9948324aaf1c81bfaf57b5c