### PR TITLE
[Feat] refactorisation du formulaire userName

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,22 +4,21 @@ import React from "react";
 import Link from "next/link";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { PowerButton } from "@src/components/buttons";
-import { useUserNameManager } from "@entities/models/userName/hooks"; // <-- le hook générique qu'on vient de créer
+import { useUserNameForm } from "@entities/models/userName/hooks";
 import UserNameModal from "@src/components/Profile/UserNameModal";
 
 const Header = () => {
     const { user, signOut } = useAuthenticator();
     const {
-        formData: { userName },
-        loading,
-        fetchData,
-    } = useUserNameManager();
+        form: { userName },
+        fetchUserName,
+    } = useUserNameForm();
     const [showModal, setShowModal] = React.useState(false);
 
     React.useEffect(() => {
         // Optionnel : fetch userName à l’ouverture du Header ou quand user change
-        fetchData();
-    }, [user, fetchData]);
+        void fetchUserName();
+    }, [user, fetchUserName]);
 
     React.useEffect(() => {
         if (user && !userName) {
@@ -84,9 +83,7 @@ const Header = () => {
                                 </>
                             ) : (
                                 <>
-                                    <span className="text-sm text-gray-400">
-                                        {loading ? "Chargement..." : "Aucun pseudo"}
-                                    </span>
+                                    <span className="text-sm text-gray-400">Aucun pseudo</span>
                                     <PowerButton
                                         onClick={signOut}
                                         className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition"

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -13,7 +13,7 @@ import { type UserProfileMinimalType } from "@entities/models/userProfile/types"
 export default function UserProfileManager() {
     const { user } = useAuthenticator();
     const profile = useUserProfileForm();
-    // const baseManager = useUserNameManager();
+    // const baseManager = useUserNameForm();
 
     const getIcon = (field: keyof UserProfileMinimalType) => {
         switch (field) {


### PR DESCRIPTION
## Résumé
- renomme le hook en `useUserNameForm` basé sur `useModelForm`
- utilise `userNameService` et les helpers de formulaire pour gérer le pseudo
- adapte les composants Header et UserNameManager au nouveau hook

## Tests
- `yarn prettier --write src/entities/models/userName/hooks.tsx src/components/Header/Header.jsx src/components/Profile/UserNameManager.tsx src/components/Profile/UserProfileManager.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689cbf0175b4832480af1001bdd6ffbe