### PR TITLE
[Fix] uniformiser alias entities

### DIFF
--- a/scripts/generator/generator.config.ts
+++ b/scripts/generator/generator.config.ts
@@ -8,13 +8,13 @@ export const GEN = {
         relations: "src/entities/relations",
     },
     paths: {
-        myTypes: "@src/entities/core",
-        createModelForm: "@src/entities/core",
-        crudService: "@src/entities/core",
-        relationService: "@src/entities/core",
-        createEntityHooks: "@src/entities/core/createEntityHooks",
+        myTypes: "@entities/core",
+        createModelForm: "@entities/core",
+        crudService: "@entities/core",
+        relationService: "@entities/core",
+        createEntityHooks: "@entities/core/createEntityHooks",
         customTypeFormDir: (refType: string) =>
-            `@src/entities/customTypes/${refType.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase()}/form`,
+            `@entities/customTypes/${refType.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase()}/form`,
     },
     rules: {
         includeIdInForm: false,

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -9,7 +9,7 @@ import EditableTextArea from "@components/forms/EditableTextArea";
 import SeoFields from "@components/forms/SeoFields";
 import OrderSelector from "@components/forms/OrderSelector";
 import SelectField from "@components/forms/SelectField";
-import { type PostType } from "@/src/entities/models/post";
+import { type PostType } from "@entities/models/post";
 import { type SeoFormType } from "@entities/customTypes/seo/types";
 import { type PostFormType } from "@entities/models/post/types";
 

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -1,10 +1,10 @@
 "use client";
 import React from "react";
 import FormActionButtons from "../components/FormActionButtons";
-import { type PostType  } from "@/src/entities/models/post";
+import { type PostType } from "@entities/models/post";
 
 interface Props {
-    posts: PostType [];
+    posts: PostType[];
     editingIndex: number | null;
     onEdit: (idx: number) => void;
     onSave: () => void;

--- a/src/entities/core/doc.md
+++ b/src/entities/core/doc.md
@@ -4,7 +4,7 @@ Le module `core` rassemble les outils de base pour manipuler les entités de l'a
 
 ## Index
 
-Le fichier [`index.ts`](./index.ts) ré-exporte les contenus des sous-dossiers `services`, `hooks`, `utils` et `types`. Cela permet d'importer toutes les fonctionnalités du module depuis `@src/entities/core` sans connaître la structure interne.
+Le fichier [`index.ts`](./index.ts) ré-exporte les contenus des sous-dossiers `services`, `hooks`, `utils` et `types`. Cela permet d'importer toutes les fonctionnalités du module depuis `@entities/core` sans connaître la structure interne.
 
 ## Rôle des sous-dossiers
 

--- a/src/entities/models/author/form.ts
+++ b/src/entities/models/author/form.ts
@@ -1,36 +1,34 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { AuthorType, AuthorFormType, AuthorTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-    
-    export const initialAuthorForm: AuthorFormType = {
-      id: "",
-  authorName: "",
-  bio: "",
-  email: "",
-  avatar: "",
-  order: 0,
+import type { AuthorType, AuthorFormType, AuthorTypeOmit } from "./types";
+import { createModelForm } from "@entities/core";
+
+export const initialAuthorForm: AuthorFormType = {
+    id: "",
+    authorName: "",
+    bio: "",
+    email: "",
+    avatar: "",
+    order: 0,
+};
+
+function toAuthorForm(model: AuthorType): AuthorFormType {
+    return {
+        authorName: model.authorName ?? "",
+        bio: model.bio ?? "",
+        email: model.email ?? "",
+        avatar: model.avatar ?? "",
+        order: model.order ?? 0,
     };
-    
-    function toAuthorForm(model: AuthorType): AuthorFormType {
-      return {
-      authorName: model.authorName ?? "",
-  bio: model.bio ?? "",
-  email: model.email ?? "",
-  avatar: model.avatar ?? "",
-  order: model.order ?? 0,
-      };
-    }
-    
-    function toAuthorInput(form: AuthorFormType): AuthorTypeOmit {
-      return form as AuthorTypeOmit;
-    }
-    
-    export const authorForm = createModelForm<AuthorType, AuthorFormType, [], AuthorTypeOmit>(
-      initialAuthorForm,
-      (model) => toAuthorForm(model),
-      toAuthorInput
-    );
-    
-    export { toAuthorForm, toAuthorInput };
-    
+}
+
+function toAuthorInput(form: AuthorFormType): AuthorTypeOmit {
+    return form as AuthorTypeOmit;
+}
+
+export const authorForm = createModelForm<AuthorType, AuthorFormType, [], AuthorTypeOmit>(
+    initialAuthorForm,
+    (model) => toAuthorForm(model),
+    toAuthorInput
+);
+
+export { toAuthorForm, toAuthorInput };

--- a/src/entities/models/author/hooks.ts
+++ b/src/entities/models/author/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { AuthorFormType } from "./types";
 import { authorConfig } from "./config";
 import { authorService } from "./service";

--- a/src/entities/models/author/service.ts
+++ b/src/entities/models/author/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const authorService = crudService("Author");

--- a/src/entities/models/author/types.ts
+++ b/src/entities/models/author/types.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
 export type AuthorType = BaseModel<"Author">;
 export type AuthorTypeOmit = CreateOmit<"Author">;
@@ -9,10 +8,4 @@ export type AuthorTypeUpdateInput = UpdateInput<"Author">;
 type CTMap = Record<string, never>;
 type RelKeys = never;
 
-export type AuthorFormType = ModelForm<
-  "Author",
-  never,
-  RelKeys,
-  CTMap,
-  never
->;
+export type AuthorFormType = ModelForm<"Author", never, RelKeys, CTMap, never>;

--- a/src/entities/models/comment/form.ts
+++ b/src/entities/models/comment/form.ts
@@ -1,34 +1,32 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { CommentType, CommentFormType, CommentTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-    
-    export const initialCommentForm: CommentFormType = {
-      id: "",
-  content: "",
-  todoId: "",
-  postId: "",
-  userNameId: "",
+import type { CommentType, CommentFormType, CommentTypeOmit } from "./types";
+import { createModelForm } from "@entities/core";
+
+export const initialCommentForm: CommentFormType = {
+    id: "",
+    content: "",
+    todoId: "",
+    postId: "",
+    userNameId: "",
+};
+
+function toCommentForm(model: CommentType): CommentFormType {
+    return {
+        content: model.content ?? "",
+        todoId: model.todoId ?? "",
+        postId: model.postId ?? "",
+        userNameId: model.userNameId ?? "",
     };
-    
-    function toCommentForm(model: CommentType): CommentFormType {
-      return {
-      content: model.content ?? "",
-  todoId: model.todoId ?? "",
-  postId: model.postId ?? "",
-  userNameId: model.userNameId ?? "",
-      };
-    }
-    
-    function toCommentInput(form: CommentFormType): CommentTypeOmit {
-      return form as CommentTypeOmit;
-    }
-    
-    export const commentForm = createModelForm<CommentType, CommentFormType, [], CommentTypeOmit>(
-      initialCommentForm,
-      (model) => toCommentForm(model),
-      toCommentInput
-    );
-    
-    export { toCommentForm, toCommentInput };
-    
+}
+
+function toCommentInput(form: CommentFormType): CommentTypeOmit {
+    return form as CommentTypeOmit;
+}
+
+export const commentForm = createModelForm<CommentType, CommentFormType, [], CommentTypeOmit>(
+    initialCommentForm,
+    (model) => toCommentForm(model),
+    toCommentInput
+);
+
+export { toCommentForm, toCommentInput };

--- a/src/entities/models/comment/hooks.ts
+++ b/src/entities/models/comment/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { CommentFormType } from "./types";
 import { commentConfig } from "./config";
 import { commentService } from "./service";

--- a/src/entities/models/comment/service.ts
+++ b/src/entities/models/comment/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const commentService = crudService("Comment");

--- a/src/entities/models/comment/types.ts
+++ b/src/entities/models/comment/types.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
 export type CommentType = BaseModel<"Comment">;
 export type CommentTypeOmit = CreateOmit<"Comment">;
@@ -9,10 +8,4 @@ export type CommentTypeUpdateInput = UpdateInput<"Comment">;
 type CTMap = Record<string, never>;
 type RelKeys = never;
 
-export type CommentFormType = ModelForm<
-  "Comment",
-  never,
-  RelKeys,
-  CTMap,
-  never
->;
+export type CommentFormType = ModelForm<"Comment", never, RelKeys, CTMap, never>;

--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -1,8 +1,8 @@
 // AUTO-GENERATED – DO NOT EDIT
 import type { PostType, PostFormType, PostTypeOmit } from "./types";
-import { createModelForm } from "@src/entities/core";
+import { createModelForm } from "@entities/core";
 
-import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
+import { initialSeoForm, toSeoForm } from "@entities/customTypes/seo/form";
 
 export const initialPostForm: PostFormType = {
     id: "",

--- a/src/entities/models/post/hooks.ts
+++ b/src/entities/models/post/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { PostFormType } from "./types";
 import { postConfig } from "./config";
 import { postService } from "./service";

--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const postService = crudService("Post");

--- a/src/entities/models/post/types.ts
+++ b/src/entities/models/post/types.ts
@@ -1,7 +1,7 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
-import type { SeoForm } from "@src/entities/customTypes/seo/form";
+import type { SeoForm } from "@entities/customTypes/seo/form";
 
 export type PostType = BaseModel<"Post">;
 export type PostTypeOmit = CreateOmit<"Post">;
@@ -10,10 +10,4 @@ export type PostTypeUpdateInput = UpdateInput<"Post">;
 type CTMap = { Seo: SeoForm };
 type RelKeys = "tag" | "section";
 
-export type PostFormType = ModelForm<
-  "Post",
-  never,
-  RelKeys,
-  CTMap,
-  "Seo"
->;
+export type PostFormType = ModelForm<"Post", never, RelKeys, CTMap, "Seo">;

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -1,8 +1,8 @@
 // AUTO-GENERATED – DO NOT EDIT
 import type { SectionType, SectionFormType, SectionTypeOmit } from "./types";
-import { createModelForm } from "@src/entities/core";
+import { createModelForm } from "@entities/core";
 
-import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
+import { initialSeoForm, toSeoForm } from "@entities/customTypes/seo/form";
 
 export const initialSectionForm: SectionFormType = {
     id: "",

--- a/src/entities/models/section/hooks.ts
+++ b/src/entities/models/section/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { SectionFormType } from "./types";
 import { sectionConfig } from "./config";
 import { sectionService } from "./service";

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const sectionService = crudService("Section");

--- a/src/entities/models/section/types.ts
+++ b/src/entities/models/section/types.ts
@@ -1,7 +1,7 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
-import type { SeoForm } from "@src/entities/customTypes/seo/form";
+import type { SeoForm } from "@entities/customTypes/seo/form";
 
 export type SectionType = BaseModel<"Section">;
 export type SectionTypeOmit = CreateOmit<"Section">;
@@ -10,10 +10,4 @@ export type SectionTypeUpdateInput = UpdateInput<"Section">;
 type CTMap = { Seo: SeoForm };
 type RelKeys = "post";
 
-export type SectionFormType = ModelForm<
-  "Section",
-  never,
-  RelKeys,
-  CTMap,
-  "Seo"
->;
+export type SectionFormType = ModelForm<"Section", never, RelKeys, CTMap, "Seo">;

--- a/src/entities/models/tag/form.ts
+++ b/src/entities/models/tag/form.ts
@@ -1,32 +1,30 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { TagType, TagFormType, TagTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-    
-    export const initialTagForm: TagFormType = {
-      id: "",
-  name: "",
-  postIds: [] as string[],
+import type { TagType, TagFormType, TagTypeOmit } from "./types";
+import { createModelForm } from "@entities/core";
+
+export const initialTagForm: TagFormType = {
+    id: "",
+    name: "",
+    postIds: [] as string[],
+};
+
+function toTagForm(model: TagType, postIds: string[] = []): TagFormType {
+    return {
+        name: model.name ?? "",
+        postIds,
     };
-    
-    function toTagForm(model: TagType, postIds: string[] = []): TagFormType {
-      return {
-      name: model.name ?? "",
-  postIds,
-      };
-    }
-    
-    function toTagInput(form: TagFormType): TagTypeOmit {
-      const { postIds, ...rest } = form;
-  void postIds;
-  return rest as TagTypeOmit;
-    }
-    
-    export const tagForm = createModelForm<TagType, TagFormType, [string[]], TagTypeOmit>(
-      initialTagForm,
-      (model, postIds: string[] = []) => toTagForm(model, postIds),
-      toTagInput
-    );
-    
-    export { toTagForm, toTagInput };
-    
+}
+
+function toTagInput(form: TagFormType): TagTypeOmit {
+    const { postIds, ...rest } = form;
+    void postIds;
+    return rest as TagTypeOmit;
+}
+
+export const tagForm = createModelForm<TagType, TagFormType, [string[]], TagTypeOmit>(
+    initialTagForm,
+    (model, postIds: string[] = []) => toTagForm(model, postIds),
+    toTagInput
+);
+
+export { toTagForm, toTagInput };

--- a/src/entities/models/tag/hooks.ts
+++ b/src/entities/models/tag/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { TagFormType } from "./types";
 import { tagConfig } from "./config";
 import { tagService } from "./service";

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const tagService = crudService("Tag");

--- a/src/entities/models/tag/types.ts
+++ b/src/entities/models/tag/types.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
 export type TagType = BaseModel<"Tag">;
 export type TagTypeOmit = CreateOmit<"Tag">;
@@ -9,10 +8,4 @@ export type TagTypeUpdateInput = UpdateInput<"Tag">;
 type CTMap = Record<string, never>;
 type RelKeys = "post";
 
-export type TagFormType = ModelForm<
-  "Tag",
-  never,
-  RelKeys,
-  CTMap,
-  never
->;
+export type TagFormType = ModelForm<"Tag", never, RelKeys, CTMap, never>;

--- a/src/entities/models/todo/form.ts
+++ b/src/entities/models/todo/form.ts
@@ -1,28 +1,26 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { TodoType, TodoFormType, TodoTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-    
-    export const initialTodoForm: TodoFormType = {
-      id: "",
-  content: "",
+import type { TodoType, TodoFormType, TodoTypeOmit } from "./types";
+import { createModelForm } from "@entities/core";
+
+export const initialTodoForm: TodoFormType = {
+    id: "",
+    content: "",
+};
+
+function toTodoForm(model: TodoType): TodoFormType {
+    return {
+        content: model.content ?? "",
     };
-    
-    function toTodoForm(model: TodoType): TodoFormType {
-      return {
-      content: model.content ?? "",
-      };
-    }
-    
-    function toTodoInput(form: TodoFormType): TodoTypeOmit {
-      return form as TodoTypeOmit;
-    }
-    
-    export const todoForm = createModelForm<TodoType, TodoFormType, [], TodoTypeOmit>(
-      initialTodoForm,
-      (model) => toTodoForm(model),
-      toTodoInput
-    );
-    
-    export { toTodoForm, toTodoInput };
-    
+}
+
+function toTodoInput(form: TodoFormType): TodoTypeOmit {
+    return form as TodoTypeOmit;
+}
+
+export const todoForm = createModelForm<TodoType, TodoFormType, [], TodoTypeOmit>(
+    initialTodoForm,
+    (model) => toTodoForm(model),
+    toTodoInput
+);
+
+export { toTodoForm, toTodoInput };

--- a/src/entities/models/todo/hooks.ts
+++ b/src/entities/models/todo/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { TodoFormType } from "./types";
 import { todoConfig } from "./config";
 import { todoService } from "./service";

--- a/src/entities/models/todo/service.ts
+++ b/src/entities/models/todo/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const todoService = crudService("Todo");

--- a/src/entities/models/todo/types.ts
+++ b/src/entities/models/todo/types.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
 export type TodoType = BaseModel<"Todo">;
 export type TodoTypeOmit = CreateOmit<"Todo">;
@@ -9,10 +8,4 @@ export type TodoTypeUpdateInput = UpdateInput<"Todo">;
 type CTMap = Record<string, never>;
 type RelKeys = never;
 
-export type TodoFormType = ModelForm<
-  "Todo",
-  never,
-  RelKeys,
-  CTMap,
-  never
->;
+export type TodoFormType = ModelForm<"Todo", never, RelKeys, CTMap, never>;

--- a/src/entities/models/userName/form.ts
+++ b/src/entities/models/userName/form.ts
@@ -1,28 +1,26 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { UserNameType, UserNameFormType, UserNameTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-    
-    export const initialUserNameForm: UserNameFormType = {
-      id: "",
-  userName: "",
+import type { UserNameType, UserNameFormType, UserNameTypeOmit } from "./types";
+import { createModelForm } from "@entities/core";
+
+export const initialUserNameForm: UserNameFormType = {
+    id: "",
+    userName: "",
+};
+
+function toUserNameForm(model: UserNameType): UserNameFormType {
+    return {
+        userName: model.userName ?? "",
     };
-    
-    function toUserNameForm(model: UserNameType): UserNameFormType {
-      return {
-      userName: model.userName ?? "",
-      };
-    }
-    
-    function toUserNameInput(form: UserNameFormType): UserNameTypeOmit {
-      return form as UserNameTypeOmit;
-    }
-    
-    export const userNameForm = createModelForm<UserNameType, UserNameFormType, [], UserNameTypeOmit>(
-      initialUserNameForm,
-      (model) => toUserNameForm(model),
-      toUserNameInput
-    );
-    
-    export { toUserNameForm, toUserNameInput };
-    
+}
+
+function toUserNameInput(form: UserNameFormType): UserNameTypeOmit {
+    return form as UserNameTypeOmit;
+}
+
+export const userNameForm = createModelForm<UserNameType, UserNameFormType, [], UserNameTypeOmit>(
+    initialUserNameForm,
+    (model) => toUserNameForm(model),
+    toUserNameInput
+);
+
+export { toUserNameForm, toUserNameInput };

--- a/src/entities/models/userName/hooks.ts
+++ b/src/entities/models/userName/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { UserNameFormType } from "./types";
 import { userNameConfig } from "./config";
 import { userNameService } from "./service";

--- a/src/entities/models/userName/service.ts
+++ b/src/entities/models/userName/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const userNameService = crudService("UserName");

--- a/src/entities/models/userName/types.ts
+++ b/src/entities/models/userName/types.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
 export type UserNameType = BaseModel<"UserName">;
 export type UserNameTypeOmit = CreateOmit<"UserName">;
@@ -9,10 +8,4 @@ export type UserNameTypeUpdateInput = UpdateInput<"UserName">;
 type CTMap = Record<string, never>;
 type RelKeys = never;
 
-export type UserNameFormType = ModelForm<
-  "UserName",
-  never,
-  RelKeys,
-  CTMap,
-  never
->;
+export type UserNameFormType = ModelForm<"UserName", never, RelKeys, CTMap, never>;

--- a/src/entities/models/userProfile/form.ts
+++ b/src/entities/models/userProfile/form.ts
@@ -1,40 +1,39 @@
 // AUTO-GENERATED – DO NOT EDIT
-    import type { UserProfileType, UserProfileFormType, UserProfileTypeOmit } from "./types";
-    import { createModelForm } from "@src/entities/core";
-    
-    
-    export const initialUserProfileForm: UserProfileFormType = {
-      id: "",
-  firstName: "",
-  familyName: "",
-  address: "",
-  postalCode: "",
-  city: "",
-  country: "",
-  phoneNumber: "",
+import type { UserProfileType, UserProfileFormType, UserProfileTypeOmit } from "./types";
+import { createModelForm } from "@entities/core";
+
+export const initialUserProfileForm: UserProfileFormType = {
+    id: "",
+    firstName: "",
+    familyName: "",
+    address: "",
+    postalCode: "",
+    city: "",
+    country: "",
+    phoneNumber: "",
+};
+
+function toUserProfileForm(model: UserProfileType): UserProfileFormType {
+    return {
+        firstName: model.firstName ?? "",
+        familyName: model.familyName ?? "",
+        address: model.address ?? "",
+        postalCode: model.postalCode ?? "",
+        city: model.city ?? "",
+        country: model.country ?? "",
+        phoneNumber: model.phoneNumber ?? "",
     };
-    
-    function toUserProfileForm(model: UserProfileType): UserProfileFormType {
-      return {
-      firstName: model.firstName ?? "",
-  familyName: model.familyName ?? "",
-  address: model.address ?? "",
-  postalCode: model.postalCode ?? "",
-  city: model.city ?? "",
-  country: model.country ?? "",
-  phoneNumber: model.phoneNumber ?? "",
-      };
-    }
-    
-    function toUserProfileInput(form: UserProfileFormType): UserProfileTypeOmit {
-      return form as UserProfileTypeOmit;
-    }
-    
-    export const userProfileForm = createModelForm<UserProfileType, UserProfileFormType, [], UserProfileTypeOmit>(
-      initialUserProfileForm,
-      (model) => toUserProfileForm(model),
-      toUserProfileInput
-    );
-    
-    export { toUserProfileForm, toUserProfileInput };
-    
+}
+
+function toUserProfileInput(form: UserProfileFormType): UserProfileTypeOmit {
+    return form as UserProfileTypeOmit;
+}
+
+export const userProfileForm = createModelForm<
+    UserProfileType,
+    UserProfileFormType,
+    [],
+    UserProfileTypeOmit
+>(initialUserProfileForm, (model) => toUserProfileForm(model), toUserProfileInput);
+
+export { toUserProfileForm, toUserProfileInput };

--- a/src/entities/models/userProfile/hooks.ts
+++ b/src/entities/models/userProfile/hooks.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { createEntityHooks } from "@src/entities/core/createEntityHooks";
+import { createEntityHooks } from "@entities/core/createEntityHooks";
 import type { UserProfileFormType } from "./types";
 import { userProfileConfig } from "./config";
 import { userProfileService } from "./service";

--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { crudService } from "@src/entities/core";
+import { crudService } from "@entities/core";
 export const userProfileService = crudService("UserProfile");

--- a/src/entities/models/userProfile/types.ts
+++ b/src/entities/models/userProfile/types.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED – DO NOT EDIT
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@src/entities/core";
-
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
 
 export type UserProfileType = BaseModel<"UserProfile">;
 export type UserProfileTypeOmit = CreateOmit<"UserProfile">;
@@ -9,10 +8,4 @@ export type UserProfileTypeUpdateInput = UpdateInput<"UserProfile">;
 type CTMap = Record<string, never>;
 type RelKeys = never;
 
-export type UserProfileFormType = ModelForm<
-  "UserProfile",
-  never,
-  RelKeys,
-  CTMap,
-  never
->;
+export type UserProfileFormType = ModelForm<"UserProfile", never, RelKeys, CTMap, never>;

--- a/src/entities/relations/postTag/service.ts
+++ b/src/entities/relations/postTag/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { relationService } from "@src/entities/core";
+import { relationService } from "@entities/core";
 export const postTagService = relationService("PostTag", "postId", "tagId");

--- a/src/entities/relations/sectionPost/service.ts
+++ b/src/entities/relations/sectionPost/service.ts
@@ -1,3 +1,3 @@
 // AUTO-GENERATED – DO NOT EDIT
-import { relationService } from "@src/entities/core";
+import { relationService } from "@entities/core";
 export const sectionPostService = relationService("SectionPost", "sectionId", "postId");


### PR DESCRIPTION
## Résumé
- aligner la configuration du générateur sur l'alias `@entities`
- remplacer les imports `@src/entities` par `@entities`
- corriger les composants du blog pour utiliser l'alias unifié

## Tests effectués
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689fe82346fc8324888105a0083552e8