### PR TITLE
[Feat] ajoute des politiques aux services Post, Section et Tag

### DIFF
--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -1,3 +1,13 @@
 import { crudService } from "@entities/core";
+import type { AuthUser, SimplePolicy } from "@entities/core/types";
+import { expandPolicy } from "@entities/core/auth";
 
-export const postService = crudService("Post");
+const policy: SimplePolicy = {
+    read: ["public", "private"],
+    create: { groups: ["ADMINS"] },
+    update: { groups: ["ADMINS"] },
+    delete: { groups: ["ADMINS"] },
+};
+const rules = expandPolicy(policy);
+
+export const postService = (user: AuthUser | null) => crudService("Post", user, rules);

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -1,3 +1,13 @@
 import { crudService } from "@entities/core";
+import type { AuthUser, SimplePolicy } from "@entities/core/types";
+import { expandPolicy } from "@entities/core/auth";
 
-export const sectionService = crudService("Section");
+const policy: SimplePolicy = {
+    read: ["public", "private"],
+    create: { groups: ["ADMINS"] },
+    update: { groups: ["ADMINS"] },
+    delete: { groups: ["ADMINS"] },
+};
+const rules = expandPolicy(policy);
+
+export const sectionService = (user: AuthUser | null) => crudService("Section", user, rules);

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,3 +1,13 @@
 import { crudService } from "@entities/core";
+import type { AuthUser, SimplePolicy } from "@entities/core/types";
+import { expandPolicy } from "@entities/core/auth";
 
-export const tagService = crudService("Tag");
+const policy: SimplePolicy = {
+    read: ["public", "private"],
+    create: { groups: ["ADMINS"] },
+    update: { groups: ["ADMINS"] },
+    delete: { groups: ["ADMINS"] },
+};
+const rules = expandPolicy(policy);
+
+export const tagService = (user: AuthUser | null) => crudService("Tag", user, rules);


### PR DESCRIPTION
## Description
- ajoute une politique SimplePolicy avec expandPolicy pour les modèles Post, Section et Tag
- les services prennent maintenant l'utilisateur pour appliquer les règles CRUD

## Tests effectués
- `yarn install`
- `yarn prettier --write src/entities/models/post/service.ts src/entities/models/section/service.ts src/entities/models/tag/service.ts`
- `yarn lint` *(échoue: Unexpected any dans `src/entities/models/author/hooks.tsx`)*


------
https://chatgpt.com/codex/tasks/task_e_689c66b4700883248c32c4d8326d9efb