### PR TITLE
[Feat] remplace les imports du barrel par des chemins directs

### DIFF
--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -2,11 +2,12 @@
 import React, { useState, useEffect, useRef } from "react";
 import PostList from "./PostList";
 import PostForm from "./PostForm";
-import { postService, type PostType  } from "@src/entities";
+import { postService } from "@src/entities/models/post/service";
+import { type PostType } from "@src/entities/models/post/types";
 import RequireAdmin from "../../../RequireAdmin";
 export default function PostManagerPage() {
-    const [posts, setPosts] = useState<PostType []>([]);
-    const [editingPost, setEditingPost] = useState<PostType  | null>(null);
+    const [posts, setPosts] = useState<PostType[]>([]);
+    const [editingPost, setEditingPost] = useState<PostType | null>(null);
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
 

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -4,7 +4,8 @@ import React, { useEffect, useState, useRef } from "react";
 import RequireAdmin from "@components/RequireAdmin";
 import SectionForm from "./SectionsForm";
 import SectionList from "./SectionList";
-import { sectionService, type SectionTypes } from "@src/entities";
+import { sectionService } from "@src/entities/models/section/service";
+import { type SectionTypes } from "@src/entities/models/section/types";
 
 export default function SectionManagerPage() {
     const [sections, setSections] = useState<SectionTypes[]>([]);

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import Link from "next/link";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { PowerButton } from "@src/components/buttons";
-import { useUserNameManager } from "@src/entities"; // <-- le hook générique qu'on vient de créer
+import { useUserNameManager } from "@src/entities/models/userName/hooks"; // <-- le hook générique qu'on vient de créer
 import UserNameModal from "@src/components/Profile/UserNameModal";
 
 const Header = () => {

--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -5,7 +5,8 @@ import "@aws-amplify/ui-react/styles.css";
 import EntitySection from "./shared/EntitySection";
 import { label as fieldLabel } from "./utilsUserName";
 import PersonIcon from "@mui/icons-material/Person";
-import { useUserNameManager, type UserNameMinimalType } from "@src/entities";
+import { useUserNameManager } from "@src/entities/models/userName/hooks";
+import { type UserNameMinimalType } from "@src/entities/models/userName/types";
 
 export default function UserNameManager() {
     const { user } = useAuthenticator();

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -7,7 +7,8 @@ import { label as fieldLabel } from "./utilsUserProfile";
 import PhoneIcon from "@mui/icons-material/Phone";
 import PersonIcon from "@mui/icons-material/Person";
 import HomeIcon from "@mui/icons-material/Home";
-import { useUserProfileManager, UserProfileMinimalType } from "@src/entities";
+import { useUserProfileManager } from "@src/entities/models/userProfile/hooks";
+import { type UserProfileMinimalType } from "@src/entities/models/userProfile/types";
 
 export default function UserProfileManager() {
     const { user } = useAuthenticator();

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -1,11 +1,7 @@
 import { useState, useEffect, type ChangeEvent } from "react";
-import {
-    authorService,
-    type AuthorType,
-    type AuthorFormType,
-    initialAuthorForm,
-    toAuthorForm,
-} from "@src/entities";
+import { authorService } from "@src/entities/models/author/service";
+import { type AuthorType, type AuthorFormType } from "@src/entities/models/author/types";
+import { initialAuthorForm, toAuthorForm } from "@src/entities/models/author/form";
 
 export function useAuthorForm(setMessage: (msg: string) => void) {
     const [authors, setAuthors] = useState<AuthorType[]>([]);

--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -3,10 +3,9 @@ import {
     type PostType,
     type PostFormType,
     type PostTypeUpdateInput,
-    toSeoForm,
-} from "@src/entities";
+} from "@src/entities/models/post/types";
+import { toSeoForm, initialSeoForm } from "@src/entities/customTypes/seo/form";
 import { createModelForm } from "@src/entities/core";
-import { initialSeoForm } from "@/src/entities/customTypes/seo/form";
 
 export const {
     zodSchema: postSchema,

--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -1,23 +1,19 @@
 import { useState, useEffect, ChangeEvent, FormEvent } from "react";
 
 import { useAutoGenFields, slugify } from "@/src/hooks/useAutoGenFields";
-import {
-    postTagService,
-    sectionPostService,
-    postService,
-    sectionService,
-    tagService,
-    authorService,
-    type PostType,
-    type PostFormType,
-    type SectionTypes,
-    type TagType,
-    type AuthorType,
-    type SeoFormType,
-    initialPostForm,
-    toPostForm,
-    initialSeoForm,
-} from "@src/entities";
+import { postTagService } from "@src/entities/relations/postTag/service";
+import { sectionPostService } from "@src/entities/relations/sectionPost/service";
+import { postService } from "@src/entities/models/post/service";
+import { sectionService } from "@src/entities/models/section/service";
+import { tagService } from "@src/entities/models/tag/service";
+import { authorService } from "@src/entities/models/author/service";
+import { type PostType, type PostFormType } from "@src/entities/models/post/types";
+import { type SectionTypes } from "@src/entities/models/section/types";
+import { type TagType } from "@src/entities/models/tag/types";
+import { type AuthorType } from "@src/entities/models/author/types";
+import { type SeoFormType } from "@src/entities/customTypes/seo/types";
+import { initialPostForm, toPostForm } from "@src/entities/models/post/form";
+import { initialSeoForm } from "@src/entities/customTypes/seo/form";
 
 export function usePostForm(post: PostType | null, onSave: () => void) {
     const [form, setForm] = useState<PostFormType>({ ...initialPostForm });

--- a/src/entities/models/post/types.ts
+++ b/src/entities/models/post/types.ts
@@ -1,5 +1,5 @@
 import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-import { type SeoTypeOmit } from "@src/entities";
+import { type SeoTypeOmit } from "@src/entities/customTypes/seo/types";
 
 export type PostType = BaseModel<"Post">;
 export type PostTypeOmit = CreateOmit<"Post">;

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -3,10 +3,9 @@ import {
     type SectionTypes,
     type SectionFormTypes,
     type SectionTypesUpdateInput,
-    toSeoForm,
-} from "@src/entities";
+} from "@src/entities/models/section/types";
+import { toSeoForm, initialSeoForm } from "@src/entities/customTypes/seo/form";
 import { createModelForm } from "@src/entities/core";
-import { initialSeoForm } from "@/src/entities/customTypes/seo/form";
 
 export const {
     zodSchema: sectionSchema,

--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -1,14 +1,10 @@
 import { useState, useEffect, ChangeEvent } from "react";
-import {
-    postService,
-    sectionService,
-    sectionPostService,
-    type PostType,
-    type SectionFormTypes,
-    type SectionTypes,
-    initialSectionForm,
-    toSectionForm,
-} from "@src/entities";
+import { postService } from "@src/entities/models/post/service";
+import { sectionService } from "@src/entities/models/section/service";
+import { sectionPostService } from "@src/entities/relations/sectionPost/service";
+import { type PostType } from "@src/entities/models/post/types";
+import { type SectionFormTypes, type SectionTypes } from "@src/entities/models/section/types";
+import { initialSectionForm, toSectionForm } from "@src/entities/models/section/form";
 import { useAutoGenFields, slugify } from "@/src/hooks/useAutoGenFields";
 
 export function useSectionForm(section: SectionTypes | null, onSave: () => void) {

--- a/src/entities/models/section/types.ts
+++ b/src/entities/models/section/types.ts
@@ -1,5 +1,5 @@
 import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-import { type SeoTypeOmit } from "@src/entities";
+import { type SeoTypeOmit } from "@src/entities/customTypes/seo/types";
 
 export type SectionTypes = BaseModel<"Section">;
 export type SectionTypesOmit = CreateOmit<"Section">;

--- a/src/entities/models/tag/form.ts
+++ b/src/entities/models/tag/form.ts
@@ -1,6 +1,10 @@
 import { z, type ZodType } from "zod";
 import { createModelForm } from "@src/entities/core";
-import { type TagType, type TagFormType, type TagTypeUpdateInput } from "@src/entities";
+import {
+    type TagType,
+    type TagFormType,
+    type TagTypeUpdateInput,
+} from "@src/entities/models/tag/types";
 
 export const {
     zodSchema: tagSchema,

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -1,15 +1,12 @@
 import { useState, useEffect, useCallback, type ChangeEvent } from "react";
 
-import {
-    postService,
-    tagService,
-    postTagService,
-    type TagFormType,
-    type TagType,
-    type PostType,
-    type PostTagType,
-    initialTagForm,
-} from "@src/entities";
+import { postService } from "@src/entities/models/post/service";
+import { tagService } from "@src/entities/models/tag/service";
+import { postTagService } from "@src/entities/relations/postTag/service";
+import { type TagFormType, type TagType } from "@src/entities/models/tag/types";
+import { type PostType } from "@src/entities/models/post/types";
+import { type PostTagType } from "@src/entities/relations/postTag/types";
+import { initialTagForm } from "@src/entities/models/tag/form";
 
 export function useTagForm() {
     const [tags, setTags] = useState<TagType[]>([]);

--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -8,8 +8,8 @@ import {
     createUserName,
     updateUserName,
     deleteUserName,
-    type UserNameMinimalType,
-} from "@src/entities/models/userName";
+} from "@src/entities/models/userName/service";
+import { type UserNameMinimalType } from "@src/entities/models/userName/types";
 
 export function useUserNameManager() {
     const { user } = useAuthenticator();

--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -8,8 +8,8 @@ import {
     createUserProfile,
     updateUserProfile,
     deleteUserProfile,
-    type UserProfileMinimalType,
-} from "@src/entities/models/userProfile";
+} from "@src/entities/models/userProfile/service";
+import { type UserProfileMinimalType } from "@src/entities/models/userProfile/types";
 
 export function useUserProfileManager() {
     const { user } = useAuthenticator();


### PR DESCRIPTION
## Description
- remplacer les imports `@src/entities` par des chemins directs vers chaque module

## Tests effectués
- `yarn install`
- `yarn prettier --write <fichiers>`
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689a1e5dc1e48324a3d880f9b0efc618