### PR TITLE
[Fix] centralisation des types core

### DIFF
--- a/src/components/forms/EntityEditor.tsx
+++ b/src/components/forms/EntityEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
-import type { FieldKey, FormMode } from "@entities/core/hooks";
+import type { FieldKey } from "@entities/core/hooks";
+import type { EditMode } from "@entities/core/types";
 import ReadOnlyView from "./ReadOnlyView";
 import EditField from "./EditField";
 import EntityForm from "./EntityForm";
@@ -26,7 +27,7 @@ export type EntityEditorProps<T extends Record<string, unknown>> = {
     /** Données du formulaire */
     form: T;
     /** Mode du formulaire (création/édition) */
-    mode: FormMode;
+    mode: EditMode;
     /** Indicateur de modification */
     dirty: boolean;
     /** Gestion des changements */

--- a/src/entities/core/auth.ts
+++ b/src/entities/core/auth.ts
@@ -1,4 +1,4 @@
-import type { AuthRule } from "./types";
+import type { EntitiesAuthRule } from "./types";
 
 export interface AuthUser {
     username?: string;
@@ -8,7 +8,7 @@ export interface AuthUser {
 export function canAccess(
     user: AuthUser | null,
     entity: Record<string, unknown>,
-    rules: AuthRule[] = []
+    rules: EntitiesAuthRule[] = []
 ): boolean {
     for (const rule of rules) {
         switch (rule.allow) {

--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -1,8 +1,9 @@
 // src/entities/core/hooks/useModelForm.ts
 "use client";
 import { useCallback, useMemo, useRef, useState } from "react";
+import type { EditMode } from "@entities/core/types";
 
-export type FormMode = "create" | "edit";
+export type FormMode = EditMode;
 export type FieldKey<T> = keyof T & string;
 export interface UseModelFormOptions<F, E = Record<string, unknown>> {
     initialForm: F;

--- a/src/entities/core/hooks/useModelForm2.ts
+++ b/src/entities/core/hooks/useModelForm2.ts
@@ -1,7 +1,8 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { EditMode } from "@entities/core/types";
 
-export type FormMode = "create" | "edit";
+export type FormMode = EditMode;
 
 export interface UseModelFormOptions<F, E = Record<string, unknown>> {
     initialForm: F;

--- a/src/entities/core/services/crudService.ts
+++ b/src/entities/core/services/crudService.ts
@@ -1,7 +1,7 @@
 // src/entities/core/services/crudService.ts
 import { client, Schema } from "./amplifyClient";
 import { canAccess } from "../auth";
-import type { AuthRule } from "../types";
+import type { EntitiesAuthRule } from "../types";
 
 type ClientModels = typeof client.models;
 type ClientModelKey = keyof ClientModels;
@@ -76,7 +76,7 @@ export function crudService<
     U = DefaultUpdateArg<K>,
     G = DefaultGetArg<K>,
     D = DefaultDeleteArg<K>,
->(key: K, opts?: { auth?: CrudAuth; rules?: AuthRule[] }) {
+>(key: K, opts?: { auth?: CrudAuth; rules?: EntitiesAuthRule[] }) {
     const model = getModelClient<K, C, U, G, D>(key);
     const rules = opts?.rules ?? [{ allow: "public" }];
     const readModes = toArray(opts?.auth?.read);

--- a/src/entities/core/types/amplifyBaseTypes.ts
+++ b/src/entities/core/types/amplifyBaseTypes.ts
@@ -1,6 +1,13 @@
 // src/entities/core/types/amplifyBaseTypes.ts
 import type { Schema } from "@/amplify/data/resource";
 
+export type AmplifyId = string;
+
+export interface AmplifyListResult<T> {
+    data: T[];
+    nextToken?: string;
+}
+
 export type BaseModel<K extends keyof Schema> = Schema[K]["type"];
 
 export type CreateOmit<K extends keyof Schema> = Omit<

--- a/src/entities/core/types/config.ts
+++ b/src/entities/core/types/config.ts
@@ -3,7 +3,7 @@
 /**
  * Règles d'authentification appliquées à une entité.
  */
-export type AuthRule =
+export type AuthRuleConfig =
     | { allow: "owner"; ownerField?: string }
     | { allow: "groups"; groups: string[] }
     | { allow: "public" }
@@ -35,10 +35,10 @@ export interface IdentifierDef extends BaseField {
     strategy?: "auto" | "uuid";
 }
 
-export type EntityFields = Record<string, FieldDef | RelationDef | IdentifierDef>;
+export type ModelFields = Record<string, FieldDef | RelationDef | IdentifierDef>;
 
-export interface EntityConfig {
+export interface ModelConfig {
     name: string;
-    fields: EntityFields;
-    auth?: AuthRule[];
+    fields: ModelFields;
+    auth?: AuthRuleConfig[];
 }

--- a/src/entities/core/types/doc.md
+++ b/src/entities/core/types/doc.md
@@ -25,7 +25,7 @@ Générique puissant destiné aux formulaires. Il part de `CreateOmit` et permet
 ### Exemple
 
 ```ts
-import type { ModelForm } from "@entities/core";
+import type { ModelForm } from "@entities/core/types";
 
 type PostForm = ModelForm<
     "Post",

--- a/src/entities/core/types/form.ts
+++ b/src/entities/core/types/form.ts
@@ -1,10 +1,23 @@
 // src/entities/core/types/form.ts
 
-import type { EntityConfig } from "@entities/core/types/config";
+import type { ModelConfig } from "./config";
 
 /**
- * Représentation générique d'un formulaire basé sur une configuration d'entité.
+ * Représentation générique d'un formulaire basé sur une configuration de modèle.
  */
-export type EntityForm<C extends EntityConfig> = {
+export type FormState<C extends ModelConfig> = {
     [K in keyof C["fields"]]?: unknown;
 };
+
+/**
+ * Mode d'édition d'un formulaire.
+ */
+export type EditMode = "create" | "edit";
+
+/**
+ * Résultat d'une validation de formulaire.
+ */
+export interface ValidationResult {
+    valid: boolean;
+    errors?: Record<string, string>;
+}

--- a/src/entities/core/types/index.ts
+++ b/src/entities/core/types/index.ts
@@ -1,4 +1,28 @@
-export * from "./amplifyBaseTypes";
-export * from "./config";
-export * from "./form";
-export * from "./model";
+// src/entities/core/types/index.ts
+
+// Amplify-based types
+export type {
+    AmplifyId,
+    AmplifyListResult,
+    BaseModel,
+    CreateOmit,
+    UpdateInput,
+    ModelForm,
+} from "./amplifyBaseTypes";
+
+// Generic model types
+export type { ModelId, Timestamps, BaseEntity, Relation, RelationArray } from "./model";
+
+// Form-related types
+export type { FormState, EditMode, ValidationResult } from "./form";
+
+// Configuration and auth types
+export type {
+    FieldKind,
+    FieldDef,
+    RelationDef,
+    IdentifierDef,
+    ModelFields,
+    ModelConfig,
+    AuthRuleConfig as EntitiesAuthRule,
+} from "./config";

--- a/src/entities/core/types/model.ts
+++ b/src/entities/core/types/model.ts
@@ -1,10 +1,21 @@
 // src/entities/core/types/model.ts
 
-import type { EntityConfig } from "@entities/core/types/config";
+/** Identifiant générique d'un modèle. */
+export type ModelId = string;
 
-/**
- * Modèle typé dérivé d'une configuration d'entité.
- */
-export type EntityModel<C extends EntityConfig> = {
-    [K in keyof C["fields"]]: unknown;
-};
+/** Champs de suivi temporel communs à toutes les entités. */
+export interface Timestamps {
+    createdAt: string;
+    updatedAt: string;
+}
+
+/** Représente une entité de base avec identifiant et timestamps. */
+export interface BaseEntity extends Timestamps {
+    id: ModelId;
+}
+
+/** Relation optionnelle vers une autre entité. */
+export type Relation<T> = T | null;
+
+/** Collection relationnelle. */
+export type RelationArray<T> = T[];

--- a/src/entities/customTypes/seo/types.ts
+++ b/src/entities/customTypes/seo/types.ts
@@ -1,4 +1,4 @@
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core/types";
 
 export type SeoType = BaseModel<"Seo">;
 export type SeoTypeOmit = CreateOmit<"Seo">;

--- a/src/entities/relations/postTag/types.ts
+++ b/src/entities/relations/postTag/types.ts
@@ -1,4 +1,4 @@
-import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core";
+import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core/types";
 
 export type PostTagType = BaseModel<"PostTag">;
 export type PostTagTypeOmit = CreateOmit<"PostTag">;

--- a/src/entities/relations/sectionPost/types.ts
+++ b/src/entities/relations/sectionPost/types.ts
@@ -1,4 +1,4 @@
-import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core";
+import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core/types";
 
 export type SectionPostType = BaseModel<"SectionPost">;
 export type SectionPostTypeOmit = CreateOmit<"SectionPost">;

--- a/src/services/blogDataService.ts
+++ b/src/services/blogDataService.ts
@@ -1,4 +1,5 @@
-import { client, canAccess, type AuthRule } from "@src/entities/core";
+import { client, canAccess } from "@src/entities/core";
+import type { EntitiesAuthRule } from "@src/entities/core/types";
 
 import type { BlogData, Author, Post, Section } from "@src/types/blog";
 
@@ -13,7 +14,7 @@ export async function fetchBlogData(): Promise<BlogData> {
             client.models.SectionPost.list({ authMode: "apiKey" }),
         ]);
 
-    const publicRule: AuthRule[] = [{ allow: "public" }];
+    const publicRule: EntitiesAuthRule[] = [{ allow: "public" }];
 
     const authorData = authorsRes.data.filter((a) => canAccess(null, a, publicRule));
     const sectionData = sectionsRes.data.filter((s) => canAccess(null, s, publicRule));


### PR DESCRIPTION
## Résumé
- uniformise les types partagés et les regroupe par domaine (amplify, modèle, formulaire, config)
- supprime les collisions de noms en renommant AuthRule en AuthRuleConfig et exporte EntitiesAuthRule
- centralise les exports via un index de types unique et ajuste les imports du dépôt

## Tests
- `yarn prettier --write src/components/forms/EntityEditor.tsx src/entities/core/auth.ts src/entities/core/hooks/useModelForm.ts src/entities/core/hooks/useModelForm2.ts src/entities/core/services/crudService.ts src/entities/core/types/amplifyBaseTypes.ts src/entities/core/types/config.ts src/entities/core/types/doc.md src/entities/core/types/form.ts src/entities/core/types/index.ts src/entities/core/types/model.ts src/entities/customTypes/seo/types.ts src/entities/relations/postTag/types.ts src/entities/relations/sectionPost/types.ts src/services/blogDataService.ts`
- `yarn lint`
- `yarn build` *(échoué : Module not found: Can't resolve '@/amplify_outputs.json')*

------
https://chatgpt.com/codex/tasks/task_e_689f15f3f2a48324969512f6c63e128d