### PR TITLE
[Fix] utilise EntitiesAuthRule dans ModelConfig

### DIFF
--- a/src/entities/core/types/config.ts
+++ b/src/entities/core/types/config.ts
@@ -40,5 +40,5 @@ export type ModelFields = Record<string, FieldDef | RelationDef | IdentifierDef>
 export interface ModelConfig {
     name: string;
     fields: ModelFields;
-    auth?: AuthRuleConfig[];
+    auth?: EntitiesAuthRule[];
 }


### PR DESCRIPTION
## Description
- remplace `AuthRuleConfig[]` par `EntitiesAuthRule[]` dans `ModelConfig`
- vérifie les modules consommateurs de `ModelConfig`

## Tests effectués
- `yarn lint` *(échoué: 'toSeoInput' non utilisé)*
- `yarn build` *(échoué: module manquant `@/amplify_outputs.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ec0ffb48324a1c3e33a638fdf9f