### PR TITLE
[Feat] refine user profile types and service

### DIFF
--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -1,5 +1,14 @@
 // src/entities/models/userProfile/service.ts
-import { crudService } from "@entities/core/services/crudService";
-export const userProfileService = crudService("UserProfile", {
-    auth: { read: "userPool", write: "userPool" },
+import { crudService } from "@entities/core";
+import type { UserProfileTypeCreateInput, UserProfileTypeUpdateInput } from "./types";
+import type { IdArg } from "@entities/core/types";
+
+export const userProfileService = crudService<
+    "UserProfile",
+    UserProfileTypeCreateInput,
+    UserProfileTypeUpdateInput,
+    IdArg,
+    IdArg
+>("UserProfile", {
+    auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });

--- a/src/entities/models/userProfile/types.ts
+++ b/src/entities/models/userProfile/types.ts
@@ -1,8 +1,8 @@
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+import type { BaseModel, CreateOmit, ModelForm } from "@entities/core/types";
 
 export type UserProfileType = BaseModel<"UserProfile">;
-export type UserProfileTypeOmit = CreateOmit<"UserProfile">;
-export type UserProfileTypeUpdateInput = UpdateInput<"UserProfile">;
+export type UserProfileTypeCreateInput = CreateOmit<"UserProfile">;
+export type UserProfileTypeUpdateInput = { id: string } & Partial<UserProfileTypeCreateInput>;
 export type UserProfileFormType = ModelForm<"UserProfile">;
 
 export type UserProfileMinimalType = {


### PR DESCRIPTION
## Summary
- define UserProfile creation and update input types
- rewrite UserProfile service with generics and standard auth block

## Testing
- `yarn prettier --write src/entities/models/userProfile/types.ts src/entities/models/userProfile/service.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689f28b440c48324b37feaa866f2644e