### PR TITLE
[Feat] sécuriser services de relations

### DIFF
--- a/src/entities/core/services/relationService.ts
+++ b/src/entities/core/services/relationService.ts
@@ -1,9 +1,15 @@
 // src/entities/core/services/relationService.ts
-import { client, Schema } from "./amplifyClient";
+import { client } from "./amplifyClient";
+import type {
+    AuthRule,
+    AuthUser,
+    Operation,
+    ModelKey,
+    BaseModel,
+    CreateData,
+} from "@entities/core/types";
+import { canAccessOp } from "../auth/authAccess";
 
-type ModelKey = keyof typeof client.models;
-type BaseModel<K extends ModelKey> = Schema[K]["type"];
-type CreateData<K extends ModelKey> = Omit<BaseModel<K>, "id" | "createdAt" | "updatedAt">;
 interface RelationCrudModel<K extends ModelKey> {
     create: (data: Partial<CreateData<K>>) => Promise<{ data: BaseModel<K> }>;
     delete: (where: Partial<CreateData<K>>) => Promise<{ data: BaseModel<K> }>;
@@ -14,42 +20,72 @@ function getRelationClient<K extends ModelKey>(key: K): RelationCrudModel<K> {
     return client.models[key] as unknown as RelationCrudModel<K>;
 }
 
+const READ: Operation = "read";
+const CREATE: Operation = "create";
+const DELETE: Operation = "delete";
+
 export function relationService<
     K extends ModelKey,
-    ParentIdKey extends keyof Schema[K]["type"] & string,
-    ChildIdKey extends keyof Schema[K]["type"] & string,
->(modelName: K, parentIdKey: ParentIdKey, childIdKey: ChildIdKey) {
+    ParentIdKey extends keyof BaseModel<K> & string,
+    ChildIdKey extends keyof BaseModel<K> & string,
+>(
+    modelName: K,
+    user: AuthUser | null,
+    rules: AuthRule[] = [{ allow: "public", operations: [READ] }],
+    parentIdKey: ParentIdKey,
+    childIdKey: ChildIdKey
+) {
     const model = getRelationClient(modelName);
 
     return {
         async create(parentId: string, childId: string) {
-            await model.create({
+            const data = {
                 [parentIdKey]: parentId,
                 [childIdKey]: childId,
-            } as Partial<CreateData<K>>);
+            } as Partial<CreateData<K>>;
+            if (!canAccessOp(user, data as Record<string, unknown>, rules, CREATE)) {
+                throw new Error("Not authorized (create)");
+            }
+            await model.create(data);
         },
 
         async delete(parentId: string, childId: string) {
+            const { data: current } = await model.list({
+                filter: { [parentIdKey]: { eq: parentId }, [childIdKey]: { eq: childId } },
+            });
+            const allowed =
+                current[0] &&
+                canAccessOp(user, current[0] as Record<string, unknown>, rules, DELETE);
+            if (!allowed) throw new Error("Not authorized (delete)");
             await model.delete({
                 [parentIdKey]: parentId,
                 [childIdKey]: childId,
             } as Partial<CreateData<K>>);
         },
         async list(args?: { filter?: Record<string, unknown> }) {
-            return model.list(args);
+            const { data } = await model.list(args);
+            return {
+                data: data.filter((item) =>
+                    canAccessOp(user, item as Record<string, unknown>, rules, READ)
+                ),
+            };
         },
         async listByParent(parentId: string) {
             const { data } = await model.list({
                 filter: { [parentIdKey]: { eq: parentId } },
             });
-            return data.map((item) => item[childIdKey]) as string[];
+            return data
+                .filter((item) => canAccessOp(user, item as Record<string, unknown>, rules, READ))
+                .map((item) => item[childIdKey]) as string[];
         },
 
         async listByChild(childId: string) {
             const { data } = await model.list({
                 filter: { [childIdKey]: { eq: childId } },
             });
-            return data.map((item) => item[parentIdKey]) as string[];
+            return data
+                .filter((item) => canAccessOp(user, item as Record<string, unknown>, rules, READ))
+                .map((item) => item[parentIdKey]) as string[];
         },
     };
 }

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useMemo, useCallback, type ChangeEvent } from "react";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { authorService as authorServiceFactory } from "@entities/models/author/service";
-import type { AuthorType, AuthorFormType, } from "@entities/models/author/types";
+import type { AuthorType, AuthorFormType } from "@entities/models/author/types";
 import { initialAuthorForm, toAuthorForm } from "@entities/models/author/form";
 import type { AuthUser } from "@entities/core/types";
 
@@ -12,8 +12,9 @@ export function useAuthorForm() {
     // Map simple -> AuthUser (ajuste si tu as déjà un util pour récupérer les groups)
     const authUser = useMemo<AuthUser | null>(() => {
         if (!user) return null;
+        const u = user as { userId?: string; username?: string };
         return {
-            username: (user as any)?.userId ?? (user as any)?.username,
+            username: u.userId ?? u.username,
             // groups: [...], // TODO: renseigner si tu veux que CREATE/UPDATE/DELETE passent les règles ADMINS
         };
     }, [user]);

--- a/src/entities/relations/postTag/service.ts
+++ b/src/entities/relations/postTag/service.ts
@@ -1,3 +1,14 @@
 import { relationService } from "@entities/core";
+import type { AuthUser, SimplePolicy } from "@entities/core/types";
+import { expandPolicy } from "@entities/core/auth";
 
-export const postTagService = relationService("PostTag", "postId", "tagId");
+const postTagPolicy: SimplePolicy = {
+    read: ["public", "private"],
+    create: { groups: ["ADMINS"] },
+    update: { groups: ["ADMINS"] },
+    delete: { groups: ["ADMINS"] },
+};
+const postTagRules = expandPolicy(postTagPolicy);
+
+export const postTagService = (user: AuthUser | null) =>
+    relationService("PostTag", user, postTagRules, "postId", "tagId");

--- a/src/entities/relations/sectionPost/service.ts
+++ b/src/entities/relations/sectionPost/service.ts
@@ -1,4 +1,15 @@
 // src/entities/relations/sectionPost/service.ts
 import { relationService } from "@entities/core";
+import type { AuthUser, SimplePolicy } from "@entities/core/types";
+import { expandPolicy } from "@entities/core/auth";
 
-export const sectionPostService = relationService("SectionPost", "sectionId", "postId");
+const sectionPostPolicy: SimplePolicy = {
+    read: ["public", "private"],
+    create: { groups: ["ADMINS"] },
+    update: { groups: ["ADMINS"] },
+    delete: { groups: ["ADMINS"] },
+};
+const sectionPostRules = expandPolicy(sectionPostPolicy);
+
+export const sectionPostService = (user: AuthUser | null) =>
+    relationService("SectionPost", user, sectionPostRules, "sectionId", "postId");


### PR DESCRIPTION
## Objectif
- ajouter des politiques SimplePolicy pour PostTag et SectionPost
- appliquer l'utilisateur et les règles dans `relationService`

## Tests effectués
- `yarn lint`
- `yarn build` *(warnings: exports manquants dans userName service)*

------
https://chatgpt.com/codex/tasks/task_e_689c66ea85dc83249b25bc7076355ee5