### PR TITLE
[Feat] gestion unifiée du pseudo utilisateur

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -6,7 +6,10 @@ import EntityEditor from "@components/forms/EntityEditor";
 import { label as fieldLabel } from "./utilsUserName";
 import PersonIcon from "@mui/icons-material/Person";
 import { useUserNameForm } from "@entities/models/userName/hooks";
-import { type UserNameFormType } from "@entities/models/userName/types";
+import {
+    type UserNameFormType,
+    type UserNameTypeUpdateInput,
+} from "@entities/models/userName/types";
 
 const fields: (keyof UserNameFormType)[] = ["userName"];
 
@@ -30,7 +33,13 @@ export default function UserNameManager() {
             deleteLabel="Supprimer le pseudo"
             renderIcon={() => <PersonIcon fontSize="small" className="text-gray-800" />}
             onClearField={(field, clear) => {
-                if (confirm(`Supprimer le contenu du champ "${fieldLabel(field)}" ?`)) {
+                if (
+                    confirm(
+                        `Supprimer le contenu du champ "${fieldLabel(
+                            field as keyof UserNameTypeUpdateInput
+                        )}" ?`
+                    )
+                ) {
                     void clear(field);
                 }
             }}
@@ -45,14 +54,8 @@ export default function UserNameManager() {
             setForm={manager.setForm}
             fields={fields}
             labels={fieldLabel as (field: keyof UserNameFormType) => string}
-            saveField={async (field, value) => {
-                manager.handleChange(field, value as never);
-                await manager.submit();
-            }}
-            clearField={async (field) => {
-                manager.handleChange(field, "" as never);
-                await manager.submit();
-            }}
+            saveField={manager.saveField}
+            clearField={manager.clearField}
             deleteEntity={manager.remove}
         />
     );

--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -36,7 +36,7 @@ export function useUserNameForm() {
         },
     });
 
-    const { adoptInitial, setMessage } = modelForm;
+    const { adoptInitial, setMessage, setForm } = modelForm;
 
     const fetchUserName = async (): Promise<UserNameFormType | null> => {
         if (!sub) return null;
@@ -46,13 +46,28 @@ export function useUserNameForm() {
                 adoptInitial(initialUserNameForm, "create");
                 return null;
             }
-            const form = toUserNameForm(data);
+            const form = toUserNameForm(data, [], []);
             adoptInitial(form, "edit");
             return form;
         } catch (err) {
             setMessage(err instanceof Error ? err.message : String(err));
             return null;
         }
+    };
+
+    const saveField = async (field: keyof UserNameFormType, value: string): Promise<void> => {
+        if (!sub) return;
+        try {
+            setMessage(null);
+            await userNameService.update({ id: sub, [field]: value });
+            setForm((f) => ({ ...f, [field]: value as never }));
+        } catch (err) {
+            setMessage(err instanceof Error ? err.message : String(err));
+        }
+    };
+
+    const clearField = async (field: keyof UserNameFormType): Promise<void> => {
+        await saveField(field, "");
     };
 
     const remove = async () => {
@@ -65,5 +80,5 @@ export function useUserNameForm() {
         }
     };
 
-    return { ...modelForm, fetchUserName, remove };
+    return { ...modelForm, fetchUserName, saveField, clearField, remove };
 }


### PR DESCRIPTION
## Objectif
- exposer les actions du formulaire de pseudo via `useUserNameForm`
- utiliser ces méthodes dans `UserNameManager`

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689cc1ffa9908324adf56da713488ba3