### PR TITLE
[Feat] gestion centralisée des messages de formulaire

### DIFF
--- a/src/components/Blog/manage/authors/AuthorsForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorsForm.tsx
@@ -4,11 +4,7 @@ import EditableTextArea from "../components/EditableTextArea";
 import FormActionButtons from "../components/FormActionButtons";
 import { useAuthorForm } from "@entities/models/author/hooks";
 
-interface Props {
-    setMessage: (msg: string) => void;
-}
-
-export default function AuthorsForm({ setMessage }: Props) {
+export default function AuthorsForm() {
     const {
         authors,
         form,
@@ -19,7 +15,8 @@ export default function AuthorsForm({ setMessage }: Props) {
         reset,
         submit,
         handleDelete,
-    } = useAuthorForm(setMessage);
+        message,
+    } = useAuthorForm();
 
     return (
         <div className="mb-6">
@@ -94,6 +91,15 @@ export default function AuthorsForm({ setMessage }: Props) {
                     </button>
                 )}
             </form>
+            {message && (
+                <p
+                    className={`mt-2 text-sm ${
+                        message.startsWith("Erreur") ? "text-red-600" : "text-green-600"
+                    }`}
+                >
+                    {message}
+                </p>
+            )}
         </div>
     );
 }

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -1,24 +1,12 @@
 import RequireAdmin from "../../../RequireAdmin";
 import AuthorsForm from "./AuthorsForm";
-import { useState } from "react";
 
 export default function CreateAuthor() {
-    const [message, setMessage] = useState("");
-
     return (
         <RequireAdmin>
             <div className="p-6 max-w-5xl mx-auto space-y-6">
                 <h1 className="text-2xl font-bold">Éditeur de blog : Auteurs</h1>
-                <AuthorsForm setMessage={setMessage} />
-                {message && (
-                    <p
-                        className={`mt-2 text-sm ${
-                            message.startsWith("Erreur") ? "text-red-600" : "text-green-600"
-                        }`}
-                    >
-                        {message}
-                    </p>
-                )}
+                <AuthorsForm />
             </div>
         </RequireAdmin>
     );

--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -21,12 +21,14 @@ export interface UseModelFormResult<F, E> {
     dirty: boolean;
     saving: boolean;
     error: unknown;
+    message: string | null;
     handleChange: <K extends keyof F>(field: K, value: F[K]) => void;
     submit: () => Promise<void>;
     reset: () => void;
     setForm: React.Dispatch<React.SetStateAction<F>>;
     setExtras: React.Dispatch<React.SetStateAction<E>>;
     setMode: React.Dispatch<React.SetStateAction<FormMode>>;
+    setMessage: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
 function deepEqual(a: unknown, b: unknown) {
@@ -57,6 +59,7 @@ export default function useModelForm<
     const [mode, setMode] = useState<FormMode>(initialMode);
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState<unknown>(null);
+    const [message, setMessage] = useState<string | null>(null);
 
     const dirty = useMemo(() => !deepEqual(form, initialRef.current), [form]);
 
@@ -101,11 +104,13 @@ export default function useModelForm<
         dirty,
         saving,
         error,
+        message,
         handleChange,
         submit,
         reset,
         setForm,
         setExtras,
         setMode,
+        setMessage,
     };
 }

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -3,11 +3,12 @@ import { authorService } from "@entities/models/author/service";
 import { type AuthorType, type AuthorFormType } from "@entities/models/author/types";
 import { initialAuthorForm, toAuthorForm } from "@entities/models/author/form";
 
-export function useAuthorForm(setMessage: (msg: string) => void) {
+export function useAuthorForm() {
     const [authors, setAuthors] = useState<AuthorType[]>([]);
     const [form, setForm] = useState<AuthorFormType>({ ...initialAuthorForm });
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
     const [loading, setLoading] = useState(true);
+    const [message, setMessage] = useState<string | null>(null);
 
     // -------- Chargement initial --------
     useEffect(() => {
@@ -81,5 +82,5 @@ export function useAuthorForm(setMessage: (msg: string) => void) {
         fetchData,
     };
 
-    return { ...modelForm, submit, reset };
+    return { ...modelForm, submit, reset, message, setMessage };
 }


### PR DESCRIPTION
## Résumé
- centralise l'état `message` dans `useModelForm`
- expose `message` et `setMessage` dans `useAuthorForm`
- simplifie les composants auteurs en utilisant le hook mis à jour

## Tests
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689b4120a4248324b192cd3ed84f0d6c