### PR TITLE
[Fix] remove duplicate hooks export

### DIFF
--- a/src/entities/core/index.ts
+++ b/src/entities/core/index.ts
@@ -3,5 +3,4 @@ export * from "./services";
 export * from "./utils";
 export { createEntityHooks } from "./utils";
 export * from "./types";
-export * from "./hooks";
 export * from "./auth";


### PR DESCRIPTION
## Summary
- remove duplicate hooks export

## Testing
- `yarn install`
- `yarn prettier src/entities/core/index.ts --write`
- `yarn lint` *(fails: React Hook useEffect has a missing dependency: 'manager'; '@typescript-eslint/no-unused-vars' for toSeoInput)*

------
https://chatgpt.com/codex/tasks/task_e_689f4bc7187c8324b2e605ffaf3d29a7