### PR TITLE
[Feat] injection du service dans les hooks générés

### DIFF
--- a/scripts/generator/render/renderModelHooks.ts
+++ b/scripts/generator/render/renderModelHooks.ts
@@ -9,8 +9,12 @@ export function renderModelHooks(m: ModelMeta) {
 import { createEntityHooks } from "${GEN.paths.createEntityHooks}";
 import type { ${m.name}FormType } from "./types";
 import { ${low}Config } from "./config";
+import { ${low}Service } from "./service";
 
-export const use${m.name}Manager = createEntityHooks<${m.name}FormType>(${low}Config);
+export const use${m.name}Manager = createEntityHooks<${m.name}FormType>({
+    ...${low}Config,
+    service: ${low}Service,
+});
 `;
     safeWrite(path.join(dir, "hooks.ts"), content);
 }

--- a/src/entities/models/author/hooks.ts
+++ b/src/entities/models/author/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { AuthorFormType } from "./types";
 import { authorConfig } from "./config";
+import { authorService } from "./service";
 
-export const useAuthorManager = createEntityHooks<AuthorFormType>(authorConfig);
+export const useAuthorManager = createEntityHooks<AuthorFormType>({
+    ...authorConfig,
+    service: authorService,
+});

--- a/src/entities/models/comment/hooks.ts
+++ b/src/entities/models/comment/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { CommentFormType } from "./types";
 import { commentConfig } from "./config";
+import { commentService } from "./service";
 
-export const useCommentManager = createEntityHooks<CommentFormType>(commentConfig);
+export const useCommentManager = createEntityHooks<CommentFormType>({
+    ...commentConfig,
+    service: commentService,
+});

--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -1,54 +1,58 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { PostType, PostFormType, PostTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-import { initialSeoForm, toSeoForm, toSeoInput } from "@src/entities/customTypes/seo/form";
-    
-    export const initialPostForm: PostFormType = {
-      id: "",
-  slug: "",
-  title: "",
-  excerpt: "",
-  content: "",
-  videoUrl: "",
-  authorId: "",
-  order: 0,
-  type: "",
-  status: "",
-  seo: { ...initialSeoForm },
-  tagIds: [] as string[],
-  sectionIds: [] as string[],
+import type { PostType, PostFormType, PostTypeOmit } from "./types";
+import { createModelForm } from "@src/entities/core";
+
+import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
+
+export const initialPostForm: PostFormType = {
+    id: "",
+    slug: "",
+    title: "",
+    excerpt: "",
+    content: "",
+    videoUrl: "",
+    authorId: "",
+    order: 0,
+    type: "",
+    status: "",
+    seo: { ...initialSeoForm },
+    tagIds: [] as string[],
+    sectionIds: [] as string[],
+};
+
+function toPostForm(
+    model: PostType,
+    tagIds: string[] = [],
+    sectionIds: string[] = []
+): PostFormType {
+    return {
+        slug: model.slug ?? "",
+        title: model.title ?? "",
+        excerpt: model.excerpt ?? "",
+        content: model.content ?? "",
+        videoUrl: model.videoUrl ?? "",
+        authorId: model.authorId ?? "",
+        order: model.order ?? 0,
+        type: model.type ?? "",
+        status: model.status ?? "",
+        seo: toSeoForm(model.seo),
+        tagIds,
+        sectionIds,
     };
-    
-    function toPostForm(model: PostType, tagIds: string[] = [], sectionIds: string[] = []): PostFormType {
-      return {
-      slug: model.slug ?? "",
-  title: model.title ?? "",
-  excerpt: model.excerpt ?? "",
-  content: model.content ?? "",
-  videoUrl: model.videoUrl ?? "",
-  authorId: model.authorId ?? "",
-  order: model.order ?? 0,
-  type: model.type ?? "",
-  status: model.status ?? "",
-  seo: toSeoForm(model.seo),
-  tagIds,
-  sectionIds,
-      };
-    }
-    
-    function toPostInput(form: PostFormType): PostTypeOmit {
-      const { tagIds, sectionIds, ...rest } = form;
-  void tagIds;
-  void sectionIds;
-  return rest as PostTypeOmit;
-    }
-    
-    export const postForm = createModelForm<PostType, PostFormType, [string[], string[]], PostTypeOmit>(
-      initialPostForm,
-      (model, tagIds: string[] = [], sectionIds: string[] = []) => toPostForm(model, tagIds, sectionIds),
-      toPostInput
-    );
-    
-    export { toPostForm, toPostInput };
-    
+}
+
+function toPostInput(form: PostFormType): PostTypeOmit {
+    const { tagIds, sectionIds, ...rest } = form;
+    void tagIds;
+    void sectionIds;
+    return rest as PostTypeOmit;
+}
+
+export const postForm = createModelForm<PostType, PostFormType, [string[], string[]], PostTypeOmit>(
+    initialPostForm,
+    (model, tagIds: string[] = [], sectionIds: string[] = []) =>
+        toPostForm(model, tagIds, sectionIds),
+    toPostInput
+);
+
+export { toPostForm, toPostInput };

--- a/src/entities/models/post/hooks.ts
+++ b/src/entities/models/post/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { PostFormType } from "./types";
 import { postConfig } from "./config";
+import { postService } from "./service";
 
-export const usePostManager = createEntityHooks<PostFormType>(postConfig);
+export const usePostManager = createEntityHooks<PostFormType>({
+    ...postConfig,
+    service: postService,
+});

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -1,41 +1,45 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { SectionType, SectionFormType, SectionTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-import { initialSeoForm, toSeoForm, toSeoInput } from "@src/entities/customTypes/seo/form";
-    
-    export const initialSectionForm: SectionFormType = {
-      id: "",
-  title: "",
-  slug: "",
-  description: "",
-  order: 0,
-  seo: { ...initialSeoForm },
-  postIds: [] as string[],
+import type { SectionType, SectionFormType, SectionTypeOmit } from "./types";
+import { createModelForm } from "@src/entities/core";
+
+import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
+
+export const initialSectionForm: SectionFormType = {
+    id: "",
+    title: "",
+    slug: "",
+    description: "",
+    order: 0,
+    seo: { ...initialSeoForm },
+    postIds: [] as string[],
+};
+
+function toSectionForm(model: SectionType, postIds: string[] = []): SectionFormType {
+    return {
+        title: model.title ?? "",
+        slug: model.slug ?? "",
+        description: model.description ?? "",
+        order: model.order ?? 0,
+        seo: toSeoForm(model.seo),
+        postIds,
     };
-    
-    function toSectionForm(model: SectionType, postIds: string[] = []): SectionFormType {
-      return {
-      title: model.title ?? "",
-  slug: model.slug ?? "",
-  description: model.description ?? "",
-  order: model.order ?? 0,
-  seo: toSeoForm(model.seo),
-  postIds,
-      };
-    }
-    
-    function toSectionInput(form: SectionFormType): SectionTypeOmit {
-      const { postIds, ...rest } = form;
-  void postIds;
-  return rest as SectionTypeOmit;
-    }
-    
-    export const sectionForm = createModelForm<SectionType, SectionFormType, [string[]], SectionTypeOmit>(
-      initialSectionForm,
-      (model, postIds: string[] = []) => toSectionForm(model, postIds),
-      toSectionInput
-    );
-    
-    export { toSectionForm, toSectionInput };
-    
+}
+
+function toSectionInput(form: SectionFormType): SectionTypeOmit {
+    const { postIds, ...rest } = form;
+    void postIds;
+    return rest as SectionTypeOmit;
+}
+
+export const sectionForm = createModelForm<
+    SectionType,
+    SectionFormType,
+    [string[]],
+    SectionTypeOmit
+>(
+    initialSectionForm,
+    (model, postIds: string[] = []) => toSectionForm(model, postIds),
+    toSectionInput
+);
+
+export { toSectionForm, toSectionInput };

--- a/src/entities/models/section/hooks.ts
+++ b/src/entities/models/section/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { SectionFormType } from "./types";
 import { sectionConfig } from "./config";
+import { sectionService } from "./service";
 
-export const useSectionManager = createEntityHooks<SectionFormType>(sectionConfig);
+export const useSectionManager = createEntityHooks<SectionFormType>({
+    ...sectionConfig,
+    service: sectionService,
+});

--- a/src/entities/models/tag/hooks.ts
+++ b/src/entities/models/tag/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { TagFormType } from "./types";
 import { tagConfig } from "./config";
+import { tagService } from "./service";
 
-export const useTagManager = createEntityHooks<TagFormType>(tagConfig);
+export const useTagManager = createEntityHooks<TagFormType>({
+    ...tagConfig,
+    service: tagService,
+});

--- a/src/entities/models/todo/hooks.ts
+++ b/src/entities/models/todo/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { TodoFormType } from "./types";
 import { todoConfig } from "./config";
+import { todoService } from "./service";
 
-export const useTodoManager = createEntityHooks<TodoFormType>(todoConfig);
+export const useTodoManager = createEntityHooks<TodoFormType>({
+    ...todoConfig,
+    service: todoService,
+});

--- a/src/entities/models/userName/hooks.ts
+++ b/src/entities/models/userName/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { UserNameFormType } from "./types";
 import { userNameConfig } from "./config";
+import { userNameService } from "./service";
 
-export const useUserNameManager = createEntityHooks<UserNameFormType>(userNameConfig);
+export const useUserNameManager = createEntityHooks<UserNameFormType>({
+    ...userNameConfig,
+    service: userNameService,
+});

--- a/src/entities/models/userProfile/hooks.ts
+++ b/src/entities/models/userProfile/hooks.ts
@@ -2,5 +2,9 @@
 import { createEntityHooks } from "@src/entities/core/createEntityHooks";
 import type { UserProfileFormType } from "./types";
 import { userProfileConfig } from "./config";
+import { userProfileService } from "./service";
 
-export const useUserProfileManager = createEntityHooks<UserProfileFormType>(userProfileConfig);
+export const useUserProfileManager = createEntityHooks<UserProfileFormType>({
+    ...userProfileConfig,
+    service: userProfileService,
+});


### PR DESCRIPTION
## Description
- injection du service dans le générateur de hooks
- régénération des modèles et ajout du service dans chaque hook
- suppression des imports `toSeoInput` inutilisés dans `post` et `section`

## Tests effectués
- `yarn install`
- `yarn gen:entities`
- `yarn prettier --write scripts/generator/render/renderModelHooks.ts src/entities/models/*/hooks.ts src/entities/models/post/form.ts src/entities/models/section/form.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4ea988308324acd220046e8acc47