### PR TITLE
[Feat] unifier le mode des formulaires d'entité

### DIFF
--- a/src/components/Blog/manage/authors/AuthorsForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorsForm.tsx
@@ -39,8 +39,8 @@ export default function AuthorsForm() {
                                 <strong>{author.authorName}</strong> — {author.email}
                             </div>
                             <FormActionButtons
-                                editingIndex={editingIndex}
-                                currentIndex={idx}
+                                editingId={editingIndex !== null ? authors[editingIndex].id : null}
+                                currentId={author.id}
                                 onEdit={() => handleEdit(idx)}
                                 onSave={submit}
                                 onCancel={reset}

--- a/src/components/Blog/manage/components/FormActionButtons.jsx
+++ b/src/components/Blog/manage/components/FormActionButtons.jsx
@@ -2,8 +2,8 @@ import ActionButtons from "./buttons/ActionButtons";
 import { EditButton, DeleteButton } from "@components/buttons";
 
 export default function FormActionButtons({
-    editingIndex,
-    currentIndex,
+    editingId,
+    currentId,
     onEdit,
     onSave,
     onCancel,
@@ -12,7 +12,7 @@ export default function FormActionButtons({
     addButtonLabel = "Ajouter",
     className = "",
 }) {
-    if (isFormNew && editingIndex === null) {
+    if (isFormNew && editingId === null) {
         return (
             <button
                 type="button"
@@ -24,7 +24,7 @@ export default function FormActionButtons({
         );
     }
 
-    if (editingIndex === currentIndex) {
+    if (editingId === currentId) {
         return (
             <ActionButtons
                 isEditing={true}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -8,7 +8,6 @@ import RequireAdmin from "../../../RequireAdmin";
 export default function PostManagerPage() {
     const [posts, setPosts] = useState<PostType[]>([]);
     const [editingPost, setEditingPost] = useState<PostType | null>(null);
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
 
     const fetchPosts = async () => {
@@ -21,14 +20,13 @@ export default function PostManagerPage() {
     }, []);
 
     // Edition par index (comme SectionManagerPage)
-    const handleEdit = (idx: number) => {
-        setEditingPost(posts[idx]);
-        setEditingIndex(idx);
+    const handleEdit = (id: string) => {
+        const post = posts.find((p) => p.id === id) ?? null;
+        setEditingPost(post);
     };
 
-    const handleDelete = async (idx: number) => {
+    const handleDelete = async (id: string) => {
         if (!confirm("Supprimer ce post ?")) return;
-        const id = posts[idx].id;
         await postService.delete({ id });
         await fetchPosts();
     };
@@ -36,12 +34,10 @@ export default function PostManagerPage() {
     const handleSave = () => {
         fetchPosts();
         setEditingPost(null);
-        setEditingIndex(null);
     };
 
     const handleCancel = () => {
         setEditingPost(null);
-        setEditingIndex(null);
     };
 
     return (
@@ -51,7 +47,7 @@ export default function PostManagerPage() {
                 <PostForm ref={formRef} post={editingPost} posts={posts} onSave={handleSave} />
                 <PostList
                     posts={posts}
-                    editingIndex={editingIndex}
+                    editingId={editingPost?.id ?? null}
                     onEdit={handleEdit}
                     onSave={() => {
                         // Appelle le submit du formulaire via la ref

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -2,7 +2,6 @@
 "use client";
 import React, { forwardRef, type ChangeEvent, type FormEvent } from "react";
 import { usePostForm } from "@entities/models/post/hooks";
-import { initialPostForm } from "@entities/models/post/form";
 import { useAutoGenFields, slugify } from "@hooks/useAutoGenFields";
 import EditableField from "../components/EditableField";
 import EditableTextArea from "../components/EditableTextArea";
@@ -30,8 +29,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
         handleChange,
         toggleTag,
         toggleSection,
-        setForm,
-        setMode,
+        startCreate,
     } = usePostForm(post);
 
     const { handleSourceFocus, handleManualEdit } = useAutoGenFields({
@@ -95,8 +93,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
             return;
         }
         await submit();
-        setMode("create");
-        setForm(initialPostForm);
+        startCreate();
         onSave();
     }
 

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -1,32 +1,25 @@
 "use client";
 import React from "react";
 import FormActionButtons from "../components/FormActionButtons";
-import { type PostType  } from "@/src/entities/models/post";
+import { type PostType } from "@/src/entities/models/post";
 
 interface Props {
-    posts: PostType [];
-    editingIndex: number | null;
-    onEdit: (idx: number) => void;
+    posts: PostType[];
+    editingId: string | null;
+    onEdit: (id: string) => void;
     onSave: () => void;
     onCancel: () => void;
-    onDelete: (idx: number) => void;
+    onDelete: (id: string) => void;
 }
 
-export default function PostList({
-    posts,
-    editingIndex,
-    onEdit,
-    onSave,
-    onCancel,
-    onDelete,
-}: Props) {
+export default function PostList({ posts, editingId, onEdit, onSave, onCancel, onDelete }: Props) {
     // Pas de mutation d'ordre du state parent (slice())
     return (
         <ul className="mt-6 space-y-2">
             {posts
                 .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-                .map((post, idx) => {
-                    const active = editingIndex === idx;
+                .map((post) => {
+                    const active = editingId === post.id;
                     return (
                         <li
                             key={post.id}
@@ -38,12 +31,12 @@ export default function PostList({
                                 <strong>{post.title}</strong> (ordre : {post.order})
                             </div>
                             <FormActionButtons
-                                editingIndex={editingIndex}
-                                currentIndex={idx}
-                                onEdit={() => onEdit(idx)}
+                                editingId={editingId}
+                                currentId={post.id}
+                                onEdit={() => onEdit(post.id)}
                                 onSave={onSave}
                                 onCancel={onCancel}
-                                onDelete={() => onDelete(idx)}
+                                onDelete={() => onDelete(post.id)}
                                 isFormNew={false}
                             />
                         </li>

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -10,7 +10,6 @@ import { type SectionTypes } from "@entities/models/section/types";
 export default function SectionManagerPage() {
     const [sections, setSections] = useState<SectionTypes[]>([]);
     const [editingSection, setEditingSection] = useState<SectionTypes | null>(null);
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
     const fetchSections = async () => {
         const { data } = await sectionService.list();
@@ -21,14 +20,13 @@ export default function SectionManagerPage() {
         fetchSections();
     }, []);
 
-    const handleEdit = (idx: number) => {
-        setEditingSection(sections[idx]);
-        setEditingIndex(idx);
+    const handleEdit = (id: string) => {
+        const section = sections.find((s) => s.id === id) ?? null;
+        setEditingSection(section);
     };
 
-    const handleDelete = async (idx: number) => {
+    const handleDelete = async (id: string) => {
         if (!confirm("Supprimer cette section ?")) return;
-        const id = sections[idx].id;
         await sectionService.delete({ id });
         await fetchSections();
     };
@@ -36,12 +34,10 @@ export default function SectionManagerPage() {
     const handleSave = () => {
         fetchSections();
         setEditingSection(null);
-        setEditingIndex(null);
     };
 
     const handleCancel = () => {
         setEditingSection(null);
-        setEditingIndex(null);
     };
 
     return (
@@ -56,7 +52,7 @@ export default function SectionManagerPage() {
                 />
                 <SectionList
                     sections={sections}
-                    editingIndex={editingIndex}
+                    editingId={editingSection?.id ?? null}
                     onEdit={handleEdit}
                     onSave={() => {
                         // Appelle le submit du formulaire via la ref

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -5,16 +5,16 @@ import FormActionButtons from "../components/FormActionButtons";
 
 interface Props {
     sections: SectionTypes[];
-    editingIndex: number | null;
-    onEdit: (idx: number) => void;
+    editingId: string | null;
+    onEdit: (id: string) => void;
     onSave: () => void;
     onCancel: () => void;
-    onDelete: (idx: number) => void;
+    onDelete: (id: string) => void;
 }
 
 export default function SectionList({
     sections,
-    editingIndex,
+    editingId,
     onEdit,
     onSave,
     onCancel,
@@ -24,8 +24,8 @@ export default function SectionList({
         <ul className="mt-6 space-y-2">
             {sections
                 .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-                .map((section, idx) => {
-                    const active = editingIndex === idx;
+                .map((section) => {
+                    const active = editingId === section.id;
                     return (
                         <li
                             key={section.id}
@@ -37,12 +37,12 @@ export default function SectionList({
                                 <strong>{section.title}</strong> (ordre : {section.order})
                             </div>
                             <FormActionButtons
-                                editingIndex={editingIndex}
-                                currentIndex={idx}
-                                onEdit={() => onEdit(idx)}
+                                editingId={editingId}
+                                currentId={section.id}
+                                onEdit={() => onEdit(section.id)}
                                 onSave={onSave}
                                 onCancel={onCancel}
-                                onDelete={() => onDelete(idx)}
+                                onDelete={() => onDelete(section.id)}
                                 isFormNew={false}
                             />
                         </li>

--- a/src/entities/core/hooks/index.ts
+++ b/src/entities/core/hooks/index.ts
@@ -7,5 +7,9 @@ export type {
     UseEntityManagerOptions,
     EntityManagerResult,
 } from "./useEntityManager";
-export { default as useModelForm } from "./useModelForm";
-export type { FormMode, UseModelFormOptions, UseModelFormResult } from "./useModelForm";
+export { default as useEntityFormManager } from "./useEntityFormManager";
+export type {
+    FormMode,
+    UseEntityFormManagerOptions,
+    UseEntityFormManagerResult,
+} from "./useEntityFormManager";

--- a/src/entities/core/hooks/useEntityFormManager.ts
+++ b/src/entities/core/hooks/useEntityFormManager.ts
@@ -1,10 +1,11 @@
-// src/entities/core/hooks/useModelForm.ts
+// src/entities/core/hooks/useEntityFormManager.ts
 "use client";
 import { useCallback, useMemo, useRef, useState } from "react";
+import type React from "react";
 
 export type FormMode = "create" | "edit";
 
-export interface UseModelFormOptions<F, E = Record<string, unknown>> {
+export interface UseEntityFormManagerOptions<F, E = Record<string, unknown>> {
     initialForm: F;
     initialExtras?: E;
     mode?: FormMode;
@@ -14,7 +15,7 @@ export interface UseModelFormOptions<F, E = Record<string, unknown>> {
     syncRelations?: (id: string, form: F) => Promise<void>;
 }
 
-export interface UseModelFormResult<F, E> {
+export interface UseEntityFormManagerResult<F, E> {
     form: F;
     extras: E;
     mode: FormMode;
@@ -29,6 +30,9 @@ export interface UseModelFormResult<F, E> {
     setExtras: React.Dispatch<React.SetStateAction<E>>;
     setMode: React.Dispatch<React.SetStateAction<FormMode>>;
     setMessage: React.Dispatch<React.SetStateAction<string | null>>;
+    startCreate: () => void;
+    startEdit: (data: F) => void;
+    cancelEdit: () => void;
 }
 
 function deepEqual(a: unknown, b: unknown) {
@@ -39,10 +43,10 @@ function deepEqual(a: unknown, b: unknown) {
     }
 }
 
-export default function useModelForm<
+export default function useEntityFormManager<
     F extends Record<string, unknown>,
     E extends Record<string, unknown> = Record<string, unknown>,
->(options: UseModelFormOptions<F, E>): UseModelFormResult<F, E> {
+>(options: UseEntityFormManagerOptions<F, E>): UseEntityFormManagerResult<F, E> {
     const {
         initialForm,
         initialExtras,
@@ -72,6 +76,27 @@ export default function useModelForm<
         setMode(initialMode);
         setError(null);
     }, [initialMode]);
+
+    const startCreate = useCallback(() => {
+        setForm(initialForm);
+        setMode("create");
+        setError(null);
+        initialRef.current = initialForm;
+    }, [initialForm]);
+
+    const startEdit = useCallback((data: F) => {
+        setForm(data);
+        setMode("edit");
+        setError(null);
+        initialRef.current = data;
+    }, []);
+
+    const cancelEdit = useCallback(() => {
+        setForm(initialForm);
+        setMode("create");
+        setError(null);
+        initialRef.current = initialForm;
+    }, [initialForm]);
 
     const submit = useCallback(async () => {
         setSaving(true);
@@ -112,5 +137,8 @@ export default function useModelForm<
         setExtras,
         setMode,
         setMessage,
+        startCreate,
+        startEdit,
+        cancelEdit,
     };
 }

--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -1,6 +1,6 @@
 // src/entities/models/post/hooks.tsx
 import { useEffect } from "react";
-import { useModelForm } from "@entities/core/hooks";
+import { useEntityFormManager } from "@entities/core/hooks";
 import { postService } from "@entities/models/post/service";
 import { postTagService } from "@entities/relations/postTag/service";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
@@ -21,7 +21,7 @@ interface Extras extends Record<string, unknown> {
 }
 
 export function usePostForm(post: PostType | null) {
-    const modelForm = useModelForm<PostFormType, Extras>({
+    const modelForm = useEntityFormManager<PostFormType, Extras>({
         initialForm: initialPostForm,
         initialExtras: { authors: [], tags: [], sections: [] },
         create: async (form) => {
@@ -72,7 +72,7 @@ export function usePostForm(post: PostType | null) {
         },
     });
 
-    const { setForm, setExtras, setMode } = modelForm;
+    const { setForm, setExtras, startEdit, startCreate } = modelForm;
 
     useEffect(() => {
         void (async () => {
@@ -96,14 +96,12 @@ export function usePostForm(post: PostType | null) {
                     postTagService.listByParent(post.id),
                     sectionPostService.listByChild(post.id),
                 ]);
-                setForm(toPostForm(post, tagIds, sectionIds));
-                setMode("edit");
+                startEdit(toPostForm(post, tagIds, sectionIds));
             } else {
-                setForm(initialPostForm);
-                setMode("create");
+                startCreate();
             }
         })();
-    }, [post, setForm, setMode]);
+    }, [post, startEdit, startCreate]);
 
     function toggleTag(tagId: string) {
         setForm((prev) => ({


### PR DESCRIPTION
## Description
- introduit `useEntityFormManager` exposant `mode`, `setMode` et des helpers (`startCreate`, `startEdit`, `cancelEdit`)
- adapte la gestion des posts et des sections en utilisant `editingId`
- ajuste `FormActionButtons` pour se baser sur les identifiants plutôt que les index

## Tests effectués
- `yarn install`
- `yarn prettier --write src/entities/core/hooks/useEntityFormManager.ts src/entities/core/hooks/index.ts src/entities/models/post/hooks.tsx src/components/Blog/manage/posts/PostForm.tsx src/components/Blog/manage/posts/PostList.tsx src/components/Blog/manage/posts/CreatePost.tsx src/components/Blog/manage/components/FormActionButtons.jsx src/components/Blog/manage/authors/AuthorsForm.tsx src/components/Blog/manage/sections/SectionList.tsx src/components/Blog/manage/sections/CreateSection.tsx`
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_689b4afbc0748324a28fe90104d3a184