### PR TITLE
[Feat] add generic model form hook

### DIFF
--- a/src/entities/core/hooks/index.ts
+++ b/src/entities/core/hooks/index.ts
@@ -7,3 +7,5 @@ export type {
     UseEntityManagerOptions,
     EntityManagerResult,
 } from "./useEntityManager";
+export { default as useModelForm } from "./useModelForm";
+export type { FormMode, UseModelFormOptions, UseModelFormResult } from "./useModelForm";


### PR DESCRIPTION
## Summary
- add generic useModelForm hook for entity forms
- re-export useModelForm from core hooks index

## Testing
- `yarn prettier --write src/entities/core/hooks/useModelForm.ts src/entities/core/hooks/index.ts`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689b251107508324a59ae70a0ad0f832