### PR TITLE
[Feat] adapte les types génériques du modèle Post

### DIFF
--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -2,6 +2,7 @@ import { z, type ZodType } from "zod";
 import {
     type PostType,
     type PostFormType,
+    type PostTypeCreateInput,
     type PostTypeUpdateInput,
 } from "@entities/models/post/types";
 import { toSeoForm, initialSeoForm } from "@entities/customTypes/seo/form";
@@ -16,7 +17,7 @@ export const {
 } = createModelForm<
     PostType,
     PostFormType,
-    PostTypeUpdateInput,
+    PostTypeCreateInput,
     PostTypeUpdateInput,
     [string[], string[]]
 >({
@@ -62,7 +63,7 @@ export const {
         tagIds,
         sectionIds,
     }),
-    toCreate: (form: PostFormType): PostTypeUpdateInput => {
+    toCreate: (form: PostFormType): PostTypeCreateInput => {
         const { tagIds, sectionIds, ...values } = form;
         void tagIds;
         void sectionIds;
@@ -72,6 +73,6 @@ export const {
         const { tagIds, sectionIds, ...values } = form;
         void tagIds;
         void sectionIds;
-        return values;
+        return values as PostTypeUpdateInput;
     },
 });

--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -1,5 +1,13 @@
 import { crudService } from "@entities/core";
+import type { IdArg } from "@entities/core/types";
+import type { PostTypeCreateInput, PostTypeUpdateInput } from "./types";
 
-export const postService = crudService("Post", {
+export const postService = crudService<
+    "Post",
+    PostTypeCreateInput,
+    PostTypeUpdateInput,
+    IdArg,
+    IdArg
+>("Post", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });

--- a/src/entities/models/post/types.ts
+++ b/src/entities/models/post/types.ts
@@ -1,9 +1,9 @@
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+import type { BaseModel, CreateOmit, ModelForm } from "@entities/core/types";
 import { type SeoTypeOmit } from "@entities/customTypes/seo/types";
 
 export type PostType = BaseModel<"Post">;
-export type PostTypeOmit = CreateOmit<"Post">;
-export type PostTypeUpdateInput = UpdateInput<"Post">;
+export type PostTypeCreateInput = CreateOmit<"Post">;
+export type PostTypeUpdateInput = { id: string } & Partial<PostTypeCreateInput>;
 
 type PostCustomTypes = { seo: SeoTypeOmit };
 export type PostFormType = ModelForm<


### PR DESCRIPTION
## Résumé
- définit `PostTypeCreateInput` et `PostTypeUpdateInput` via `@entities/core/types`
- utilise ces nouveaux types pour `PostForm` et `crudService`

## Tests effectués
- `yarn prettier --write src/entities/models/post/types.ts src/entities/models/post/form.ts src/entities/models/post/service.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689f28ab14088324b84557669bdd79eb