### PR TITLE
[Feat] prise en charge de tableaux et callbacks dans useEntityManager

### DIFF
--- a/src/components/Profile/shared/EntityForm.tsx
+++ b/src/components/Profile/shared/EntityForm.tsx
@@ -1,6 +1,6 @@
 // src/components/shared/EntityForm.tsx
 "use client";
-import React, { type ChangeEvent, FormEvent } from "react";
+import React, { type FormEvent } from "react";
 import { SaveButton, AddButton, CancelButton } from "../../buttons/Buttons";
 import { type FieldKey } from "@entities/core/hooks";
 
@@ -8,7 +8,7 @@ type Props<T extends Record<string, unknown>> = {
     formData: Partial<T>;
     fields: FieldKey<T>[];
     labels: (field: FieldKey<T>) => string;
-    handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    handleChange: (field: FieldKey<T>, value: unknown) => void;
     handleSubmit: () => void;
     isEdit: boolean;
     onCancel: () => void;
@@ -43,7 +43,7 @@ export default function EntityForm<T extends Record<string, unknown>>({
                         name={String(field)}
                         placeholder={labels(field)}
                         value={String(formData[field] ?? "")}
-                        onChange={handleChange}
+                        onChange={(e) => handleChange(field, e.target.value)}
                         className="w-full p-2 border rounded"
                         required={requiredFields.includes(field)}
                     />

--- a/src/entities/core/hooks/doc.md
+++ b/src/entities/core/hooks/doc.md
@@ -2,7 +2,7 @@
 
 ## useEntityManager
 
-Hook utilitaire pour gérer une entité. Il prend en charge des champs `string` ou typés via une configuration.
+Hook utilitaire pour gérer une entité. Il prend en charge des champs `string`, des tableaux (IDs de relations) ou encore des objets imbriqués via une configuration.
 
 ### Paramètres clés
 
@@ -14,6 +14,8 @@ Hook utilitaire pour gérer une entité. Il prend en charge des champs `string` 
 - `fields` : liste des clés gérées.
 - `initialData` : valeurs initiales du formulaire.
 - `config` : décrit pour chaque champ `parse`, `serialize`, `validate` (optionnel) et `emptyValue`.
+- `preSave` : callback optionnel exécuté avant la sauvegarde (ex. synchronisation de relations). Il peut retourner les données à persister.
+- `postSave` : callback optionnel exécuté après la sauvegarde.
 
 ### Valeurs de retour
 
@@ -21,11 +23,11 @@ Hook utilitaire pour gérer une entité. Il prend en charge des champs `string` 
 - `formData` et `setFormData` : état local du formulaire.
 - `editMode` et `setEditMode` : indicateur d'édition globale.
 - `editModeField` et `setEditModeField` : édition ciblée d'un champ.
-- `handleChange` : met à jour `formData` depuis un champ `<input>`.
+- `handleChange` : met à jour `formData` pour un champ donné.
 - `save` / `saveField` / `clearField` / `deleteEntity` : actions CRUD.
 - `labels`, `fields` : renvoient les paramètres correspondants.
 - `loading` : indique qu'une opération est en cours.
-- `fetchData` : déclenche manuellement la récupération.
+- `fetchData` : déclenche manuellement la récupération et retourne l'entité.
 
 ### Exemple
 
@@ -54,4 +56,7 @@ const { formData, handleChange, save } = useEntityManager({
         },
     },
 });
+
+// Exemple d'utilisation de handleChange
+handleChange("age", "42");
 ```

--- a/src/entities/core/utils/createEntityHooks.ts
+++ b/src/entities/core/utils/createEntityHooks.ts
@@ -84,7 +84,7 @@ export function createEntityHooks<T extends Record<string, string>>(
             (acc, f) => ({
                 ...acc,
                 [f]: {
-                    parse: (v: string) => v,
+                    parse: (v) => String(v),
                     serialize: (v: string) => v,
                     emptyValue: "",
                 },

--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -67,7 +67,7 @@ export function useUserNameManager() {
 
     const fieldConfig: FieldConfig<UserNameMinimalType> = {
         userName: {
-            parse: (v: string) => v,
+            parse: (v) => String(v),
             serialize: (v: string) => v,
             emptyValue: "",
         },

--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -84,13 +84,13 @@ export function useUserProfileManager() {
     };
 
     const fieldConfig: FieldConfig<UserProfileMinimalType> = {
-        firstName: { parse: (v: string) => v, serialize: (v: string) => v, emptyValue: "" },
-        familyName: { parse: (v: string) => v, serialize: (v: string) => v, emptyValue: "" },
-        phoneNumber: { parse: (v: string) => v, serialize: (v: string) => v, emptyValue: "" },
-        address: { parse: (v: string) => v, serialize: (v: string) => v, emptyValue: "" },
-        postalCode: { parse: (v: string) => v, serialize: (v: string) => v, emptyValue: "" },
-        city: { parse: (v: string) => v, serialize: (v: string) => v, emptyValue: "" },
-        country: { parse: (v: string) => v, serialize: (v: string) => v, emptyValue: "" },
+        firstName: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
+        familyName: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
+        phoneNumber: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
+        address: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
+        postalCode: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
+        city: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
+        country: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
     };
 
     const manager = useEntityManager<UserProfileMinimalType>({


### PR DESCRIPTION
## Objectif
- Permettre la gestion de champs tableaux et d’objets imbriqués dans `useEntityManager`
- Ajouter des hooks `preSave`/`postSave` pour synchroniser les relations
- Mettre à jour la documentation et les hooks associés

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689aff3129b48324ae20de084755f005