### PR TITLE
[Feat] réimplémente createEntityHooks

### DIFF
--- a/src/entities/core/createEntityHooks.ts
+++ b/src/entities/core/createEntityHooks.ts
@@ -1,0 +1,1 @@
+export { createEntityHooks } from "./utils";

--- a/src/entities/core/hooks/index.ts
+++ b/src/entities/core/hooks/index.ts
@@ -2,4 +2,6 @@
 
 export { default as useModelForm } from "./useModelForm";
 export { default as useModelForm2 } from "./useModelForm2";
+export { useEntityManager } from "./useEntityManager";
 export type { FormMode, UseModelFormOptions, UseModelFormResult, FieldKey } from "./useModelForm";
+export type { FieldConfig, UseEntityManagerConfig } from "./useEntityManager";

--- a/src/entities/core/hooks/useEntityManager.ts
+++ b/src/entities/core/hooks/useEntityManager.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { FieldKey } from "./useModelForm";
+
+export type FieldConfig<T extends Record<string, unknown>> = {
+    [K in FieldKey<T>]: {
+        parse: (v: unknown) => T[K];
+        serialize: (v: T[K]) => unknown;
+        emptyValue: T[K];
+    };
+};
+
+export type UseEntityManagerConfig<T extends Record<string, unknown>> = {
+    fetch: () => Promise<(T & { id?: string }) | null>;
+    create: (data: T) => Promise<void>;
+    update: (entity: (T & { id?: string }) | null, data: Partial<T>) => Promise<void>;
+    remove: (entity: (T & { id?: string }) | null) => Promise<void>;
+    labels: (field: FieldKey<T>) => string;
+    fields: FieldKey<T>[];
+    initialData: T;
+    config: FieldConfig<T>;
+};
+
+export function useEntityManager<T extends Record<string, unknown>>(
+    options: UseEntityManagerConfig<T>
+) {
+    const { fetch, create, update, remove, labels, fields, initialData, config } = options;
+    const [entity, setEntity] = useState<(T & { id?: string }) | null>(null);
+    const [formData, setFormData] = useState<T>(initialData);
+    const [editMode, setEditMode] = useState(false);
+    const [editModeField, setEditModeField] = useState<FieldKey<T> | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    const fetchData = useCallback(async () => {
+        setLoading(true);
+        try {
+            const res = await fetch();
+            if (res) {
+                setEntity(res);
+                const next = fields.reduce((acc, f) => {
+                    const value = res[f];
+                    const parser = config[f].parse;
+                    acc[f] = parser(value) as T[typeof f];
+                    return acc;
+                }, {} as T);
+                setFormData(next);
+            } else {
+                setEntity(null);
+                setFormData(initialData);
+            }
+            return res;
+        } finally {
+            setLoading(false);
+        }
+    }, [fetch, fields, config, initialData]);
+
+    useEffect(() => {
+        void fetchData();
+    }, [fetchData]);
+
+    const handleChange = useCallback((field: FieldKey<T>, value: unknown) => {
+        setFormData((prev) => ({ ...prev, [field]: value as T[typeof field] }));
+    }, []);
+
+    const save = useCallback(async () => {
+        if (entity) {
+            await update(entity, formData);
+        } else {
+            await create(formData);
+        }
+        await fetchData();
+    }, [entity, formData, update, create, fetchData]);
+
+    const saveField = useCallback(
+        async (field: FieldKey<T>) => {
+            if (!entity) return;
+            const partial = { [field]: formData[field] } as Partial<T>;
+            await update(entity, partial);
+            await fetchData();
+        },
+        [entity, formData, update, fetchData]
+    );
+
+    const clearField = useCallback(
+        (field: FieldKey<T>) => {
+            setFormData((prev) => ({ ...prev, [field]: config[field].emptyValue }));
+        },
+        [config]
+    );
+
+    const deleteEntity = useCallback(async () => {
+        if (!entity) return;
+        await remove(entity);
+        setEntity(null);
+        setFormData(initialData);
+    }, [entity, remove, initialData]);
+
+    return {
+        entity,
+        formData,
+        setFormData,
+        editMode,
+        setEditMode,
+        editModeField,
+        setEditModeField,
+        handleChange,
+        save,
+        saveField,
+        clearField,
+        deleteEntity,
+        labels,
+        fields,
+        loading,
+        fetchData,
+    } as const;
+}

--- a/src/entities/core/index.ts
+++ b/src/entities/core/index.ts
@@ -1,6 +1,7 @@
 export * from "./hooks";
 export * from "./services";
 export * from "./utils";
+export { createEntityHooks } from "./utils";
 export * from "./types";
 export * from "./hooks";
 export * from "./auth";

--- a/src/entities/core/utils/createEntityHooks.ts
+++ b/src/entities/core/utils/createEntityHooks.ts
@@ -1,108 +1,106 @@
-// "use client";
+"use client";
 
-// /* src/entities/createEntityHooks.ts  */
+import { useState } from "react";
+import { useAuthenticator } from "@aws-amplify/ui-react";
+import { useEntityManager, type FieldKey, type FieldConfig } from "@entities/core/hooks";
 
-// import { useState } from "react";
-// import { useAuthenticator } from "@aws-amplify/ui-react";
-// import { useEntityManager, type FieldKey, type FieldConfig } from "@entities/core/hooks";
+interface EntityService<T extends Record<string, string>> {
+    get: (id: string) => Promise<(T & { id?: string }) | null>;
+    create: (id: string, data: T) => Promise<void>;
+    update: (id: string, data: Partial<T>) => Promise<void>;
+    delete: (id: string) => Promise<void>;
+}
 
-// interface EntityService<T extends Record<string, string>> {
-//     get: (id: string) => Promise<(T & { id?: string }) | null>;
-//     create: (id: string, data: T) => Promise<void>;
-//     update: (id: string, data: Partial<T>) => Promise<void>;
-//     delete: (id: string) => Promise<void>;
-// }
+export interface CreateEntityHooksConfig<T extends Record<string, string>> {
+    model: string;
+    fields: FieldKey<T>[];
+    labels: (field: FieldKey<T>) => string;
+    service: EntityService<T>;
+    relations?: unknown;
+    customTypes?: unknown;
+}
 
-// export interface CreateEntityHooksConfig<T extends Record<string, string>> {
-//     model: string;
-//     fields: FieldKey<T>[];
-//     labels: (field: FieldKey<T>) => string;
-//     service: EntityService<T>;
-//     relations?: unknown;
-//     customTypes?: unknown;
-// }
+export function createEntityHooks<T extends Record<string, string>>(
+    config: CreateEntityHooksConfig<T>
+) {
+    return function useGeneratedEntityManager() {
+        const { user } = useAuthenticator();
+        const sub = user?.userId ?? user?.username;
+        const [error, setError] = useState<Error | null>(null);
 
-// export function createEntityHooks<T extends Record<string, string>>(
-//     config: CreateEntityHooksConfig<T>
-// ) {
-//     return function useGeneratedEntityManager() {
-//         const { user } = useAuthenticator();
-//         const sub = user?.userId ?? user?.username;
-//         const [error, setError] = useState<Error | null>(null);
+        const fetch = async () => {
+            if (!sub) return null;
+            try {
+                const item = await config.service.get(sub);
+                if (!item) return null;
+                const data: T & { id?: string } = {
+                    id: sub,
+                    ...config.fields.reduce((acc, f) => ({ ...acc, [f]: item[f] ?? "" }), {} as T),
+                };
+                return data;
+            } catch (e) {
+                setError(e as Error);
+                return null;
+            }
+        };
 
-//         const fetch = async () => {
-//             if (!sub) return null;
-//             try {
-//                 const item = await config.service.get(sub);
-//                 if (!item) return null;
-//                 const data: T & { id?: string } = {
-//                     id: sub,
-//                     ...config.fields.reduce((acc, f) => ({ ...acc, [f]: item[f] ?? "" }), {} as T),
-//                 };
-//                 return data;
-//             } catch (e) {
-//                 setError(e as Error);
-//                 return null;
-//             }
-//         };
+        const create = async (data: T) => {
+            if (!sub) throw new Error("id manquant");
+            try {
+                setError(null);
+                await config.service.create(sub, data);
+            } catch (e) {
+                setError(e as Error);
+            }
+        };
 
-//         const create = async (data: T) => {
-//             if (!sub) throw new Error("id manquant");
-//             try {
-//                 setError(null);
-//                 await config.service.create(sub, data);
-//             } catch (e) {
-//                 setError(e as Error);
-//             }
-//         };
+        const update = async (_entity: (T & { id?: string }) | null, data: Partial<T>) => {
+            void _entity;
+            if (!sub) throw new Error("id manquant");
+            try {
+                setError(null);
+                await config.service.update(sub, data);
+            } catch (e) {
+                setError(e as Error);
+            }
+        };
 
-//         const update = async (_entity: (T & { id?: string }) | null, data: Partial<T>) => {
-//             void _entity;
-//             if (!sub) throw new Error("id manquant");
-//             try {
-//                 setError(null);
-//                 await config.service.update(sub, data);
-//             } catch (e) {
-//                 setError(e as Error);
-//             }
-//         };
+        const remove = async (_entity: (T & { id?: string }) | null) => {
+            void _entity;
+            if (!sub) return;
+            try {
+                setError(null);
+                await config.service.delete(sub);
+            } catch (e) {
+                setError(e as Error);
+            }
+        };
 
-//         const remove = async (_entity: (T & { id?: string }) | null) => {
-//             void _entity;
-//             if (!sub) return;
-//             try {
-//                 setError(null);
-//                 await config.service.delete(sub);
-//             } catch (e) {
-//                 setError(e as Error);
-//             }
-//         };
+        const initialData = config.fields.reduce((acc, f) => ({ ...acc, [f]: "" }), {} as T);
 
-//         const initialData = config.fields.reduce((acc, f) => ({ ...acc, [f]: "" }), {} as T);
+        const fieldConfig: FieldConfig<T> = config.fields.reduce(
+            (acc, f) => ({
+                ...acc,
+                [f]: {
+                    parse: (v) => String(v) as T[typeof f],
+                    serialize: (v: string) => v,
+                    emptyValue: "" as T[typeof f],
+                },
+            }),
+            {} as FieldConfig<T>
+        );
 
-//         const fieldConfig: FieldConfig<T> = config.fields.reduce(
-//             (acc, f) => ({
-//                 ...acc,
-//                 [f]: {
-//                     parse: (v) => String(v),
-//                     serialize: (v: string) => v,
-//                     emptyValue: "",
-//                 },
-//             }),
-//             {} as FieldConfig<T>
-//         );
+        const manager = useEntityManager<T>({
+            fetch,
+            create,
+            update,
+            remove,
+            labels: config.labels,
+            fields: config.fields,
+            initialData,
+            config: fieldConfig,
+        });
 
-//         const manager = useEntityManager<T>({
-//             fetch,
-//             create,
-//             update,
-//             remove,
-//             labels: config.labels,
-//             fields: config.fields,
-//             initialData,
-//             config: fieldConfig,
-//         });
-
-//         return { ...manager, error };
-//     };
-// }
+        return { ...manager, error };
+    };
+}

--- a/src/entities/core/utils/index.ts
+++ b/src/entities/core/utils/index.ts
@@ -1,4 +1,4 @@
 export * from "./amplifyUiConfig";
 export * from "./createModelForm";
-// export * from "./createEntityHooks";
+export * from "./createEntityHooks";
 export * from "./syncManyToMany";


### PR DESCRIPTION
## Résumé
- réécriture complète de `createEntityHooks` avec gestion CRUD et authentification
- ajout du hook générique `useEntityManager`
- export du nouvel utilitaire dans les index

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689f469783e08324aae50f52f48ce075