### PR TITLE
[Feat] gestion des sections via useModelForm

### DIFF
--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -5,21 +5,23 @@ import RequireAdmin from "@components/RequireAdmin";
 import SectionForm from "./SectionsForm";
 import SectionList from "./SectionList";
 import { sectionService } from "@entities/models/section/service";
-import { type SectionTypes } from "@entities/models/section/types";
+import { type SectionTypes, initialSectionForm, useSectionForm } from "@entities/models/section";
 
 export default function SectionManagerPage() {
-    const [sections, setSections] = useState<SectionTypes[]>([]);
     const [editingSection, setEditingSection] = useState<SectionTypes | null>(null);
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
-    const fetchSections = async () => {
-        const { data } = await sectionService.list();
-        setSections(data ?? []);
-    };
+    const manager = useSectionForm(editingSection);
+    const {
+        extras: { sections },
+        fetchSections,
+        setForm,
+        setMode,
+    } = manager;
 
     useEffect(() => {
         fetchSections();
-    }, []);
+    }, [fetchSections]);
 
     const handleEdit = (idx: number) => {
         setEditingSection(sections[idx]);
@@ -33,8 +35,8 @@ export default function SectionManagerPage() {
         await fetchSections();
     };
 
-    const handleSave = () => {
-        fetchSections();
+    const handleSave = async () => {
+        await fetchSections();
         setEditingSection(null);
         setEditingIndex(null);
     };
@@ -42,6 +44,8 @@ export default function SectionManagerPage() {
     const handleCancel = () => {
         setEditingSection(null);
         setEditingIndex(null);
+        setMode("create");
+        setForm(initialSectionForm);
     };
 
     return (
@@ -50,8 +54,8 @@ export default function SectionManagerPage() {
                 <h1 className="text-2xl font-bold">Gestion des Sections</h1>
                 <SectionForm
                     ref={formRef}
-                    section={editingSection}
-                    sections={sections}
+                    manager={manager}
+                    editingIndex={editingIndex}
                     onSave={handleSave}
                 />
                 <SectionList
@@ -59,7 +63,6 @@ export default function SectionManagerPage() {
                     editingIndex={editingIndex}
                     onEdit={handleEdit}
                     onSave={() => {
-                        // Appelle le submit du formulaire via la ref
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { type SectionTypes } from "@/src/entities/models/section";
+import { type SectionTypes } from "@entities/models/section";
 import FormActionButtons from "../components/FormActionButtons";
 
 interface Props {

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -1,75 +1,118 @@
 "use client";
-import React, { forwardRef } from "react";
+import React, { forwardRef, type ChangeEvent, type FormEvent } from "react";
 import EditableField from "@components/forms/EditableField";
 import EditableTextArea from "@components/forms/EditableTextArea";
 import SeoFields from "@components/forms/SeoFields";
 import OrderSelector from "@components/forms/OrderSelector";
 import ItemSelector from "@components/forms/ItemSelector";
-import { useSectionForm } from "@entities/models/section/hooks";
-import { type SectionTypes } from "@/src/entities/models/section";
+import { useAutoGenFields, slugify } from "@hooks/useAutoGenFields";
+import {
+    type SectionFormTypes,
+    initialSectionForm,
+    useSectionForm,
+} from "@entities/models/section";
 
 interface Props {
-    section: SectionTypes | null;
+    manager: ReturnType<typeof useSectionForm>;
     onSave: () => void;
-    sections: SectionTypes[];
+    editingIndex: number | null;
 }
 
 const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
-    { section, onSave, sections },
+    { manager, onSave, editingIndex },
     ref
 ) {
     const {
         form,
-        posts,
-        saving,
+        extras: { posts, sections },
+        submit,
         handleChange,
-        handleSubmit,
         setForm,
-        handleTitleFocus,
-        handleTitleBlur,
-    } = useSectionForm(section, onSave);
+        setMode,
+        mode,
+        saving,
+    } = manager;
+
+    const { handleSourceFocus, handleManualEdit } = useAutoGenFields({
+        configs: [
+            {
+                editingKey: "title",
+                source: form.title ?? "",
+                current: form.slug ?? "",
+                target: "slug",
+                setter: (v) => handleChange("slug", slugify(v ?? "")),
+                transform: slugify,
+            },
+            {
+                editingKey: "title",
+                source: form.title ?? "",
+                current: form.seo.title ?? "",
+                target: "seo.title",
+                setter: (v) => handleChange("seo", { ...form.seo, title: v ?? "" }),
+            },
+            {
+                editingKey: "description",
+                source: form.description ?? "",
+                current: form.seo.description ?? "",
+                target: "seo.description",
+                setter: (v) => handleChange("seo", { ...form.seo, description: v ?? "" }),
+            },
+        ],
+    });
+
+    function handleFieldChange(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+        const { name, value } = e.target;
+        if (name === "title" || name === "description") {
+            handleSourceFocus(name);
+        }
+        if (name.startsWith("seo.")) {
+            const key = name.split(".")[1] as keyof SectionFormTypes["seo"];
+            handleChange("seo", { ...form.seo, [key]: value });
+            handleManualEdit(`seo.${key}`);
+        } else if (name === "slug") {
+            handleChange("slug", slugify(value));
+            handleManualEdit("slug");
+        } else {
+            handleChange(name as keyof SectionFormTypes, value as never);
+        }
+    }
+
+    async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        await submit();
+        setMode("create");
+        setForm(initialSectionForm);
+        onSave();
+    }
 
     return (
-        <form
-            ref={ref}
-            onSubmit={(e) => {
-                e.preventDefault();
-                handleSubmit();
-            }}
-            className="space-y-2"
-        >
+        <form ref={ref} onSubmit={handleSubmit} className="space-y-2">
             <EditableField
                 name="title"
                 label="Titre"
                 value={form.title}
-                onChange={handleChange}
-                onFocus={() => handleTitleFocus("title")}
-                onBlur={() => handleTitleBlur("title")}
+                onChange={handleFieldChange}
                 readOnly={false}
             />
             <EditableField
                 name="slug"
                 label="Slug"
                 value={form.slug}
-                onChange={handleChange}
+                onChange={handleFieldChange}
                 readOnly={false}
             />
             <EditableTextArea
                 name="description"
                 label="Description"
                 value={form.description ?? ""}
-                onChange={handleChange}
-                onFocus={() => handleTitleFocus("description")}
-                onBlur={() => handleTitleBlur("description")}
+                onChange={handleFieldChange}
                 readOnly={false}
             />
             <OrderSelector
                 sections={sections}
-                currentIndex={sections.findIndex((s) => s.id === section?.id)}
+                currentIndex={editingIndex ?? -1}
                 value={form.order ?? 1}
-                onReorder={(_: number, newOrder: number) =>
-                    setForm((f) => ({ ...f, order: newOrder }))
-                }
+                onReorder={(_: number, newOrder: number) => handleChange("order", newOrder)}
             />
             <SeoFields
                 seo={{
@@ -77,7 +120,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
                     description: form.seo.description ?? "",
                     image: form.seo.image ?? "",
                 }}
-                onChange={handleChange}
+                onChange={handleFieldChange}
                 readOnly={false}
             />
             <ItemSelector
@@ -93,7 +136,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
                 disabled={saving}
                 className="bg-blue-500 text-white px-4 py-2 rounded"
             >
-                {section ? "Mettre à jour" : "Créer"}
+                {mode === "edit" ? "Mettre à jour" : "Créer"}
             </button>
         </form>
     );


### PR DESCRIPTION
## Description
- refactorer le hook `useSectionForm` pour exposer `extras.sections` et `fetchSections`
- adapter `SectionsForm` à l'API `useModelForm`
- utiliser les méthodes du hook dans `CreateSection`

## Tests effectués
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689c98d775488324b9fe5464cc9b910d