### PR TITLE
[Feat] refactor tag hooks with model form

### DIFF
--- a/src/components/Blog/manage/components/tag/PostTagsManager.jsx
+++ b/src/components/Blog/manage/components/tag/PostTagsManager.jsx
@@ -6,8 +6,7 @@ export default function TagsAssociationManager({
     tags,
     tagsForPost,
     isTagLinked,
-    onAdd,
-    onRemove,
+    onToggle,
     loading,
 }) {
     return (
@@ -43,11 +42,7 @@ export default function TagsAssociationManager({
                                     <ButtonBase
                                         key={tag.id}
                                         label={tag.name}
-                                        onClick={() =>
-                                            isTagLinked(post.id, tag.id)
-                                                ? onRemove(post.id, tag.id)
-                                                : onAdd(post.id, tag.id)
-                                        }
+                                        onClick={() => onToggle(post.id, tag.id)}
                                         color={isTagLinked(post.id, tag.id) ? "primary" : "inherit"}
                                         variant={
                                             isTagLinked(post.id, tag.id) ? "contained" : "outlined"

--- a/src/components/Blog/manage/components/tag/TagManager.jsx
+++ b/src/components/Blog/manage/components/tag/TagManager.jsx
@@ -3,14 +3,12 @@ import { AddButton, EditButton, DeleteButton, SaveButton, CancelButton } from "@
 
 export default function TagCrudManager({
     tags,
-    newTag,
-    editTagId,
-    editTagName,
-    setNewTag,
-    setEditTagId,
-    setEditTagName,
-    onCreate,
-    onUpdate,
+    mode,
+    formName,
+    onChangeName,
+    onSubmit,
+    onEdit,
+    onCancel,
     onDelete,
 }) {
     return (
@@ -21,45 +19,32 @@ export default function TagCrudManager({
             <div className="flex flex-wrap gap-2 items-center mb-2">
                 <input
                     type="text"
-                    value={newTag}
-                    onChange={(e) => setNewTag(e.target.value)}
-                    placeholder="Nouveau tag"
+                    value={formName}
+                    onChange={(e) => onChangeName(e.target.value)}
+                    placeholder="Nom du tag"
                     className="border rounded p-2 flex-1 bg-white"
                 />
 
-                <AddButton label="Ajouter" onClick={onCreate} />
+                {mode === "create" ? (
+                    <AddButton label="Ajouter" onClick={onSubmit} />
+                ) : (
+                    <>
+                        <SaveButton label="Enregistrer" onClick={onSubmit} />
+                        <CancelButton label="Annuler" onClick={onCancel} />
+                    </>
+                )}
             </div>
             <ul className="flex flex-wrap gap-2 mt-2">
-                {tags.map((tag) =>
-                    editTagId === tag.id ? (
-                        <li key={tag.id} className="flex gap-2 items-center">
-                            <input
-                                value={editTagName}
-                                onChange={(e) => setEditTagName(e.target.value)}
-                                className="border rounded p-2"
-                                autoFocus
-                            />
-                            <SaveButton label="Enregistrer" onClick={onUpdate} />
-                            <CancelButton label="Annuler" onClick={() => setEditTagId(null)} />
-                        </li>
-                    ) : (
-                        <li
-                            key={tag.id}
-                            className="flex gap-2 items-center px-4 py-1 bg-blue-50 border border-blue-100 rounded-lg"
-                        >
-                            <span className="font-semibold text-blue-700 px-2">{tag.name}</span>
-                            <EditButton
-                                label=""
-                                onClick={() => {
-                                    setEditTagId(tag.id);
-                                    setEditTagName(tag.name);
-                                }}
-                                color="#1976d2"
-                            />
-                            <DeleteButton label="" onClick={() => onDelete(tag.id)} />
-                        </li>
-                    )
-                )}
+                {tags.map((tag) => (
+                    <li
+                        key={tag.id}
+                        className="flex gap-2 items-center px-4 py-1 bg-blue-50 border border-blue-100 rounded-lg"
+                    >
+                        <span className="font-semibold text-blue-700 px-2">{tag.name}</span>
+                        <EditButton label="" onClick={() => onEdit(tag.id)} color="#1976d2" />
+                        <DeleteButton label="" onClick={() => onDelete(tag.id)} />
+                    </li>
+                ))}
             </ul>
         </fieldset>
     );

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -9,42 +9,20 @@ import { useTagForm } from "@entities/models/tag/hooks";
 
 export default function PostsTagsManagerPage() {
     const {
-        tags,
-        posts,
         form,
-        editingIndex,
+        extras: { tags, posts },
+        mode,
         loading,
-        setForm,
-        handleEdit,
-        handleCancel,
-        handleSubmit,
-        handleDelete,
-        handleAddPostTag,
-        handleRemovePostTag,
+        handleChange,
+        edit,
+        cancel,
+        save,
+        remove,
+        toggle,
         tagsForPost,
         isTagLinked,
         fetchAll,
     } = useTagForm();
-
-    const newTag = editingIndex === null ? form.name : "";
-    const editTagId = editingIndex !== null ? tags[editingIndex].id : null;
-    const editTagName = editingIndex !== null ? form.name : "";
-
-    function setNewTag(value: string) {
-        if (editingIndex === null) setForm({ ...form, name: value });
-    }
-
-    function setEditTagId(id: string | null) {
-        if (id === null) handleCancel();
-        else {
-            const idx = tags.findIndex((t) => t.id === id);
-            if (idx !== -1) handleEdit(idx);
-        }
-    }
-
-    function setEditTagName(value: string) {
-        if (editingIndex !== null) setForm({ ...form, name: value });
-    }
 
     return (
         <RequireAdmin>
@@ -55,17 +33,18 @@ export default function PostsTagsManagerPage() {
                 </div>
                 <TagCrudManager
                     tags={tags}
-                    newTag={newTag}
-                    editTagId={editTagId}
-                    editTagName={editTagName}
-                    setNewTag={setNewTag}
-                    setEditTagId={setEditTagId}
-                    setEditTagName={setEditTagName}
-                    onCreate={handleSubmit}
-                    onUpdate={handleSubmit}
+                    mode={mode}
+                    formName={form.name}
+                    onChangeName={(v) => handleChange("name", v)}
+                    onSubmit={save}
+                    onEdit={(id: string) => {
+                        const idx = tags.findIndex((t) => t.id === id);
+                        if (idx !== -1) void edit(idx);
+                    }}
+                    onCancel={cancel}
                     onDelete={(id: string) => {
                         const idx = tags.findIndex((t) => t.id === id);
-                        if (idx !== -1) handleDelete(idx);
+                        if (idx !== -1) void remove(idx);
                     }}
                 />
                 <TagsAssociationManager
@@ -73,8 +52,7 @@ export default function PostsTagsManagerPage() {
                     tags={tags}
                     tagsForPost={tagsForPost}
                     isTagLinked={isTagLinked}
-                    onAdd={handleAddPostTag}
-                    onRemove={handleRemovePostTag}
+                    onToggle={toggle}
                     loading={loading}
                 />
             </div>

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -1,134 +1,160 @@
-import { useState, useEffect, useCallback, type ChangeEvent } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useModelForm } from "@entities/core/hooks";
 import { postService } from "@entities/models/post/service";
 import { tagService } from "@entities/models/tag/service";
 import { postTagService } from "@entities/relations/postTag/service";
 import { type TagFormType, type TagType } from "@entities/models/tag/types";
 import { type PostType } from "@entities/models/post/types";
 import { type PostTagType } from "@entities/relations/postTag/types";
-import { initialTagForm } from "@entities/models/tag/form";
+import { initialTagForm, toTagForm } from "@entities/models/tag/form";
 import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
 
+interface Extras {
+    tags: TagType[];
+    posts: PostType[];
+    postTags: PostTagType[];
+}
+
 export function useTagForm() {
-    const [tags, setTags] = useState<TagType[]>([]);
-    const [posts, setPosts] = useState<PostType[]>([]);
-    const [postTags, setPostTags] = useState<PostTagType[]>([]);
+    const currentId = useRef<string | null>(null);
     const [loading, setLoading] = useState(true);
 
-    const [form, setForm] = useState<TagFormType>(initialTagForm);
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const modelForm = useModelForm<TagFormType, Extras>({
+        initialForm: initialTagForm,
+        initialExtras: { tags: [], posts: [], postTags: [] },
+        create: async (form) => {
+            const { data } = await tagService.create({ name: form.name });
+            if (!data) throw new Error("Erreur lors de la création du tag");
+            return data.id;
+        },
+        update: async (form) => {
+            if (!currentId.current) {
+                throw new Error("ID du tag manquant pour la mise à jour");
+            }
+            const { data } = await tagService.update({
+                id: currentId.current,
+                name: form.name,
+            });
+            if (!data) throw new Error("Erreur lors de la mise à jour du tag");
+            return data.id;
+        },
+        syncRelations: async (id, form) => {
+            const current = await postTagService.listByChild(id);
+            await syncManyToMany(
+                current,
+                form.postIds,
+                (postId) => postTagService.create(postId, id),
+                (postId) => postTagService.delete(postId, id)
+            );
+        },
+    });
+
+    const { extras, setExtras, setForm, setMode, submit } = modelForm;
 
     const fetchAll = useCallback(async () => {
         setLoading(true);
-        const [tagsData, postsData, postTagsData] = await Promise.all([
+        const [t, p, pt] = await Promise.all([
             tagService.list(),
             postService.list(),
             postTagService.list(),
-            // crudService("PostTag").list(),
         ]);
-        setTags(tagsData.data ?? []);
-        setPosts(postsData.data ?? []);
-        setPostTags(postTagsData.data ?? []);
+        setExtras({
+            tags: t.data ?? [],
+            posts: p.data ?? [],
+            postTags: pt.data ?? [],
+        });
         setLoading(false);
-    }, []);
+    }, [setExtras]);
 
     useEffect(() => {
         void fetchAll();
     }, [fetchAll]);
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        setForm((f) => ({ ...f, [name]: value }));
-    };
+    const edit = useCallback(
+        async (idx: number) => {
+            const tag = extras.tags[idx];
+            const postIds = await postTagService.listByChild(tag.id);
+            currentId.current = tag.id;
+            setForm(toTagForm(tag, postIds));
+            setMode("edit");
+        },
+        [extras.tags, setForm, setMode]
+    );
 
-    const handleEdit = async (idx: number) => {
-        const tag = tags[idx];
-        const postIds = await postTagService.listByChild(tag.id);
-        setForm({ name: tag.name ?? "", postIds });
-        setEditingIndex(idx);
-    };
+    const cancel = useCallback(() => {
+        currentId.current = null;
+        setForm(initialTagForm);
+        setMode("create");
+    }, [setForm, setMode]);
 
-    const handleCancel = () => {
-        setEditingIndex(null);
-        setForm({ name: "", postIds: [] });
-    };
+    const remove = useCallback(
+        async (idx: number) => {
+            const tag = extras.tags[idx];
+            if (!window.confirm("Supprimer ce tag ?")) return;
+            const linkedPosts = await postTagService.listByChild(tag.id);
+            await Promise.all(linkedPosts.map((p) => postTagService.delete(p, tag.id)));
+            await tagService.delete({ id: tag.id });
+            await fetchAll();
+        },
+        [extras.tags, fetchAll]
+    );
 
-    async function syncRelations(tagId: string) {
-        const current = await postTagService.listByChild(tagId);
-        await syncManyToMany(
-            current,
-            form.postIds,
-            (postId) => postTagService.create(postId, tagId),
-            (postId) => postTagService.delete(postId, tagId)
-        );
-    }
-
-    const handleSubmit = async () => {
-        if (!form.name.trim()) return;
-
-        if (editingIndex === null) {
-            const { data } = await tagService.create({ name: form.name });
-            if (data) await syncRelations(data.id);
-        } else {
-            const tag = tags[editingIndex];
-            await tagService.update({ id: tag.id, name: form.name });
-            await syncRelations(tag.id);
-        }
-
-        await fetchAll();
-        handleCancel();
-    };
-
-    const handleDelete = async (idx: number) => {
-        const tag = tags[idx];
-        if (!window.confirm("Supprimer ce tag ?")) return;
-        const linkedPosts = await postTagService.listByChild(tag.id);
-        await Promise.all(linkedPosts.map((p) => postTagService.delete(p, tag.id)));
-        await tagService.delete({ id: tag.id });
-        await fetchAll();
-    };
-
-    const handleAddPostTag = async (postId: string, tagId: string) => {
-        await postTagService.create(postId, tagId);
-        setPostTags((prev) => [...prev, { postId, tagId } as PostTagType]);
-    };
-
-    const handleRemovePostTag = async (postId: string, tagId: string) => {
-        await postTagService.delete(postId, tagId);
-        setPostTags((prev) => prev.filter((pt) => !(pt.postId === postId && pt.tagId === tagId)));
-    };
+    const toggle = useCallback(
+        async (postId: string, tagId: string) => {
+            const exists = extras.postTags.some((pt) => pt.postId === postId && pt.tagId === tagId);
+            if (exists) {
+                await postTagService.delete(postId, tagId);
+                setExtras((prev) => ({
+                    ...prev,
+                    postTags: prev.postTags.filter(
+                        (pt) => !(pt.postId === postId && pt.tagId === tagId)
+                    ),
+                }));
+            } else {
+                await postTagService.create(postId, tagId);
+                setExtras((prev) => ({
+                    ...prev,
+                    postTags: [...prev.postTags, { postId, tagId }],
+                }));
+            }
+        },
+        [extras.postTags, setExtras]
+    );
 
     const tagsForPost = useCallback(
         (postId: string) => {
-            const tagIds = postTags.filter((pt) => pt.postId === postId).map((pt) => pt.tagId);
-            return tags.filter((t) => tagIds.includes(t.id));
+            const tagIds = extras.postTags
+                .filter((pt) => pt.postId === postId)
+                .map((pt) => pt.tagId);
+            return extras.tags.filter((t) => tagIds.includes(t.id));
         },
-        [postTags, tags]
+        [extras.postTags, extras.tags]
     );
 
     const isTagLinked = useCallback(
         (postId: string, tagId: string) =>
-            postTags.some((pt) => pt.postId === postId && pt.tagId === tagId),
-        [postTags]
+            extras.postTags.some((pt) => pt.postId === postId && pt.tagId === tagId),
+        [extras.postTags]
     );
 
+    const save = useCallback(async () => {
+        await submit();
+        await fetchAll();
+        cancel();
+    }, [submit, fetchAll, cancel]);
+
     return {
-        tags,
-        posts,
-        form,
-        editingIndex,
+        ...modelForm,
         loading,
-        setForm,
-        handleChange,
-        handleEdit,
-        handleCancel,
-        handleSubmit,
-        handleDelete,
-        handleAddPostTag,
-        handleRemovePostTag,
+        fetchAll,
+        edit,
+        cancel,
+        save,
+        remove,
+        toggle,
         tagsForPost,
         isTagLinked,
-        fetchAll,
     };
 }
 


### PR DESCRIPTION
## Summary
- refactor tag form hook to use useModelForm and sync post relations
- load tags, posts and relations into extras and provide toggle utility
- adjust tag management components for new hook API

## Testing
- `yarn install`
- `yarn prettier --write src/entities/models/tag/hooks.tsx src/components/Blog/manage/components/tag/TagManager.jsx src/components/Blog/manage/components/tag/PostTagsManager.jsx src/components/Blog/manage/tags/CreateTag.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689c96d183208324afff77b075e266cc