### PR TITLE
[Fix] validation auteur et reset du formulaire de post

### DIFF
--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -29,6 +29,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
         handleChange,
         toggleTag,
         toggleSection,
+        reset: resetForm,
     } = usePostForm(post);
 
     const { handleSourceFocus, handleManualEdit } = useAutoGenFields({
@@ -87,7 +88,12 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
 
     async function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
+        if (!form.authorId) {
+            alert("Veuillez sélectionner un auteur.");
+            return;
+        }
         await submit();
+        resetForm();
         onSave();
     }
 


### PR DESCRIPTION
## Description
- utilise `resetForm` fourni par `usePostForm`
- vérifie `authorId` avant soumission, réinitialise le formulaire après sauvegarde

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689b43306edc8324b961153f6c116b4b