### PR TITLE
[Feat] typage générique du service Tag

### DIFF
--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,5 +1,10 @@
 import { crudService } from "@entities/core";
+import type { TagTypeCreateInput, TagTypeUpdateInput } from "./types";
+import type { IdArg } from "@entities/core/types";
 
-export const tagService = crudService("Tag", {
-    auth: { read: ["apiKey", "userPool"], write: "userPool" },
-});
+export const tagService = crudService<"Tag", TagTypeCreateInput, TagTypeUpdateInput, IdArg, IdArg>(
+    "Tag",
+    {
+        auth: { read: ["apiKey", "userPool"], write: "userPool" },
+    }
+);

--- a/src/entities/models/tag/types.ts
+++ b/src/entities/models/tag/types.ts
@@ -1,6 +1,7 @@
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core/types";
 
 export type TagType = BaseModel<"Tag">;
 export type TagTypeOmit = CreateOmit<"Tag">;
-export type TagTypeUpdateInput = UpdateInput<"Tag">;
+export type TagTypeCreateInput = UpdateInput<"Tag">;
+export type TagTypeUpdateInput = { id: string } & Partial<TagTypeCreateInput>;
 export type TagFormType = ModelForm<"Tag", "posts", "post">;


### PR DESCRIPTION
## Description
- remplace l'import core dans les types de Tag
- ajoute `TagTypeCreateInput` et `TagTypeUpdateInput`
- met à jour le service Tag avec l'API générique et `IdArg`

## Tests effectués
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689f28ae53308324a5008708ccfcffc8