### PR TITLE
[Feat] ajout du hook useModelForm

### DIFF
--- a/src/entities/core/hooks/doc.md
+++ b/src/entities/core/hooks/doc.md
@@ -1,62 +1,80 @@
-# Hooks de gestion d'entité
+# Hook de gestion d'entité
 
-## useEntityManager
+## useModelForm
 
-Hook utilitaire pour gérer une entité. Il prend en charge des champs `string`, des tableaux (IDs de relations) ou encore des objets imbriqués via une configuration.
+Hook combinant la gestion d'un formulaire d'entité, la synchronisation des relations et l'édition champ par champ.
 
 ### Paramètres clés
 
-- `fetch` : récupère l'entité actuelle.
+- `fetch` : récupère l'entité initiale.
 - `create` : crée une nouvelle entité.
-- `update` : met à jour une entité existante.
-- `remove` : supprime l'entité.
-- `labels` : retourne un libellé lisible pour chaque champ.
-- `fields` : liste des clés gérées.
-- `initialData` : valeurs initiales du formulaire.
-- `config` : décrit pour chaque champ `parse`, `serialize`, `validate` (optionnel) et `emptyValue`.
-- `preSave` : callback optionnel exécuté avant la sauvegarde (ex. synchronisation de relations). Il peut retourner les données à persister.
-- `postSave` : callback optionnel exécuté après la sauvegarde.
+- `update` : met à jour l'entité courante.
+- `remove` : supprime l'entité (optionnel).
+- `initialForm` : valeurs initiales du formulaire.
+- `initialExtras` : données annexes optionnelles.
+- `fields` : liste des champs gérés.
+- `config` : pour chaque champ : `parse`, `serialize`, `validate` (optionnel) et `emptyValue`.
+- `preSave` / `postSave` : callbacks exécutés avant et après la sauvegarde.
+- `syncRelations` : synchronise les relations après sauvegarde.
+- `validate` : validation globale optionnelle.
+- `mode` : mode initial (`create` ou `edit`).
 
 ### Valeurs de retour
 
-- `entity` : entité récupérée ou `null`.
-- `formData` et `setFormData` : état local du formulaire.
-- `editMode` et `setEditMode` : indicateur d'édition globale.
-- `editModeField` et `setEditModeField` : édition ciblée d'un champ.
-- `handleChange` : met à jour `formData` pour un champ donné.
-- `save` / `saveField` / `clearField` / `deleteEntity` : actions CRUD.
-- `labels`, `fields` : renvoient les paramètres correspondants.
-- `loading` : indique qu'une opération est en cours.
-- `fetchData` : déclenche manuellement la récupération et retourne l'entité.
+- `form`, `setForm` : état du formulaire.
+- `extras`, `setExtras` : état additionnel.
+- `mode`, `setMode` : mode actuel (`create`/`edit`).
+- `dirty` : indique si des changements non sauvegardés existent.
+- `saving` : indique si une sauvegarde est en cours.
+- `error` : dernière erreur rencontrée.
+- `message`, `setMessage` : message utilisateur.
+- `editMode`, `setEditMode` : contrôle de l'édition globale.
+- `editModeField`, `setEditModeField` : édition champ par champ.
+- `handleChange` : met à jour un champ.
+- `submit` : sauvegarde globale.
+- `saveField` : sauvegarde le champ ciblé.
+- `clearField` : réinitialise un champ.
+- `fetchData` : rafraîchit l'entité.
+- `deleteEntity` : supprime l'entité.
+- `startCreate` / `startEdit` / `cancelEdit` : gestion du mode de formulaire.
+- `reset` : réinitialise le formulaire.
 
 ### Exemple
 
 ```ts
-import { useEntityManager } from "@entities/core/hooks";
+import { useModelForm } from "@entities/core/hooks";
 
-const { formData, handleChange, save } = useEntityManager({
+const {
+    form,
+    handleChange,
+    submit,
+    editMode,
+    setEditMode,
+    editModeField,
+    setEditModeField,
+    saveField,
+} = useModelForm({
     fetch: async () => null,
-    create: async (data) => {},
+    create: async (data) => "id",
     update: async (entity, data) => {},
     remove: async (entity) => {},
-    labels: (field) => field,
-    fields: ["age", "active"],
-    initialData: { age: 0, active: false },
+    initialForm: { name: "", age: 0 },
+    fields: ["name", "age"],
     config: {
+        name: {
+            parse: (v) => String(v),
+            serialize: (v) => v,
+            emptyValue: "",
+        },
         age: {
             parse: (v) => Number(v),
             serialize: (v) => v,
             validate: (v) => v >= 0,
             emptyValue: 0,
         },
-        active: {
-            parse: (v) => v === "true",
-            serialize: (v) => String(v),
-            emptyValue: false,
-        },
     },
 });
 
-// Exemple d'utilisation de handleChange
-handleChange("age", "42");
+handleChange("name", "Jean");
+await submit();
 ```

--- a/src/entities/core/hooks/index.ts
+++ b/src/entities/core/hooks/index.ts
@@ -1,15 +1,10 @@
 "use client";
-export { default as useEntityManager } from "./useEntityManager";
+export { default as useModelForm } from "./useModelForm";
 export type {
     FieldKey,
     SingleFieldConfig,
     FieldConfig,
-    UseEntityManagerOptions,
-    EntityManagerResult,
-} from "./useEntityManager";
-export { default as useEntityFormManager } from "./useEntityFormManager";
-export type {
     FormMode,
-    UseEntityFormManagerOptions,
-    UseEntityFormManagerResult,
-} from "./useEntityFormManager";
+    UseModelFormOptions,
+    UseModelFormResult,
+} from "./useModelForm";

--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -1,0 +1,321 @@
+// src/entities/core/hooks/useModelForm.ts
+"use client";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type React from "react";
+
+export type FieldKey<T> = keyof T & string;
+
+export interface SingleFieldConfig<V> {
+    parse: (input: unknown) => V;
+    serialize: (value: V) => unknown;
+    validate?: (value: V) => boolean;
+    emptyValue: V;
+}
+
+export type FieldConfig<T> = { [K in FieldKey<T>]: SingleFieldConfig<T[K]> };
+
+export type FormMode = "create" | "edit";
+
+export interface UseModelFormOptions<
+    F extends Record<string, unknown>,
+    E extends Record<string, unknown> = Record<string, unknown>,
+> {
+    fetch?: () => Promise<(F & { id?: string }) | null>;
+    create: (data: F) => Promise<string | void>;
+    update: (entity: (F & { id?: string }) | null, data: Partial<F>) => Promise<void>;
+    remove?: (entity: (F & { id?: string }) | null) => Promise<void>;
+    initialForm: F;
+    initialExtras?: E;
+    mode?: FormMode;
+    validate?: (form: F) => Promise<boolean> | boolean;
+    fields: FieldKey<F>[];
+    config: FieldConfig<F>;
+    preSave?: (data: F, entity: (F & { id?: string }) | null) => Promise<F | void>;
+    postSave?: (data: F, entity: (F & { id?: string }) | null) => Promise<void>;
+    syncRelations?: (id: string, form: F) => Promise<void>;
+}
+
+export interface UseModelFormResult<F, E> {
+    entity: (F & { id?: string }) | null;
+    form: F;
+    extras: E;
+    mode: FormMode;
+    dirty: boolean;
+    saving: boolean;
+    error: unknown;
+    message: string | null;
+    editMode: boolean;
+    setEditMode: React.Dispatch<React.SetStateAction<boolean>>;
+    editModeField: { field: FieldKey<F>; value: string } | null;
+    setEditModeField: React.Dispatch<
+        React.SetStateAction<{ field: FieldKey<F>; value: string } | null>
+    >;
+    handleChange: (field: FieldKey<F>, value: unknown) => void;
+    submit: () => Promise<void>;
+    reset: () => void;
+    setForm: React.Dispatch<React.SetStateAction<F>>;
+    setExtras: React.Dispatch<React.SetStateAction<E>>;
+    setMode: React.Dispatch<React.SetStateAction<FormMode>>;
+    setMessage: React.Dispatch<React.SetStateAction<string | null>>;
+    startCreate: () => void;
+    startEdit: (data: F) => void;
+    cancelEdit: () => void;
+    saveField: () => Promise<void>;
+    clearField: (field: FieldKey<F>) => Promise<void>;
+    fetchData: () => Promise<(F & { id?: string }) | null>;
+    deleteEntity: () => Promise<void>;
+}
+
+function deepEqual(a: unknown, b: unknown) {
+    try {
+        return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+        return false;
+    }
+}
+
+export default function useModelForm<
+    F extends Record<string, unknown>,
+    E extends Record<string, unknown> = Record<string, unknown>,
+>(options: UseModelFormOptions<F, E>): UseModelFormResult<F, E> {
+    const {
+        fetch,
+        create,
+        update,
+        remove,
+        initialForm,
+        initialExtras,
+        mode: initialMode = "create",
+        validate,
+        fields,
+        config,
+        preSave,
+        postSave,
+        syncRelations,
+    } = options;
+
+    const initialRef = useRef(initialForm);
+    const [entity, setEntity] = useState<(F & { id?: string }) | null>(null);
+    const [form, setForm] = useState<F>(initialForm);
+    const [extras, setExtras] = useState<E>((initialExtras as E) ?? ({} as E));
+    const [mode, setMode] = useState<FormMode>(initialMode);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<unknown>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [editMode, setEditMode] = useState(false);
+    const [editModeField, setEditModeField] = useState<{
+        field: FieldKey<F>;
+        value: string;
+    } | null>(null);
+
+    const dirty = useMemo(() => !deepEqual(form, initialRef.current), [form]);
+
+    const handleChange = useCallback(
+        (field: FieldKey<F>, value: unknown) => {
+            const parsed = config[field].parse(value);
+            if (config[field].validate && !config[field].validate(parsed)) return;
+            setForm((f) => ({ ...f, [field]: parsed }));
+        },
+        [config]
+    );
+
+    const fetchData = useCallback(async () => {
+        if (!fetch) return null;
+        try {
+            const data = await fetch();
+            setEntity(data);
+            if (data) {
+                const next = { ...initialForm } as F;
+                fields.forEach((f) => {
+                    const raw = (data as Record<string, unknown>)[f];
+                    next[f] = config[f].parse(raw);
+                });
+                setForm(next);
+                initialRef.current = next;
+                setMode("edit");
+            } else {
+                setForm(initialForm);
+                setMode("create");
+                initialRef.current = initialForm;
+            }
+            return data;
+        } catch (e) {
+            setError(e);
+            return null;
+        } finally {
+            setEditMode(false);
+        }
+    }, [fetch, fields, config, initialForm]);
+
+    useEffect(() => {
+        if (fetch) {
+            fetchData();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const reset = useCallback(() => {
+        setForm(initialRef.current);
+        setMode(initialMode);
+        setError(null);
+        setEditMode(false);
+    }, [initialMode]);
+
+    const startCreate = useCallback(() => {
+        setEntity(null);
+        setForm(initialForm);
+        setMode("create");
+        setError(null);
+        setEditMode(true);
+        initialRef.current = initialForm;
+    }, [initialForm]);
+
+    const startEdit = useCallback((data: F) => {
+        setForm(data);
+        setMode("edit");
+        setError(null);
+        setEditMode(true);
+        initialRef.current = data;
+    }, []);
+
+    const cancelEdit = useCallback(() => {
+        setForm(initialRef.current);
+        setEditMode(false);
+        setError(null);
+    }, []);
+
+    const submit = useCallback(async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            if (validate) {
+                const valid = await validate(form);
+                if (!valid) {
+                    setSaving(false);
+                    return;
+                }
+            }
+            let serialized = { ...form } as F;
+            for (const f of fields) {
+                const value = form[f];
+                if (config[f].validate && !config[f].validate(value)) {
+                    setSaving(false);
+                    return;
+                }
+                serialized[f] = config[f].serialize(value) as F[FieldKey<F>];
+            }
+            serialized = (await preSave?.(serialized, entity)) ?? serialized;
+            const id =
+                mode === "create"
+                    ? await create(serialized)
+                    : (await update(entity, serialized), entity?.id ?? "");
+            if (syncRelations && typeof id === "string" && id) {
+                await syncRelations(id, serialized);
+            }
+            const updated = await fetchData();
+            await postSave?.(serialized, updated);
+            initialRef.current = form;
+            setEditMode(false);
+            setMessage("Saved");
+            setMode("edit");
+        } catch (e) {
+            setError(e);
+        } finally {
+            setSaving(false);
+        }
+    }, [
+        form,
+        validate,
+        fields,
+        config,
+        preSave,
+        entity,
+        mode,
+        create,
+        update,
+        syncRelations,
+        fetchData,
+        postSave,
+    ]);
+
+    const saveField = useCallback(async () => {
+        if (!editModeField) return;
+        setSaving(true);
+        try {
+            const { field, value } = editModeField;
+            const parsed = config[field].parse(value);
+            if (config[field].validate && !config[field].validate(parsed)) return;
+            const serialized = config[field].serialize(parsed);
+            await update(entity, { [field]: serialized } as Partial<F>);
+            setForm((f) => ({ ...f, [field]: parsed }));
+            setEditModeField(null);
+        } catch (e) {
+            setError(e);
+        } finally {
+            setSaving(false);
+        }
+    }, [editModeField, config, update, entity]);
+
+    const clearField = useCallback(
+        async (field: FieldKey<F>) => {
+            setSaving(true);
+            try {
+                const empty = config[field].emptyValue;
+                const serialized = config[field].serialize(empty);
+                await update(entity, { [field]: serialized } as Partial<F>);
+                setForm((f) => ({ ...f, [field]: empty }));
+            } catch (e) {
+                setError(e);
+            } finally {
+                setSaving(false);
+            }
+        },
+        [config, update, entity]
+    );
+
+    const deleteEntity = useCallback(async () => {
+        if (!remove) return;
+        setSaving(true);
+        try {
+            await remove(entity);
+            setEntity(null);
+            setForm(initialForm);
+            setMode("create");
+            setEditMode(false);
+            initialRef.current = initialForm;
+        } catch (e) {
+            setError(e);
+        } finally {
+            setSaving(false);
+        }
+    }, [remove, entity, initialForm]);
+
+    return {
+        entity,
+        form,
+        extras,
+        mode,
+        dirty,
+        saving,
+        error,
+        message,
+        editMode,
+        setEditMode,
+        editModeField,
+        setEditModeField,
+        handleChange,
+        submit,
+        reset,
+        setForm,
+        setExtras,
+        setMode,
+        setMessage,
+        startCreate,
+        startEdit,
+        cancelEdit,
+        saveField,
+        clearField,
+        fetchData,
+        deleteEntity,
+    };
+}


### PR DESCRIPTION
## Objectif
- fusionner les anciennes gestions de formulaire dans `useModelForm`.
- centraliser l'export et documenter l'API.

## Tests effectués
- `yarn prettier --write src/entities/core/hooks/useModelForm.ts src/entities/core/hooks/index.ts src/entities/core/hooks/doc.md`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689b51b7ff008324b5c19db470caaebf