### PR TITLE
[Feat] gestion du chargement des entités

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -22,7 +22,8 @@ export default function UserNameManager() {
         if (user) {
             void manager.refresh(); // 🔄 charge/rafraîchit au montage et quand l'user change
         }
-    }, [user, manager.refresh]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [user]);
 
     if (!user) return <Authenticator />;
 
@@ -57,6 +58,7 @@ export default function UserNameManager() {
             saveField={manager.saveField} // ⬅️ refetch inclus
             clearField={manager.clearField}
             deleteEntity={manager.remove} // ⬅️ refetch inclus
+            loading={manager.loading}
         />
     );
 }

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -90,6 +90,7 @@ export default function UserProfileManager() {
             saveField={profile.saveField}
             clearField={profile.clearField}
             deleteEntity={profile.deleteProfile}
+            loading={profile.loading}
         />
     );
 }

--- a/src/components/forms/EntityEditor.tsx
+++ b/src/components/forms/EntityEditor.tsx
@@ -48,6 +48,8 @@ export type EntityEditorProps<T extends Record<string, unknown>> = {
     clearField?: (field: FieldKey<T>) => Promise<void>;
     /** Suppression de l'entité */
     deleteEntity?: () => Promise<void>;
+    /** Indique si une opération est en cours */
+    loading?: boolean;
 };
 
 export default function EntityEditor<T extends Record<string, unknown>>(
@@ -72,6 +74,7 @@ export default function EntityEditor<T extends Record<string, unknown>>(
         saveField,
         clearField,
         deleteEntity,
+        loading = false,
     } = props;
     const [editModeField, setEditModeField] = useState<{
         field: FieldKey<T>;
@@ -91,6 +94,19 @@ export default function EntityEditor<T extends Record<string, unknown>>(
             void clearField?.(field);
         }
     };
+
+    if (loading) {
+        return (
+            <section
+                className={`w-full max-w-md mx-auto px-4 py-6 bg-white shadow rounded-lg mb-8 ${
+                    className ?? ""
+                }`}
+            >
+                <h1 className="text-2xl font-bold text-center mb-6">{title}</h1>
+                <p className="text-center text-gray-500">Chargement…</p>
+            </section>
+        );
+    }
 
     return (
         <section

--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -21,6 +21,7 @@ export function useUserProfileForm(): UserProfileFormResult {
     const { user } = useAuthenticator();
     const sub = user?.userId ?? user?.username;
     const [error, setError] = useState<Error | null>(null);
+    const [loading, setLoading] = useState(false);
 
     const initialForm: UserProfileMinimalType = {
         firstName: "",
@@ -67,6 +68,7 @@ export function useUserProfileForm(): UserProfileFormResult {
 
     const fetchProfile = async (): Promise<UserProfileMinimalType | null> => {
         if (!sub) return null;
+        setLoading(true);
         try {
             const { data } = await userProfileService.get({ id: sub });
             if (!data) return null;
@@ -84,17 +86,22 @@ export function useUserProfileForm(): UserProfileFormResult {
         } catch (e) {
             setError(e as Error);
             return null;
+        } finally {
+            setLoading(false);
         }
     };
 
     const saveField = async (field: keyof UserProfileMinimalType, value: string): Promise<void> => {
         if (!sub) return;
+        setLoading(true);
         try {
             setError(null);
             await userProfileService.update({ id: sub, [field]: value });
             setForm((f) => ({ ...f, [field]: value }));
         } catch (e) {
             setError(e as Error);
+        } finally {
+            setLoading(false);
         }
     };
 
@@ -104,6 +111,7 @@ export function useUserProfileForm(): UserProfileFormResult {
 
     const deleteProfile = async (): Promise<void> => {
         if (!sub) return;
+        setLoading(true);
         try {
             setError(null);
             await userProfileService.delete({ id: sub });
@@ -111,6 +119,8 @@ export function useUserProfileForm(): UserProfileFormResult {
             reset();
         } catch (e) {
             setError(e as Error);
+        } finally {
+            setLoading(false);
         }
     };
 
@@ -126,6 +136,7 @@ export function useUserProfileForm(): UserProfileFormResult {
 
     return {
         ...formManager,
+        loading: loading || formManager.saving,
         fetchProfile,
         saveField,
         clearField,


### PR DESCRIPTION
## Description
- ajoute une prop `loading` à `EntityEditor`
- propage l'état de chargement depuis `useUserProfileForm` et `useUserNameForm`
- affiche une vue de chargement dans l'éditeur lorsque nécessaire

## Tests effectués
- `yarn prettier --write src/components/forms/EntityEditor.tsx src/components/Profile/UserProfileManager.tsx src/components/Profile/UserNameManager.tsx src/entities/models/userProfile/hooks.tsx src/entities/models/userName/hooks.tsx`
- `yarn lint`
- `yarn build` *(échoué : module `@/amplify_outputs.json` manquant)*

------
https://chatgpt.com/codex/tasks/task_e_689fd900267483248e9e541880e5253f