### PR TITLE
[Feat] refactor EntityEditor for model forms

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -24,7 +24,6 @@ export default function UserNameManager() {
     return (
         <EntityEditor<UserNameMinimalType>
             title="Mon pseudo public"
-            manager={manager}
             requiredFields={["userName"]}
             deleteLabel="Supprimer le pseudo"
             renderIcon={() => <PersonIcon fontSize="small" className="text-gray-800" />}
@@ -33,6 +32,21 @@ export default function UserNameManager() {
                     void clear(field);
                 }
             }}
+            form={manager.formData}
+            mode={manager.entity ? "edit" : "create"}
+            dirty={false}
+            handleChange={manager.handleChange}
+            submit={manager.save}
+            reset={() => manager.fetchData()}
+            setForm={manager.setFormData}
+            fields={manager.fields}
+            labels={manager.labels}
+            saveField={(field, value) => {
+                manager.setEditModeField({ field, value });
+                return manager.saveField();
+            }}
+            clearField={manager.clearField}
+            deleteEntity={manager.deleteEntity}
         />
     );
 }

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -7,12 +7,12 @@ import { label as fieldLabel } from "./utilsUserProfile";
 import PhoneIcon from "@mui/icons-material/Phone";
 import PersonIcon from "@mui/icons-material/Person";
 import HomeIcon from "@mui/icons-material/Home";
-import { useUserProfileManager } from "@entities/models/userProfile/hooks";
+import { useUserProfileForm } from "@entities/models/userProfile/hooks";
 import { type UserProfileMinimalType } from "@entities/models/userProfile/types";
 
 export default function UserProfileManager() {
     const { user } = useAuthenticator();
-    const manager = useUserProfileManager();
+    const profile = useUserProfileForm();
     // const baseManager = useUserNameManager();
 
     const getIcon = (field: keyof UserProfileMinimalType) => {
@@ -55,7 +55,7 @@ export default function UserProfileManager() {
     };
     useEffect(() => {
         if (user) {
-            manager.fetchData();
+            void profile.fetchProfile();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [user]);
@@ -74,7 +74,23 @@ export default function UserProfileManager() {
                     void clear(field);
                 }
             }}
-            manager={manager}
+            form={profile.form}
+            mode={profile.mode}
+            dirty={profile.dirty}
+            handleChange={
+                profile.handleChange as (
+                    field: keyof UserProfileMinimalType,
+                    value: unknown
+                ) => void
+            }
+            submit={profile.submit}
+            reset={profile.reset}
+            setForm={profile.setForm}
+            fields={profile.fields}
+            labels={profile.labels}
+            saveField={profile.saveField}
+            clearField={profile.clearField}
+            deleteEntity={profile.deleteProfile}
         />
     );
 }

--- a/src/components/forms/EntityEditor.tsx
+++ b/src/components/forms/EntityEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React from "react";
-import type { FieldKey, EntityManagerResult } from "@entities/core/hooks";
+import React, { useState } from "react";
+import type { FieldKey, FormMode } from "@entities/core/hooks";
 import ReadOnlyView from "./ReadOnlyView";
 import EditField from "./EditField";
 import EntityForm from "./EntityForm";
@@ -22,58 +22,72 @@ export type EntityEditorProps<T extends Record<string, unknown>> = {
     /** Classe optionnelle pour la section */
     className?: string;
     /** Personnalisation de l'effacement d'un champ */
-    onClearField?: (field: FieldKey<T>, clear: (field: FieldKey<T>) => void) => void;
-    /** Gestionnaire de l'entité */
-    manager: EntityManagerResult<T>;
+    onClearField?: (field: FieldKey<T>, clear: (field: FieldKey<T>) => Promise<void>) => void;
+    /** Données du formulaire */
+    form: T;
+    /** Mode du formulaire (création/édition) */
+    mode: FormMode;
+    /** Indicateur de modification */
+    dirty: boolean;
+    /** Gestion des changements */
+    handleChange: (field: FieldKey<T>, value: unknown) => void;
+    /** Soumission du formulaire */
+    submit: () => Promise<void>;
+    /** Réinitialisation du formulaire */
+    reset: () => void;
+    /** Permet de remplacer le formulaire */
+    setForm: React.Dispatch<React.SetStateAction<T>>;
+    /** Champs gérés */
+    fields: FieldKey<T>[];
+    /** Libellés des champs */
+    labels: (field: FieldKey<T>) => string;
+    /** Sauvegarde d'un champ individuel */
+    saveField?: (field: FieldKey<T>, value: string) => Promise<void>;
+    /** Effacement d'un champ individuel */
+    clearField?: (field: FieldKey<T>) => Promise<void>;
+    /** Suppression de l'entité */
+    deleteEntity?: () => Promise<void>;
 };
 
-export default function EntityEditor<T extends Record<string, unknown>>({
-    title,
-    requiredFields = [],
-    renderIcon,
-    renderValue,
-    extraButtons,
-    deleteLabel,
-    className,
-    onClearField,
-    manager,
-}: EntityEditorProps<T>) {
+export default function EntityEditor<T extends Record<string, unknown>>(
+    props: EntityEditorProps<T>
+) {
     const {
-        entity,
-        formData,
-        setFormData,
-        editMode,
-        setEditMode,
-        editModeField,
-        setEditModeField,
+        title,
+        requiredFields = [],
+        renderIcon,
+        renderValue,
+        extraButtons,
+        deleteLabel,
+        className,
+        onClearField,
+        form,
+        mode,
         handleChange,
-        save,
+        submit,
+        reset,
+        fields,
+        labels,
         saveField,
         clearField,
         deleteEntity,
-        labels,
-        fields,
-        fetchData,
-    } = manager;
+    } = props;
+    const [editModeField, setEditModeField] = useState<{
+        field: FieldKey<T>;
+        value: string;
+    } | null>(null);
 
     const handleCancel = () => {
-        setEditMode(false);
-        if (entity) {
-            const reset = { ...formData } as T;
-            fields.forEach((f) => {
-                reset[f] = entity[f];
-            });
-            setFormData(reset);
-        } else {
-            void fetchData();
-        }
+        reset();
     };
 
     const handleClearField = (field: FieldKey<T>) => {
         if (onClearField) {
-            onClearField(field, clearField);
+            onClearField(field, async (f) => {
+                await clearField?.(f);
+            });
         } else {
-            void clearField(field);
+            void clearField?.(field);
         }
     };
 
@@ -85,11 +99,11 @@ export default function EntityEditor<T extends Record<string, unknown>>({
         >
             <h1 className="text-2xl font-bold text-center mb-6">{title}</h1>
 
-            {!editMode && entity && !editModeField && (
+            {mode === "edit" && !editModeField && (
                 <ReadOnlyView<T>
                     title={title}
                     fields={fields}
-                    data={formData}
+                    data={form}
                     labels={labels}
                     renderIcon={renderIcon}
                     renderValue={renderValue}
@@ -103,27 +117,38 @@ export default function EntityEditor<T extends Record<string, unknown>>({
                 <EditField<T>
                     editModeField={editModeField}
                     setEditModeField={setEditModeField}
-                    saveSingleField={saveField}
+                    saveSingleField={() =>
+                        saveField
+                            ? saveField(editModeField.field, editModeField.value).then(() =>
+                                  setEditModeField(null)
+                              )
+                            : Promise.resolve()
+                    }
                     labels={labels}
                 />
             )}
 
-            {(editMode || !entity) && !editModeField && (
+            {mode === "create" && !editModeField && (
                 <EntityForm<T>
-                    formData={formData}
+                    formData={form}
                     fields={fields}
                     labels={labels}
                     handleChange={handleChange}
-                    handleSubmit={save}
-                    isEdit={!!entity}
+                    handleSubmit={() => submit().then(() => void 0)}
+                    isEdit={false}
                     onCancel={handleCancel}
                     requiredFields={requiredFields}
                 />
             )}
 
-            {entity && !editMode && !editModeField && deleteLabel && (
+            {mode === "edit" && !editModeField && deleteLabel && (
                 <div className="flex items-center justify-center mt-8">
-                    <DeleteButton onClick={deleteEntity} label={deleteLabel} />
+                    <DeleteButton
+                        onClick={() => {
+                            void deleteEntity?.();
+                        }}
+                        label={deleteLabel}
+                    />
                 </div>
             )}
         </section>

--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -1,76 +1,28 @@
 // src/entities/models/userProfile/hooks.tsx
 import { useState } from "react";
 import { useAuthenticator } from "@aws-amplify/ui-react";
-import { useEntityManager, type FieldConfig } from "@entities/core/hooks";
+import { useModelForm, type UseModelFormResult } from "@entities/core/hooks";
 import { label as fieldLabel } from "@/src/components/Profile/utilsUserProfile";
 import { userProfileService } from "@entities/models/userProfile/service";
 import { type UserProfileMinimalType } from "@entities/models/userProfile/types";
 
-export function useUserProfileManager() {
+export interface UserProfileFormResult
+    extends UseModelFormResult<UserProfileMinimalType, Record<string, unknown>> {
+    fetchProfile: () => Promise<UserProfileMinimalType | null>;
+    saveField: (field: keyof UserProfileMinimalType, value: string) => Promise<void>;
+    clearField: (field: keyof UserProfileMinimalType) => Promise<void>;
+    deleteProfile: () => Promise<void>;
+    fields: (keyof UserProfileMinimalType)[];
+    labels: (field: keyof UserProfileMinimalType) => string;
+    error: Error | null;
+}
+
+export function useUserProfileForm(): UserProfileFormResult {
     const { user } = useAuthenticator();
     const sub = user?.userId ?? user?.username;
     const [error, setError] = useState<Error | null>(null);
 
-    const fetch = async () => {
-        if (!sub) return null;
-        try {
-            const { data: item } = await userProfileService.get({ id: sub });
-            if (!item) return null;
-            const data: UserProfileMinimalType & { id?: string } = {
-                id: sub,
-                firstName: item.firstName ?? "",
-                familyName: item.familyName ?? "",
-                phoneNumber: item.phoneNumber ?? "",
-                address: item.address ?? "",
-                postalCode: item.postalCode ?? "",
-                city: item.city ?? "",
-                country: item.country ?? "",
-            };
-            return data;
-        } catch (e) {
-            setError(e as Error);
-            return null;
-        }
-    };
-
-    const create = async (data: UserProfileMinimalType) => {
-        if (!sub) throw new Error("id manquant");
-        try {
-            setError(null);
-            await userProfileService.create({ id: sub, ...data } as unknown as Parameters<
-                typeof userProfileService.create
-            >[0]);
-        } catch (e) {
-            setError(e as Error);
-        }
-    };
-
-    const update = async (
-        _entity: (UserProfileMinimalType & { id?: string }) | null,
-        data: Partial<UserProfileMinimalType>
-    ) => {
-        void _entity;
-        if (!sub) throw new Error("id manquant");
-        try {
-            setError(null);
-            await userProfileService.update({ id: sub, ...data });
-        } catch (e) {
-            setError(e as Error);
-        }
-    };
-
-    const remove = async (_entity: (UserProfileMinimalType & { id?: string }) | null) => {
-        void _entity;
-        if (!sub) return;
-        try {
-            setError(null);
-            await userProfileService.delete({ id: sub });
-        } catch (e) {
-            setError(e as Error);
-        }
-    };
-
-    const initialData: UserProfileMinimalType = {
+    const initialForm: UserProfileMinimalType = {
         firstName: "",
         familyName: "",
         phoneNumber: "",
@@ -80,34 +32,108 @@ export function useUserProfileManager() {
         country: "",
     };
 
-    const fieldConfig: FieldConfig<UserProfileMinimalType> = {
-        firstName: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
-        familyName: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
-        phoneNumber: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
-        address: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
-        postalCode: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
-        city: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
-        country: { parse: (v) => String(v), serialize: (v: string) => v, emptyValue: "" },
+    const create = async (form: UserProfileMinimalType) => {
+        if (!sub) throw new Error("id manquant");
+        try {
+            setError(null);
+            await userProfileService.create({ id: sub, ...form } as unknown as Parameters<
+                typeof userProfileService.create
+            >[0]);
+        } catch (e) {
+            setError(e as Error);
+        }
+        return sub ?? "";
     };
 
-    const manager = useEntityManager<UserProfileMinimalType>({
-        fetch,
+    const update = async (form: UserProfileMinimalType) => {
+        if (!sub) throw new Error("id manquant");
+        try {
+            setError(null);
+            await userProfileService.update({ id: sub, ...form });
+        } catch (e) {
+            setError(e as Error);
+        }
+        return sub ?? "";
+    };
+
+    const formManager = useModelForm<UserProfileMinimalType>({
+        initialForm,
+        mode: "create",
         create,
         update,
-        remove,
-        labels: fieldLabel,
-        fields: [
-            "firstName",
-            "familyName",
-            "phoneNumber",
-            "address",
-            "postalCode",
-            "city",
-            "country",
-        ],
-        initialData,
-        config: fieldConfig,
     });
 
-    return { ...manager, error };
+    const { setForm, adoptInitial, reset } = formManager;
+
+    const fetchProfile = async (): Promise<UserProfileMinimalType | null> => {
+        if (!sub) return null;
+        try {
+            const { data } = await userProfileService.get({ id: sub });
+            if (!data) return null;
+            const loaded: UserProfileMinimalType = {
+                firstName: data.firstName ?? "",
+                familyName: data.familyName ?? "",
+                phoneNumber: data.phoneNumber ?? "",
+                address: data.address ?? "",
+                postalCode: data.postalCode ?? "",
+                city: data.city ?? "",
+                country: data.country ?? "",
+            };
+            adoptInitial(loaded, "edit");
+            return loaded;
+        } catch (e) {
+            setError(e as Error);
+            return null;
+        }
+    };
+
+    const saveField = async (field: keyof UserProfileMinimalType, value: string): Promise<void> => {
+        if (!sub) return;
+        try {
+            setError(null);
+            await userProfileService.update({ id: sub, [field]: value });
+            setForm((f) => ({ ...f, [field]: value }));
+        } catch (e) {
+            setError(e as Error);
+        }
+    };
+
+    const clearField = async (field: keyof UserProfileMinimalType): Promise<void> => {
+        await saveField(field, "");
+    };
+
+    const deleteProfile = async (): Promise<void> => {
+        if (!sub) return;
+        try {
+            setError(null);
+            await userProfileService.delete({ id: sub });
+            adoptInitial(initialForm, "create");
+            reset();
+        } catch (e) {
+            setError(e as Error);
+        }
+    };
+
+    const fields: (keyof UserProfileMinimalType)[] = [
+        "firstName",
+        "familyName",
+        "phoneNumber",
+        "address",
+        "postalCode",
+        "city",
+        "country",
+    ];
+
+    return {
+        ...formManager,
+        fetchProfile,
+        saveField,
+        clearField,
+        deleteProfile,
+        fields,
+        labels: fieldLabel,
+        error,
+    };
 }
+
+export { fieldLabel };


### PR DESCRIPTION
## Description
- refactor EntityEditor to work with useModelForm-style managers
- add useUserProfileForm hook and adapt profile management
- adjust UserNameManager to new editor API

## Tests effectués
- `yarn prettier --write src/components/forms/EntityEditor.tsx src/entities/models/userProfile/hooks.tsx src/components/Profile/UserProfileManager.tsx`
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689cb664ecf08324a4b7b38c28463257