### PR TITLE
[Feat] intègre nouveau useAuthorForm

### DIFF
--- a/src/components/Blog/manage/authors/AuthorsForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorsForm.tsx
@@ -1,20 +1,19 @@
 import React from "react";
 import EditableField from "@components/forms/EditableField";
 import EditableTextArea from "@components/forms/EditableTextArea";
-import FormActionButtons from "../components/FormActionButtons";
+import FormActionButtons from "@components/Blog/manage/components/FormActionButtons";
 import { useAuthorForm } from "@entities/models/author/hooks";
 
 export default function AuthorsForm() {
     const {
-        authors,
         form,
+        extras: { authors, loading },
         editingIndex,
-        loading,
-        handleFormChange,
-        handleEdit,
+        handleChange,
+        edit,
         reset,
         submit,
-        handleDelete,
+        remove,
         message,
     } = useAuthorForm();
 
@@ -41,10 +40,10 @@ export default function AuthorsForm() {
                             <FormActionButtons
                                 editingIndex={editingIndex}
                                 currentIndex={idx}
-                                onEdit={() => handleEdit(idx)}
+                                onEdit={() => edit(idx)}
                                 onSave={submit}
                                 onCancel={reset}
-                                onDelete={() => handleDelete(idx)}
+                                onDelete={() => remove(idx)}
                                 isFormNew={false}
                             />
                         </li>
@@ -57,28 +56,28 @@ export default function AuthorsForm() {
                     name="authorName"
                     label="Nom"
                     value={form.authorName ?? ""}
-                    onChange={handleFormChange}
+                    onChange={handleChange}
                     readOnly={false}
                 />
                 <EditableField
                     name="avatar"
                     label="URL de l'avatar"
                     value={form.avatar ?? ""}
-                    onChange={handleFormChange}
+                    onChange={handleChange}
                     readOnly={false}
                 />
                 <EditableTextArea
                     name="bio"
                     label="Bio"
                     value={form.bio ?? ""}
-                    onChange={handleFormChange}
+                    onChange={handleChange}
                     readOnly={false}
                 />
                 <EditableField
                     name="email"
                     label="Email"
                     value={form.email ?? ""}
-                    onChange={handleFormChange}
+                    onChange={handleChange}
                     readOnly={false}
                 />
                 {editingIndex === null && (

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -1,5 +1,5 @@
-import RequireAdmin from "../../../RequireAdmin";
-import AuthorsForm from "./AuthorsForm";
+import RequireAdmin from "@components/RequireAdmin";
+import AuthorsForm from "@components/Blog/manage/authors/AuthorsForm";
 
 export default function CreateAuthor() {
     return (

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -38,72 +38,70 @@ export function useAuthorForm() {
         },
     });
 
-    const { setForm, setExtras, setMode, setMessage, submit, reset, handleChange } = modelForm;
-
     const fetchAuthors = useCallback(async () => {
-        setExtras((prev) => ({ ...prev, loading: true }));
+        modelForm.setExtras((prev) => ({ ...prev, loading: true }));
         const { data } = await authorService.list();
         authorsRef.current = data ?? [];
-        setExtras({ authors: authorsRef.current, loading: false });
-    }, [setExtras]);
+        modelForm.setExtras({ authors: authorsRef.current, loading: false });
+    }, [modelForm]);
 
     useEffect(() => {
         void fetchAuthors();
     }, [fetchAuthors]);
 
-    const handleEdit = (idx: number) => {
+    const edit = (idx: number) => {
         const author = authorsRef.current[idx];
         if (!author) return;
         editingIndex.current = idx;
-        setForm(toAuthorForm(author, []));
-        setMode("edit");
+        modelForm.setForm(toAuthorForm(author, []));
+        modelForm.setMode("edit");
     };
 
-    const handleDelete = async (idx: number) => {
+    const remove = async (idx: number) => {
         const author = authorsRef.current[idx];
         if (!author?.id) return;
         if (!window.confirm("Supprimer cet auteur ?")) return;
         try {
             await authorService.delete({ id: author.id });
             await fetchAuthors();
-            setMessage("Auteur supprimé !");
+            modelForm.setMessage("Auteur supprimé !");
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            setMessage(`Erreur : ${msg}`);
+            modelForm.setMessage(`Erreur : ${msg}`);
         }
     };
 
     async function submitForm() {
         try {
-            await submit();
+            await modelForm.submit();
             await fetchAuthors();
-            setMessage(editingIndex.current === null ? "Auteur ajouté !" : "Auteur mis à jour !");
+            modelForm.setMessage(
+                editingIndex.current === null ? "Auteur ajouté !" : "Auteur mis à jour !"
+            );
             resetForm();
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            setMessage(`Erreur : ${msg}`);
+            modelForm.setMessage(`Erreur : ${msg}`);
         }
     }
 
     function resetForm() {
         editingIndex.current = null;
-        setMode("create");
-        reset();
+        modelForm.setMode("create");
+        modelForm.reset();
     }
 
-    const handleFormChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
-        handleChange(name as keyof AuthorFormType, value as never);
+        modelForm.handleChange(name as keyof AuthorFormType, value as never);
     };
 
     return {
         ...modelForm,
-        authors: modelForm.extras.authors,
-        loading: modelForm.extras.loading,
         editingIndex: editingIndex.current,
-        handleEdit,
-        handleDelete,
-        handleFormChange,
+        handleChange,
+        edit,
+        remove,
         submit: submitForm,
         reset: resetForm,
     };


### PR DESCRIPTION
## Description
- adapte AuthorsForm au nouveau hook `useAuthorForm`
- simplifie CreateAuthor en utilisant les imports alias
- refactore le hook auteur pour exposer `extras` et les actions `edit`, `remove`, `submit`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Parameter 'v' implicitly has an 'any' type in src/components/Blog/manage/tags/CreateTag.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689c9992ea70832496457f749daf9969