### PR TITLE
[Feat] support profile-based access rules

### DIFF
--- a/src/entities/core/__tests__/auth.test.ts
+++ b/src/entities/core/__tests__/auth.test.ts
@@ -49,6 +49,18 @@ describe("canAccess", () => {
         expect(canAccess(null, entity, rules)).toBe(false);
     });
 
+    it("autorise selon un rôle du profil", () => {
+        const rules: AuthRule[] = [{ allow: "profile", field: "roles", values: ["admin"] }];
+        const profileUser = { profile: { roles: ["admin"] } };
+        expect(canAccess(profileUser, entity, rules)).toBe(true);
+    });
+
+    it("refuse si le rôle du profil ne correspond pas", () => {
+        const rules: AuthRule[] = [{ allow: "profile", field: "roles", values: ["admin"] }];
+        const profileUser = { profile: { roles: ["user"] } };
+        expect(canAccess(profileUser, entity, rules)).toBe(false);
+    });
+
     it("refuse pour une règle inconnue", () => {
         const rules = [{ allow: "custom" }] as AuthRule[];
         expect(canAccess(user, entity, rules)).toBe(false);

--- a/src/entities/core/auth.ts
+++ b/src/entities/core/auth.ts
@@ -1,8 +1,9 @@
-import type { AuthRule } from "./types";
+import type { AuthRule, UserProfile } from "./types";
 
 export interface AuthUser {
     username?: string;
     groups?: string[];
+    profile?: UserProfile;
 }
 
 export function canAccess(
@@ -26,6 +27,19 @@ export function canAccess(
             case "groups": {
                 if (user?.groups && rule.groups.some((g) => user.groups?.includes(g))) {
                     return true;
+                }
+                break;
+            }
+            case "profile": {
+                const value = user?.profile?.[rule.field];
+                if (Array.isArray(value)) {
+                    if (rule.values.some((v) => (value as unknown[]).includes(v))) {
+                        return true;
+                    }
+                } else if (value !== undefined) {
+                    if (rule.values.includes(value as never)) {
+                        return true;
+                    }
                 }
                 break;
             }

--- a/src/entities/core/types/auth.ts
+++ b/src/entities/core/types/auth.ts
@@ -1,0 +1,10 @@
+export interface UserProfile {
+    roles?: string[];
+    [key: string]: unknown;
+}
+
+export interface ProfileRule {
+    allow: "profile";
+    field: string;
+    values: (string | number | boolean)[];
+}

--- a/src/entities/core/types/config.ts
+++ b/src/entities/core/types/config.ts
@@ -1,11 +1,14 @@
 // src/entities/core/types/config.ts
 
+import type { ProfileRule } from "./auth";
+
 /**
  * Règles d'authentification appliquées à une entité.
  */
 export type AuthRule =
     | { allow: "owner"; ownerField?: string }
     | { allow: "groups"; groups: string[] }
+    | ProfileRule
     | { allow: "public" }
     | { allow: "private" };
 

--- a/src/entities/core/types/index.ts
+++ b/src/entities/core/types/index.ts
@@ -2,3 +2,4 @@ export * from "./amplifyBaseTypes";
 export * from "./config";
 export * from "./form";
 export * from "./model";
+export * from "./auth";


### PR DESCRIPTION
## Description
- ajoute un type `UserProfile` et un champ `profile` sur `AuthUser`
- étend `AuthRule` avec `ProfileRule` et gère ce cas dans `canAccess`
- exporte les nouveaux types via `types/index.ts`
- ajoute des tests pour l'accès par rôle de profil

## Tests effectués
- `yarn lint`
- `yarn test`
- `yarn build` *(échoue : Type error: Expected 2-3 arguments, but got 1. in src/entities/models/author/service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b4fe9b170832484af60cfcbdfc0db