### PR TITLE
Fix: simplifier retour useAuthorForm

### DIFF
--- a/src/components/Blog/manage/authors/AuthorsForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorsForm.tsx
@@ -16,8 +16,8 @@ export default function AuthorsForm({ setMessage }: Props) {
         loading,
         handleFormChange,
         handleEdit,
-        handleCancel,
-        handleSave,
+        reset,
+        submit,
         handleDelete,
     } = useAuthorForm(setMessage);
 
@@ -45,8 +45,8 @@ export default function AuthorsForm({ setMessage }: Props) {
                                 editingIndex={editingIndex}
                                 currentIndex={idx}
                                 onEdit={() => handleEdit(idx)}
-                                onSave={handleSave}
-                                onCancel={handleCancel}
+                                onSave={submit}
+                                onCancel={reset}
                                 onDelete={() => handleDelete(idx)}
                                 isFormNew={false}
                             />
@@ -87,7 +87,7 @@ export default function AuthorsForm({ setMessage }: Props) {
                 {editingIndex === null && (
                     <button
                         type="button"
-                        onClick={handleSave}
+                        onClick={submit}
                         className="bg-green-500 text-white py-2 rounded-lg hover:bg-green-600 transition"
                     >
                         Ajouter un auteur

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -27,9 +27,6 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
         extras: { authors, tags, sections },
         submit,
         handleChange,
-        dirty,
-        saving,
-        reset,
         toggleTag,
         toggleSection,
     } = usePostForm(post);

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -32,12 +32,12 @@ export function useAuthorForm(setMessage: (msg: string) => void) {
         setForm(toAuthorForm(authors[idx], []));
     };
 
-    const handleCancel = () => {
+    function reset() {
         setEditingIndex(null);
         setForm({ ...initialAuthorForm });
-    };
+    }
 
-    const handleSave = async () => {
+    async function submit() {
         if (!form.authorName) return;
         try {
             const { postIds, ...authorInput } = form;
@@ -50,12 +50,12 @@ export function useAuthorForm(setMessage: (msg: string) => void) {
                 setMessage("Auteur mis à jour !");
             }
             await fetchData(); // Refresh list after change
-            handleCancel();
+            reset();
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             setMessage(`Erreur : ${msg}`);
         }
-    };
+    }
 
     const handleDelete = async (idx: number) => {
         if (!authors[idx]?.id) return;
@@ -70,16 +70,16 @@ export function useAuthorForm(setMessage: (msg: string) => void) {
         }
     };
 
-    return {
+    const modelForm = {
         authors,
         form,
         editingIndex,
         loading,
         handleFormChange,
         handleEdit,
-        handleCancel,
-        handleSave,
         handleDelete,
         fetchData,
     };
+
+    return { ...modelForm, submit, reset };
 }


### PR DESCRIPTION
## Description
- harmoniser les retours de `useAuthorForm`
- ajuster les formulaires selon la nouvelle API

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689b3c81f6e88324b27eb4b645beb213