### PR TITLE
[Feat] enrich entity hooks interface

### DIFF
--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -54,7 +54,7 @@ export default function UserProfileManager() {
     };
     useEffect(() => {
         if (user) {
-            void profile.fetchProfile();
+            void profile.refresh();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [user]);
@@ -89,7 +89,7 @@ export default function UserProfileManager() {
             labels={profile.labels}
             saveField={profile.saveField}
             clearField={profile.clearField}
-            deleteEntity={profile.deleteProfile}
+            deleteEntity={profile.remove}
             loading={profile.loading}
         />
     );

--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -1,54 +1,58 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { PostType, PostFormType, PostTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-import { initialSeoForm, toSeoForm, toSeoInput } from "@src/entities/customTypes/seo/form";
-    
-    export const initialPostForm: PostFormType = {
-      id: "",
-  slug: "",
-  title: "",
-  excerpt: "",
-  content: "",
-  videoUrl: "",
-  authorId: "",
-  order: 0,
-  type: "",
-  status: "",
-  seo: { ...initialSeoForm },
-  tagIds: [] as string[],
-  sectionIds: [] as string[],
+import type { PostType, PostFormType, PostTypeOmit } from "./types";
+import { createModelForm } from "@src/entities/core";
+
+import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
+
+export const initialPostForm: PostFormType = {
+    id: "",
+    slug: "",
+    title: "",
+    excerpt: "",
+    content: "",
+    videoUrl: "",
+    authorId: "",
+    order: 0,
+    type: "",
+    status: "",
+    seo: { ...initialSeoForm },
+    tagIds: [] as string[],
+    sectionIds: [] as string[],
+};
+
+function toPostForm(
+    model: PostType,
+    tagIds: string[] = [],
+    sectionIds: string[] = []
+): PostFormType {
+    return {
+        slug: model.slug ?? "",
+        title: model.title ?? "",
+        excerpt: model.excerpt ?? "",
+        content: model.content ?? "",
+        videoUrl: model.videoUrl ?? "",
+        authorId: model.authorId ?? "",
+        order: model.order ?? 0,
+        type: model.type ?? "",
+        status: model.status ?? "",
+        seo: toSeoForm(model.seo),
+        tagIds,
+        sectionIds,
     };
-    
-    function toPostForm(model: PostType, tagIds: string[] = [], sectionIds: string[] = []): PostFormType {
-      return {
-      slug: model.slug ?? "",
-  title: model.title ?? "",
-  excerpt: model.excerpt ?? "",
-  content: model.content ?? "",
-  videoUrl: model.videoUrl ?? "",
-  authorId: model.authorId ?? "",
-  order: model.order ?? 0,
-  type: model.type ?? "",
-  status: model.status ?? "",
-  seo: toSeoForm(model.seo),
-  tagIds,
-  sectionIds,
-      };
-    }
-    
-    function toPostInput(form: PostFormType): PostTypeOmit {
-      const { tagIds, sectionIds, ...rest } = form;
-  void tagIds;
-  void sectionIds;
-  return rest as PostTypeOmit;
-    }
-    
-    export const postForm = createModelForm<PostType, PostFormType, [string[], string[]], PostTypeOmit>(
-      initialPostForm,
-      (model, tagIds: string[] = [], sectionIds: string[] = []) => toPostForm(model, tagIds, sectionIds),
-      toPostInput
-    );
-    
-    export { toPostForm, toPostInput };
-    
+}
+
+function toPostInput(form: PostFormType): PostTypeOmit {
+    const { tagIds, sectionIds, ...rest } = form;
+    void tagIds;
+    void sectionIds;
+    return rest as PostTypeOmit;
+}
+
+export const postForm = createModelForm<PostType, PostFormType, [string[], string[]], PostTypeOmit>(
+    initialPostForm,
+    (model, tagIds: string[] = [], sectionIds: string[] = []) =>
+        toPostForm(model, tagIds, sectionIds),
+    toPostInput
+);
+
+export { toPostForm, toPostInput };

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -1,41 +1,45 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { SectionType, SectionFormType, SectionTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-import { initialSeoForm, toSeoForm, toSeoInput } from "@src/entities/customTypes/seo/form";
-    
-    export const initialSectionForm: SectionFormType = {
-      id: "",
-  title: "",
-  slug: "",
-  description: "",
-  order: 0,
-  seo: { ...initialSeoForm },
-  postIds: [] as string[],
+import type { SectionType, SectionFormType, SectionTypeOmit } from "./types";
+import { createModelForm } from "@src/entities/core";
+
+import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
+
+export const initialSectionForm: SectionFormType = {
+    id: "",
+    title: "",
+    slug: "",
+    description: "",
+    order: 0,
+    seo: { ...initialSeoForm },
+    postIds: [] as string[],
+};
+
+function toSectionForm(model: SectionType, postIds: string[] = []): SectionFormType {
+    return {
+        title: model.title ?? "",
+        slug: model.slug ?? "",
+        description: model.description ?? "",
+        order: model.order ?? 0,
+        seo: toSeoForm(model.seo),
+        postIds,
     };
-    
-    function toSectionForm(model: SectionType, postIds: string[] = []): SectionFormType {
-      return {
-      title: model.title ?? "",
-  slug: model.slug ?? "",
-  description: model.description ?? "",
-  order: model.order ?? 0,
-  seo: toSeoForm(model.seo),
-  postIds,
-      };
-    }
-    
-    function toSectionInput(form: SectionFormType): SectionTypeOmit {
-      const { postIds, ...rest } = form;
-  void postIds;
-  return rest as SectionTypeOmit;
-    }
-    
-    export const sectionForm = createModelForm<SectionType, SectionFormType, [string[]], SectionTypeOmit>(
-      initialSectionForm,
-      (model, postIds: string[] = []) => toSectionForm(model, postIds),
-      toSectionInput
-    );
-    
-    export { toSectionForm, toSectionInput };
-    
+}
+
+function toSectionInput(form: SectionFormType): SectionTypeOmit {
+    const { postIds, ...rest } = form;
+    void postIds;
+    return rest as SectionTypeOmit;
+}
+
+export const sectionForm = createModelForm<
+    SectionType,
+    SectionFormType,
+    [string[]],
+    SectionTypeOmit
+>(
+    initialSectionForm,
+    (model, postIds: string[] = []) => toSectionForm(model, postIds),
+    toSectionInput
+);
+
+export { toSectionForm, toSectionInput };

--- a/src/entities/models/userName/hooks.ts
+++ b/src/entities/models/userName/hooks.ts
@@ -4,7 +4,7 @@ import type { UserNameFormType } from "./types";
 import { userNameConfig } from "./config";
 import { userNameService } from "./service";
 
-export const useUserNameManager = createEntityHooks<UserNameFormType>({
+export const useUserNameForm = createEntityHooks<UserNameFormType>({
     ...userNameConfig,
     service: userNameService,
 });

--- a/src/entities/models/userProfile/hooks.ts
+++ b/src/entities/models/userProfile/hooks.ts
@@ -4,7 +4,7 @@ import type { UserProfileFormType } from "./types";
 import { userProfileConfig } from "./config";
 import { userProfileService } from "./service";
 
-export const useUserProfileManager = createEntityHooks<UserProfileFormType>({
+export const useUserProfileForm = createEntityHooks<UserProfileFormType>({
     ...userProfileConfig,
     service: userProfileService,
 });


### PR DESCRIPTION
## Summary
- étendre `createEntityHooks` pour exposer `form`, `mode`, `reset`, `refresh`...
- renommer les hooks utilisateur en `useUserProfileForm` et `useUserNameForm`
- adapter `UserProfileManager` au nouveau contrat et nettoyer des imports inutilisés

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689fe4fa78848324b58441af8a065c87