### PR TITLE
[Feat] utilitaire de synchronisation many-to-many

### DIFF
--- a/src/entities/core/utils/index.ts
+++ b/src/entities/core/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./amplifyUiConfig";
 export * from "./createModelForm";
 export * from "./createEntityHooks";
+export * from "./syncManyToMany";

--- a/src/entities/core/utils/syncManyToMany.ts
+++ b/src/entities/core/utils/syncManyToMany.ts
@@ -1,0 +1,10 @@
+export async function syncManyToMany(
+    currentIds: string[],
+    targetIds: string[],
+    createFn: (id: string) => Promise<unknown>,
+    deleteFn: (id: string) => Promise<unknown>
+) {
+    const toAdd = targetIds.filter((id) => !currentIds.includes(id));
+    const toRemove = currentIds.filter((id) => !targetIds.includes(id));
+    await Promise.all([...toAdd.map((id) => createFn(id)), ...toRemove.map((id) => deleteFn(id))]);
+}


### PR DESCRIPTION
## Description
- factorise la synchronisation des relations avec `syncManyToMany`
- applique l'utilitaire aux formulaires des posts, sections et tags

## Tests effectués
- `yarn prettier --write src/entities/core/utils/syncManyToMany.ts src/entities/core/utils/index.ts src/entities/models/post/hooks.tsx src/entities/models/tag/hooks.tsx src/entities/models/section/hooks.tsx`
- `yarn lint`
- `yarn build` *(échoue: Property 'selectedTagIds' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689afa958220832480a1b80d87f9341c