### PR TITLE
[Feat] étendre la factory de formulaires

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
         "remark-gfm": "^4.0.1",
         "sass": "1.60.0",
         "sharp": "^0.34.1",
-        "ts-morph": "^26.0.0"
+        "ts-morph": "^26.0.0",
+        "zod": "^4.0.17"
     },
     "devDependencies": {
         "@aws-amplify/backend": "^1.16.1",

--- a/src/entities/core/utils/createModelForm.ts
+++ b/src/entities/core/utils/createModelForm.ts
@@ -1,15 +1,29 @@
 // src/entities/core/utils/createModelForm.ts
 
 /**
- * Génère un couple { initialForm, toForm } pour un modèle spécifique.
- * Cela permet de centraliser la logique de transformation des données.
+ * Génère un objet regroupant toutes les fonctions nécessaires à la
+ * manipulation d'un formulaire basé sur un modèle spécifique.
  */
-export function createModelForm<M, F, A extends unknown[] = unknown[]>(
-    initialForm: F,
-    toForm: (model: M, ...args: A) => F
-) {
+import type { ZodType } from "zod";
+
+export function createModelForm<M, F, C, U, A extends unknown[] = unknown[]>({
+    zodSchema,
+    initialForm,
+    toForm,
+    toCreate,
+    toUpdate,
+}: {
+    zodSchema: ZodType<F>;
+    initialForm: F;
+    toForm: (model: M, ...args: A) => F;
+    toCreate: (form: F) => C;
+    toUpdate: (form: F) => U;
+}) {
     return {
+        zodSchema,
         initialForm,
         toForm,
+        toCreate,
+        toUpdate,
     } as const;
 }

--- a/src/entities/core/utils/doc.md
+++ b/src/entities/core/utils/doc.md
@@ -9,11 +9,15 @@ Ce module centralise la configuration de l'interface d'authentification d'AWS Am
 
 ## `createModelForm`
 
-`createModelForm` génère un objet `{ initialForm, toForm }` permettant de convertir un modèle en valeurs de formulaire.
+`createModelForm` génère un objet `{ zodSchema, initialForm, toForm, toCreate, toUpdate }`
+permettant de centraliser la transformation des modèles, la validation et la
+conversion vers les formats de création ou de mise à jour.
 
 ### Exemple
 
 ```ts
+import { z } from "zod";
+
 interface Utilisateur {
     id: string;
     email: string;
@@ -26,13 +30,24 @@ interface FormulaireUtilisateur {
     nomComplet: string;
 }
 
-const utilisateurForm = createModelForm<Utilisateur, FormulaireUtilisateur>(
-    { email: "", nomComplet: "" },
-    (user) => ({
+const utilisateurForm = createModelForm<
+    Utilisateur,
+    FormulaireUtilisateur,
+    FormulaireUtilisateur,
+    FormulaireUtilisateur
+>({
+    zodSchema: z.object({
+        email: z.string(),
+        nomComplet: z.string(),
+    }),
+    initialForm: { email: "", nomComplet: "" },
+    toForm: (user) => ({
         email: user.email,
         nomComplet: `${user.prenom} ${user.nom}`,
-    })
-);
+    }),
+    toCreate: (form) => form,
+    toUpdate: (form) => form,
+});
 
 const exemple: Utilisateur = {
     id: "42",

--- a/src/entities/models/author/config.ts
+++ b/src/entities/models/author/config.ts
@@ -1,21 +1,19 @@
-import { initialAuthorForm, toAuthorForm } from "./form";
-import type { AuthorFormType, AuthorTypeUpdateInput } from "./types";
+import {
+    authorSchema,
+    initialAuthorForm,
+    toAuthorForm,
+    toAuthorCreate,
+    toAuthorUpdate,
+} from "./form";
 
 export const authorConfig = {
     auth: "admin",
     identifier: "id",
     fields: ["authorName", "bio", "email", "avatar", "order"],
     relations: ["posts"],
+    zodSchema: authorSchema,
     toForm: toAuthorForm,
-    toCreate: (form: AuthorFormType): AuthorTypeUpdateInput => {
-        const { postIds, ...values } = form;
-        void postIds;
-        return values;
-    },
-    toUpdate: (form: AuthorFormType): AuthorTypeUpdateInput => {
-        const { postIds, ...values } = form;
-        void postIds;
-        return values;
-    },
+    toCreate: toAuthorCreate,
+    toUpdate: toAuthorUpdate,
     initialForm: initialAuthorForm,
 };

--- a/src/entities/models/author/form.ts
+++ b/src/entities/models/author/form.ts
@@ -1,23 +1,49 @@
-import type { AuthorType, AuthorFormType } from "./types";
+import { z, type ZodType } from "zod";
+import type { AuthorType, AuthorFormType, AuthorTypeUpdateInput } from "./types";
 import { createModelForm } from "@src/entities/core";
 
-export const { initialForm: initialAuthorForm, toForm: toAuthorForm } = createModelForm<
+export const {
+    zodSchema: authorSchema,
+    initialForm: initialAuthorForm,
+    toForm: toAuthorForm,
+    toCreate: toAuthorCreate,
+    toUpdate: toAuthorUpdate,
+} = createModelForm<
     AuthorType,
     AuthorFormType,
+    AuthorTypeUpdateInput,
+    AuthorTypeUpdateInput,
     [string[]]
->(
-    {
+>({
+    zodSchema: z.object({
+        authorName: z.string(),
+        avatar: z.string(),
+        bio: z.string(),
+        email: z.string(),
+        postIds: z.array(z.string()),
+    }) as ZodType<AuthorFormType>,
+    initialForm: {
         authorName: "",
         avatar: "",
         bio: "",
         email: "",
         postIds: [],
     },
-    (author, postIds: string[] = []) => ({
+    toForm: (author, postIds: string[] = []) => ({
         authorName: author.authorName ?? "",
         avatar: author.avatar ?? "",
         bio: author.bio ?? "",
         email: author.email ?? "",
         postIds,
-    })
-);
+    }),
+    toCreate: (form: AuthorFormType): AuthorTypeUpdateInput => {
+        const { postIds, ...values } = form;
+        void postIds;
+        return values;
+    },
+    toUpdate: (form: AuthorFormType): AuthorTypeUpdateInput => {
+        const { postIds, ...values } = form;
+        void postIds;
+        return values;
+    },
+});

--- a/src/entities/models/post/config.ts
+++ b/src/entities/models/post/config.ts
@@ -1,5 +1,4 @@
-import { initialPostForm, toPostForm } from "./form";
-import type { PostFormType, PostTypeUpdateInput } from "./types";
+import { postSchema, initialPostForm, toPostForm, toPostCreate, toPostUpdate } from "./form";
 
 export const postConfig = {
     auth: "admin",
@@ -17,18 +16,9 @@ export const postConfig = {
         "seo",
     ],
     relations: ["author", "tags", "sections", "comments"],
+    zodSchema: postSchema,
     toForm: toPostForm,
-    toCreate: (form: PostFormType): PostTypeUpdateInput => {
-        const { tagIds, sectionIds, ...values } = form;
-        void tagIds;
-        void sectionIds;
-        return values;
-    },
-    toUpdate: (form: PostFormType): PostTypeUpdateInput => {
-        const { tagIds, sectionIds, ...values } = form;
-        void tagIds;
-        void sectionIds;
-        return values;
-    },
+    toCreate: toPostCreate,
+    toUpdate: toPostUpdate,
     initialForm: initialPostForm,
 };

--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -1,13 +1,41 @@
-import { type PostType, type PostFormType, toSeoForm } from "@src/entities";
+import { z, type ZodType } from "zod";
+import {
+    type PostType,
+    type PostFormType,
+    type PostTypeUpdateInput,
+    toSeoForm,
+} from "@src/entities";
 import { createModelForm } from "@src/entities/core";
 import { initialSeoForm } from "@/src/entities/customTypes/seo/form";
 
-export const { initialForm: initialPostForm, toForm: toPostForm } = createModelForm<
+export const {
+    zodSchema: postSchema,
+    initialForm: initialPostForm,
+    toForm: toPostForm,
+    toCreate: toPostCreate,
+    toUpdate: toPostUpdate,
+} = createModelForm<
     PostType,
     PostFormType,
+    PostTypeUpdateInput,
+    PostTypeUpdateInput,
     [string[], string[]]
->(
-    {
+>({
+    zodSchema: z.object({
+        slug: z.string(),
+        title: z.string(),
+        excerpt: z.string(),
+        content: z.string(),
+        status: z.string(),
+        authorId: z.string(),
+        order: z.number(),
+        videoUrl: z.string(),
+        type: z.string(),
+        seo: z.any(),
+        tagIds: z.array(z.string()),
+        sectionIds: z.array(z.string()),
+    }) as ZodType<PostFormType>,
+    initialForm: {
         slug: "",
         title: "",
         excerpt: "",
@@ -21,7 +49,7 @@ export const { initialForm: initialPostForm, toForm: toPostForm } = createModelF
         tagIds: [],
         sectionIds: [],
     },
-    (post, tagIds: string[] = [], sectionIds: string[] = []) => ({
+    toForm: (post, tagIds: string[] = [], sectionIds: string[] = []) => ({
         slug: post.slug ?? "",
         title: post.title ?? "",
         excerpt: post.excerpt ?? "",
@@ -34,5 +62,17 @@ export const { initialForm: initialPostForm, toForm: toPostForm } = createModelF
         seo: toSeoForm(post.seo),
         tagIds,
         sectionIds,
-    })
-);
+    }),
+    toCreate: (form: PostFormType): PostTypeUpdateInput => {
+        const { tagIds, sectionIds, ...values } = form;
+        void tagIds;
+        void sectionIds;
+        return values;
+    },
+    toUpdate: (form: PostFormType): PostTypeUpdateInput => {
+        const { tagIds, sectionIds, ...values } = form;
+        void tagIds;
+        void sectionIds;
+        return values;
+    },
+});

--- a/src/entities/models/section/config.ts
+++ b/src/entities/models/section/config.ts
@@ -1,21 +1,19 @@
-import { initialSectionForm, toSectionForm } from "./form";
-import type { SectionFormTypes, SectionTypesUpdateInput } from "./types";
+import {
+    sectionSchema,
+    initialSectionForm,
+    toSectionForm,
+    toSectionCreate,
+    toSectionUpdate,
+} from "./form";
 
 export const sectionConfig = {
     auth: "admin",
     identifier: "id",
     fields: ["slug", "title", "description", "order", "seo"],
     relations: ["posts"],
+    zodSchema: sectionSchema,
     toForm: toSectionForm,
-    toCreate: (form: SectionFormTypes): SectionTypesUpdateInput => {
-        const { postIds, ...values } = form;
-        void postIds;
-        return values;
-    },
-    toUpdate: (form: SectionFormTypes): SectionTypesUpdateInput => {
-        const { postIds, ...values } = form;
-        void postIds;
-        return values;
-    },
+    toCreate: toSectionCreate,
+    toUpdate: toSectionUpdate,
     initialForm: initialSectionForm,
 };

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -1,13 +1,35 @@
-import { type SectionTypes, type SectionFormTypes, toSeoForm } from "@src/entities";
+import { z, type ZodType } from "zod";
+import {
+    type SectionTypes,
+    type SectionFormTypes,
+    type SectionTypesUpdateInput,
+    toSeoForm,
+} from "@src/entities";
 import { createModelForm } from "@src/entities/core";
 import { initialSeoForm } from "@/src/entities/customTypes/seo/form";
 
-export const { initialForm: initialSectionForm, toForm: toSectionForm } = createModelForm<
+export const {
+    zodSchema: sectionSchema,
+    initialForm: initialSectionForm,
+    toForm: toSectionForm,
+    toCreate: toSectionCreate,
+    toUpdate: toSectionUpdate,
+} = createModelForm<
     SectionTypes,
     SectionFormTypes,
+    SectionTypesUpdateInput,
+    SectionTypesUpdateInput,
     [string[]]
->(
-    {
+>({
+    zodSchema: z.object({
+        slug: z.string(),
+        title: z.string(),
+        description: z.string(),
+        order: z.number(),
+        seo: z.any(),
+        postIds: z.array(z.string()),
+    }) as ZodType<SectionFormTypes>,
+    initialForm: {
         slug: "",
         title: "",
         description: "",
@@ -15,12 +37,22 @@ export const { initialForm: initialSectionForm, toForm: toSectionForm } = create
         seo: { ...initialSeoForm },
         postIds: [],
     },
-    (section, postIds: string[] = []) => ({
+    toForm: (section, postIds: string[] = []) => ({
         slug: section.slug ?? "",
         title: section.title ?? "",
         description: section.description ?? "",
         order: section.order ?? 1,
         seo: toSeoForm(section.seo),
         postIds,
-    })
-);
+    }),
+    toCreate: (form: SectionFormTypes): SectionTypesUpdateInput => {
+        const { postIds, ...values } = form;
+        void postIds;
+        return values;
+    },
+    toUpdate: (form: SectionFormTypes): SectionTypesUpdateInput => {
+        const { postIds, ...values } = form;
+        void postIds;
+        return values;
+    },
+});

--- a/src/entities/models/tag/config.ts
+++ b/src/entities/models/tag/config.ts
@@ -1,21 +1,13 @@
-import { initialTagForm, toTagForm } from "./form";
-import type { TagFormType,  TagTypeUpdateInput } from "./types";
+import { tagSchema, initialTagForm, toTagForm, toTagCreate, toTagUpdate } from "./form";
 
 export const tagConfig = {
     auth: "admin",
     identifier: "id",
     fields: ["name"],
     relations: ["posts"],
+    zodSchema: tagSchema,
     toForm: toTagForm,
-    toCreate: (form: TagFormType): TagTypeUpdateInput => {
-        const { postIds, ...values } = form;
-        void postIds;
-        return values;
-    },
-    toUpdate: (form: TagFormType): TagTypeUpdateInput => {
-        const { postIds, ...values } = form;
-        void postIds;
-        return values;
-    },
+    toCreate: toTagCreate,
+    toUpdate: toTagUpdate,
     initialForm: initialTagForm,
 };

--- a/src/entities/models/tag/form.ts
+++ b/src/entities/models/tag/form.ts
@@ -1,17 +1,34 @@
+import { z, type ZodType } from "zod";
 import { createModelForm } from "@src/entities/core";
-import { type TagType, type TagFormType } from "@src/entities";
+import { type TagType, type TagFormType, type TagTypeUpdateInput } from "@src/entities";
 
-export const { initialForm: initialTagForm, toForm: toTagForm } = createModelForm<
-    TagType,
-    TagFormType,
-    [string[]]
->(
-    {
+export const {
+    zodSchema: tagSchema,
+    initialForm: initialTagForm,
+    toForm: toTagForm,
+    toCreate: toTagCreate,
+    toUpdate: toTagUpdate,
+} = createModelForm<TagType, TagFormType, TagTypeUpdateInput, TagTypeUpdateInput, [string[]]>({
+    zodSchema: z.object({
+        name: z.string(),
+        postIds: z.array(z.string()),
+    }) as ZodType<TagFormType>,
+    initialForm: {
         name: "",
         postIds: [],
     },
-    (tag, postIds: string[] = []) => ({
+    toForm: (tag, postIds: string[] = []) => ({
         name: tag.name ?? "",
         postIds,
-    })
-);
+    }),
+    toCreate: (form: TagFormType): TagTypeUpdateInput => {
+        const { postIds, ...values } = form;
+        void postIds;
+        return values;
+    },
+    toUpdate: (form: TagFormType): TagTypeUpdateInput => {
+        const { postIds, ...values } = form;
+        void postIds;
+        return values;
+    },
+});

--- a/src/entities/models/userName/config.ts
+++ b/src/entities/models/userName/config.ts
@@ -1,17 +1,19 @@
-import { initialUserNameForm, toUserNameForm } from "./form";
-import type { UserNameFormType, UserNameTypeUpdateInput } from "./types";
+import {
+    userNameSchema,
+    initialUserNameForm,
+    toUserNameForm,
+    toUserNameCreate,
+    toUserNameUpdate,
+} from "./form";
 
 export const userNameConfig = {
     auth: "owner",
     identifier: "id",
     fields: ["userName"],
     relations: ["comments", "postComments"],
+    zodSchema: userNameSchema,
     toForm: toUserNameForm,
-    toCreate: (form: UserNameFormType): UserNameTypeUpdateInput => ({
-        ...form,
-    }),
-    toUpdate: (form: UserNameFormType): UserNameTypeUpdateInput => ({
-        ...form,
-    }),
+    toCreate: toUserNameCreate,
+    toUpdate: toUserNameUpdate,
     initialForm: initialUserNameForm,
 };

--- a/src/entities/models/userName/form.ts
+++ b/src/entities/models/userName/form.ts
@@ -1,19 +1,39 @@
+import { z, type ZodType } from "zod";
 import { createModelForm } from "@src/entities/core";
-import type { UserNameType, UserNameFormType } from "./types";
+import type { UserNameType, UserNameFormType, UserNameTypeUpdateInput } from "./types";
 
-export const { initialForm: initialUserNameForm, toForm: toUserNameForm } = createModelForm<
+export const {
+    zodSchema: userNameSchema,
+    initialForm: initialUserNameForm,
+    toForm: toUserNameForm,
+    toCreate: toUserNameCreate,
+    toUpdate: toUserNameUpdate,
+} = createModelForm<
     UserNameType,
     UserNameFormType,
+    UserNameTypeUpdateInput,
+    UserNameTypeUpdateInput,
     [string[], string[]]
->(
-    {
+>({
+    zodSchema: z.object({
+        userName: z.string(),
+        commentsIds: z.array(z.string()),
+        postCommentsIds: z.array(z.string()),
+    }) as ZodType<UserNameFormType>,
+    initialForm: {
         userName: "",
         commentsIds: [],
         postCommentsIds: [],
     },
-    (userName, commentsIds: string[] = [], postCommentsIds: string[] = []) => ({
+    toForm: (userName, commentsIds: string[] = [], postCommentsIds: string[] = []) => ({
         userName: userName.userName ?? "",
         commentsIds,
         postCommentsIds,
-    })
-);
+    }),
+    toCreate: (form: UserNameFormType): UserNameTypeUpdateInput => ({
+        ...form,
+    }),
+    toUpdate: (form: UserNameFormType): UserNameTypeUpdateInput => ({
+        ...form,
+    }),
+});

--- a/src/entities/models/userProfile/config.ts
+++ b/src/entities/models/userProfile/config.ts
@@ -1,16 +1,18 @@
-import { initialUserProfileForm, toUserProfileForm } from "./form";
-import type { UserProfileFormType, UserProfileTypeUpdateInput } from "./types";
+import {
+    userProfileSchema,
+    initialUserProfileForm,
+    toUserProfileForm,
+    toUserProfileCreate,
+    toUserProfileUpdate,
+} from "./form";
 
 export const userProfileConfig = {
     auth: "owner",
     identifier: "id",
     fields: ["firstName", "familyName", "address", "postalCode", "city", "country", "phoneNumber"],
+    zodSchema: userProfileSchema,
     toForm: toUserProfileForm,
-    toCreate: (form: UserProfileFormType): UserProfileTypeUpdateInput => ({
-        ...form,
-    }),
-    toUpdate: (form: UserProfileFormType): UserProfileTypeUpdateInput => ({
-        ...form,
-    }),
+    toCreate: toUserProfileCreate,
+    toUpdate: toUserProfileUpdate,
     initialForm: initialUserProfileForm,
 };

--- a/src/entities/models/userProfile/form.ts
+++ b/src/entities/models/userProfile/form.ts
@@ -1,11 +1,29 @@
+import { z, type ZodType } from "zod";
 import { createModelForm } from "@src/entities/core";
-import type { UserProfileType, UserProfileFormType } from "./types";
+import type { UserProfileType, UserProfileFormType, UserProfileTypeUpdateInput } from "./types";
 
-export const { initialForm: initialUserProfileForm, toForm: toUserProfileForm } = createModelForm<
+export const {
+    zodSchema: userProfileSchema,
+    initialForm: initialUserProfileForm,
+    toForm: toUserProfileForm,
+    toCreate: toUserProfileCreate,
+    toUpdate: toUserProfileUpdate,
+} = createModelForm<
     UserProfileType,
-    UserProfileFormType
->(
-    {
+    UserProfileFormType,
+    UserProfileTypeUpdateInput,
+    UserProfileTypeUpdateInput
+>({
+    zodSchema: z.object({
+        firstName: z.string(),
+        familyName: z.string(),
+        address: z.string(),
+        postalCode: z.string(),
+        city: z.string(),
+        country: z.string(),
+        phoneNumber: z.string(),
+    }) as ZodType<UserProfileFormType>,
+    initialForm: {
         firstName: "",
         familyName: "",
         address: "",
@@ -14,7 +32,7 @@ export const { initialForm: initialUserProfileForm, toForm: toUserProfileForm } 
         country: "",
         phoneNumber: "",
     },
-    (profile) => ({
+    toForm: (profile) => ({
         firstName: profile.firstName ?? "",
         familyName: profile.familyName ?? "",
         address: profile.address ?? "",
@@ -22,5 +40,11 @@ export const { initialForm: initialUserProfileForm, toForm: toUserProfileForm } 
         city: profile.city ?? "",
         country: profile.country ?? "",
         phoneNumber: profile.phoneNumber ?? "",
-    })
-);
+    }),
+    toCreate: (form: UserProfileFormType): UserProfileTypeUpdateInput => ({
+        ...form,
+    }),
+    toUpdate: (form: UserProfileFormType): UserProfileTypeUpdateInput => ({
+        ...form,
+    }),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10912,6 +10912,7 @@ __metadata:
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.2"
     webpack: "npm:^5.0.0"
+    zod: "npm:^4.0.17"
   languageName: unknown
   linkType: soft
 
@@ -20613,6 +20614,13 @@ __metadata:
   version: 3.25.28
   resolution: "zod@npm:3.25.28"
   checksum: 10c0/557fb621813d128f8090c43de65f9e8661ce9bd8bd29d7adc6b38b0a79e14729a8926e28a2e6eee2fa0ec0ea390cc549363f50235e8f45d2e4771906d1f87b20
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.0.17":
+  version: 4.0.17
+  resolution: "zod@npm:4.0.17"
+  checksum: 10c0/c56ef4cc02f8f52be8724c5a8b338266202d68477c7606bee9b7299818b75c9adc27f16f4b6704a372f3e7578bd016f389de19bfec766564b7c39d0d327c540a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Objectif
- étendre la factory pour retourner `zodSchema`, `initialForm`, `toForm`, `toCreate`, `toUpdate`
- aligner les signatures sur les besoins des entités

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689a17cc605483249b97ef1ca6c82e99