### PR TITLE
[Feat] ajout du profil utilisateur

### DIFF
--- a/src/entities/core/__tests__/auth.test.ts
+++ b/src/entities/core/__tests__/auth.test.ts
@@ -38,6 +38,24 @@ describe("canAccess", () => {
         expect(canAccess(restrictedUser, entity, rules)).toBe(true);
     });
 
+    it("autorise selon un rôle de profil", () => {
+        const rules: AuthRule[] = [{ allow: "profile", attribute: "roles", values: ["admin"] }];
+        const profiledUser = {
+            username: "alice",
+            profile: { roles: ["admin"] },
+        };
+        expect(canAccess(profiledUser, entity, rules)).toBe(true);
+    });
+
+    it("refuse si le rôle de profil ne correspond pas", () => {
+        const rules: AuthRule[] = [{ allow: "profile", attribute: "roles", values: ["admin"] }];
+        const profiledUser = {
+            username: "bob",
+            profile: { roles: ["user"] },
+        };
+        expect(canAccess(profiledUser, entity, rules)).toBe(false);
+    });
+
     it("autorise l'accès public", () => {
         const rules: AuthRule[] = [{ allow: "public" }];
         expect(canAccess(null, entity, rules)).toBe(true);

--- a/src/entities/core/auth.ts
+++ b/src/entities/core/auth.ts
@@ -1,8 +1,14 @@
 import type { AuthRule } from "./types";
 
+export interface UserProfile {
+    roles?: string[];
+    [key: string]: unknown;
+}
+
 export interface AuthUser {
     username?: string;
     groups?: string[];
+    profile?: UserProfile;
 }
 
 export function canAccess(
@@ -25,6 +31,21 @@ export function canAccess(
             }
             case "groups": {
                 if (user?.groups && rule.groups.some((g) => user.groups?.includes(g))) {
+                    return true;
+                }
+                break;
+            }
+            case "profile": {
+                const attr = rule.attribute;
+                const value = user?.profile?.[attr];
+                if (Array.isArray(value)) {
+                    if (value.some((v) => rule.values.includes(v as string | number | boolean))) {
+                        return true;
+                    }
+                } else if (
+                    value !== undefined &&
+                    rule.values.includes(value as string | number | boolean)
+                ) {
                     return true;
                 }
                 break;

--- a/src/entities/core/types/config.ts
+++ b/src/entities/core/types/config.ts
@@ -6,6 +6,7 @@
 export type AuthRule =
     | { allow: "owner"; ownerField?: string }
     | { allow: "groups"; groups: string[] }
+    | { allow: "profile"; attribute: string; values: (string | number | boolean)[] }
     | { allow: "public" }
     | { allow: "private" };
 

--- a/src/entities/core/types/index.ts
+++ b/src/entities/core/types/index.ts
@@ -2,3 +2,4 @@ export * from "./amplifyBaseTypes";
 export * from "./config";
 export * from "./form";
 export * from "./model";
+export type { AuthUser, UserProfile } from "../auth";


### PR DESCRIPTION
## Objectif
- enrichir `AuthUser` avec un profil
- exploiter ces données dans `canAccess`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Expected 2-3 arguments, but got 1)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689b5149fa008324b12246650e403269