### PR TITLE
[Feat] générer hook de formulaire

### DIFF
--- a/scripts/generator/entry.ts
+++ b/scripts/generator/entry.ts
@@ -6,6 +6,7 @@ import { renderModel } from "./render/renderModel";
 import { renderPivot } from "./render/renderPivot";
 import { renderCustomType } from "./render/renderCustomType";
 import { GEN } from "./generator.config";
+import { execa } from "execa";
 
 async function main() {
     const ROOT = process.cwd();
@@ -46,6 +47,15 @@ async function main() {
         (m) => m.type === "model" && !(pivots as string[]).includes(m.name)
     ))
         renderModel(m as any, relations as any);
+
+    await execa(
+        "yarn",
+        ["prettier", "--write", GEN.out.models, GEN.out.customTypes, GEN.out.relations],
+        {
+            cwd: ROOT,
+            stdio: "inherit",
+        }
+    );
 
     console.log("✅ Generation done.");
 }

--- a/scripts/generator/render/renderModelForm.ts
+++ b/scripts/generator/render/renderModelForm.ts
@@ -23,32 +23,33 @@ export function renderModelForm(m: ModelMeta, relations: RelationsMap) {
         .join("\n");
 
     const initLines: string[] = [];
-    if (GEN.rules.includeIdInForm) initLines.push(`  id: "",`);
+    if (GEN.rules.includeIdInForm) initLines.push(`    id: "",`);
     for (const f of simple) {
         const name = (f as any).name;
         const kind = (f as any).kind;
         if (name === "id" && GEN.rules.includeIdInForm) continue;
-        if (kind === "string" || kind === "id" || kind === "enum") initLines.push(`  ${name}: "",`);
-        else if (kind === "number") initLines.push(`  ${name}: 0,`);
-        else if (kind === "boolean") initLines.push(`  ${name}: false,`);
+        if (kind === "string" || kind === "id" || kind === "enum")
+            initLines.push(`    ${name}: "",`);
+        else if (kind === "number") initLines.push(`    ${name}: 0,`);
+        else if (kind === "boolean") initLines.push(`    ${name}: false,`);
     }
-    for (const cf of custom) initLines.push(`  ${cf.name}: { ...initial${cf.refType}Form },`);
-    for (const k of relKeysSingular) initLines.push(`  ${k}Ids: [] as string[],`);
+    for (const cf of custom) initLines.push(`    ${cf.name}: { ...initial${cf.refType}Form },`);
+    for (const k of relKeysSingular) initLines.push(`    ${k}Ids: [] as string[],`);
 
     const toFormLines: string[] = [];
-    if (GEN.rules.includeIdInForm) toFormLines.push(`  id: model.id ?? "",`);
+    if (GEN.rules.includeIdInForm) toFormLines.push(`        id: model.id ?? "",`);
     for (const f of simple) {
         const name = (f as any).name;
         const kind = (f as any).kind;
         if (name === "id") continue;
         if (kind === "string" || kind === "id" || kind === "enum")
-            toFormLines.push(`  ${name}: model.${name} ?? "",`);
-        else if (kind === "number") toFormLines.push(`  ${name}: model.${name} ?? 0,`);
-        else if (kind === "boolean") toFormLines.push(`  ${name}: model.${name} ?? false,`);
+            toFormLines.push(`        ${name}: model.${name} ?? "",`);
+        else if (kind === "number") toFormLines.push(`        ${name}: model.${name} ?? 0,`);
+        else if (kind === "boolean") toFormLines.push(`        ${name}: model.${name} ?? false,`);
     }
     for (const cf of custom)
-        toFormLines.push(`  ${cf.name}: to${cf.refType}Form(model.${cf.name}),`);
-    for (const k of relKeysSingular) toFormLines.push(`  ${k}Ids,`);
+        toFormLines.push(`        ${cf.name}: to${cf.refType}Form(model.${cf.name}),`);
+    for (const k of relKeysSingular) toFormLines.push(`        ${k}Ids,`);
 
     const argsTupleType = manyToMany.length
         ? `[${manyToMany.map(() => "string[]").join(", ")}]`
@@ -63,41 +64,41 @@ export function renderModelForm(m: ModelMeta, relations: RelationsMap) {
     const low = m.name[0].toLowerCase() + m.name.slice(1);
 
     const content = `// AUTO-GENERATED – DO NOT EDIT
-    import type { ${m.name}Type, ${m.name}FormType, ${m.name}TypeOmit } from "./types";
-    import { createModelForm } from "${GEN.paths.createModelForm}";
-    ${ctImports ? "\n" + ctImports : ""}
-    
-    export const initial${m.name}Form: ${m.name}FormType = {
-    ${initLines.join("\n")}
+import type { ${m.name}Type, ${m.name}FormType, ${m.name}TypeOmit } from "./types";
+import { createModelForm } from "${GEN.paths.createModelForm}";
+${ctImports ? ctImports + "\n" : ""}
+
+export const initial${m.name}Form: ${m.name}FormType = {
+${initLines.join("\n")}
+};
+
+function to${m.name}Form(model: ${m.name}Type${argsDecl}): ${m.name}FormType {
+    return {
+${toFormLines.join("\n")}
     };
-    
-    function to${m.name}Form(model: ${m.name}Type${argsDecl}): ${m.name}FormType {
-      return {
-    ${toFormLines.join("\n")}
-      };
+}
+
+function to${m.name}Input(form: ${m.name}FormType): ${m.name}TypeOmit {
+${(() => {
+    const vars: string[] = [];
+    if (GEN.rules.includeIdInForm) vars.push("id");
+    for (const k of relKeysSingular) vars.push(`${k}Ids`);
+    if (vars.length) {
+        const destruct = vars.join(", ");
+        const voidLines = vars.map((v) => `    void ${v};`).join("\n");
+        return `    const { ${destruct}, ...rest } = form;\n${voidLines}\n    return rest as ${m.name}TypeOmit;`;
     }
-    
-    function to${m.name}Input(form: ${m.name}FormType): ${m.name}TypeOmit {
-    ${(() => {
-        const vars: string[] = [];
-        if (GEN.rules.includeIdInForm) vars.push("id");
-        for (const k of relKeysSingular) vars.push(`${k}Ids`);
-        if (vars.length) {
-            const destruct = vars.join(", ");
-            const voidLines = vars.map((v) => `  void ${v};`).join("\n");
-            return `  const { ${destruct}, ...rest } = form;\n${voidLines}\n  return rest as ${m.name}TypeOmit;`;
-        }
-        return `  return form as ${m.name}TypeOmit;`;
-    })()}
-    }
-    
-    export const ${low}Form = createModelForm<${m.name}Type, ${m.name}FormType, ${argsTupleType}, ${m.name}TypeOmit>(
-      initial${m.name}Form,
-      (model${argsDecl}) => to${m.name}Form(model${argsCall}),
-      to${m.name}Input
-    );
-    
-    export { to${m.name}Form, to${m.name}Input };
-    `;
+    return `    return form as ${m.name}TypeOmit;`;
+})()}
+}
+
+export const ${low}Form = createModelForm<${m.name}Type, ${m.name}FormType, ${argsTupleType}, ${m.name}TypeOmit>(
+    initial${m.name}Form,
+    (model${argsDecl}) => to${m.name}Form(model${argsCall}),
+    to${m.name}Input,
+);
+
+export { to${m.name}Form, to${m.name}Input };
+`;
     safeWrite(path.join(dir, "form.ts"), content);
 }

--- a/scripts/generator/render/renderModelHooks.ts
+++ b/scripts/generator/render/renderModelHooks.ts
@@ -11,10 +11,49 @@ import type { ${m.name}FormType } from "./types";
 import { ${low}Config } from "./config";
 import { ${low}Service } from "./service";
 
-export const use${m.name}Manager = createEntityHooks<${m.name}FormType>({
+const use${m.name}Base = createEntityHooks<${m.name}FormType>({
     ...${low}Config,
     service: ${low}Service,
 });
+
+export const use${m.name}Manager = use${m.name}Base;
+
+export const use${m.name}Form = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = use${m.name}Base();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};
 `;
     safeWrite(path.join(dir, "hooks.ts"), content);
 }

--- a/src/entities/models/author/hooks.ts
+++ b/src/entities/models/author/hooks.ts
@@ -4,7 +4,46 @@ import type { AuthorFormType } from "./types";
 import { authorConfig } from "./config";
 import { authorService } from "./service";
 
-export const useAuthorManager = createEntityHooks<AuthorFormType>({
+const useAuthorBase = createEntityHooks<AuthorFormType>({
     ...authorConfig,
     service: authorService,
 });
+
+export const useAuthorManager = useAuthorBase;
+
+export const useAuthorForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = useAuthorBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};

--- a/src/entities/models/comment/hooks.ts
+++ b/src/entities/models/comment/hooks.ts
@@ -4,7 +4,46 @@ import type { CommentFormType } from "./types";
 import { commentConfig } from "./config";
 import { commentService } from "./service";
 
-export const useCommentManager = createEntityHooks<CommentFormType>({
+const useCommentBase = createEntityHooks<CommentFormType>({
     ...commentConfig,
     service: commentService,
 });
+
+export const useCommentManager = useCommentBase;
+
+export const useCommentForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = useCommentBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};

--- a/src/entities/models/post/hooks.ts
+++ b/src/entities/models/post/hooks.ts
@@ -4,7 +4,46 @@ import type { PostFormType } from "./types";
 import { postConfig } from "./config";
 import { postService } from "./service";
 
-export const usePostManager = createEntityHooks<PostFormType>({
+const usePostBase = createEntityHooks<PostFormType>({
     ...postConfig,
     service: postService,
 });
+
+export const usePostManager = usePostBase;
+
+export const usePostForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = usePostBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};

--- a/src/entities/models/section/hooks.ts
+++ b/src/entities/models/section/hooks.ts
@@ -4,7 +4,46 @@ import type { SectionFormType } from "./types";
 import { sectionConfig } from "./config";
 import { sectionService } from "./service";
 
-export const useSectionManager = createEntityHooks<SectionFormType>({
+const useSectionBase = createEntityHooks<SectionFormType>({
     ...sectionConfig,
     service: sectionService,
 });
+
+export const useSectionManager = useSectionBase;
+
+export const useSectionForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = useSectionBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};

--- a/src/entities/models/tag/hooks.ts
+++ b/src/entities/models/tag/hooks.ts
@@ -4,7 +4,46 @@ import type { TagFormType } from "./types";
 import { tagConfig } from "./config";
 import { tagService } from "./service";
 
-export const useTagManager = createEntityHooks<TagFormType>({
+const useTagBase = createEntityHooks<TagFormType>({
     ...tagConfig,
     service: tagService,
 });
+
+export const useTagManager = useTagBase;
+
+export const useTagForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = useTagBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};

--- a/src/entities/models/todo/hooks.ts
+++ b/src/entities/models/todo/hooks.ts
@@ -4,7 +4,46 @@ import type { TodoFormType } from "./types";
 import { todoConfig } from "./config";
 import { todoService } from "./service";
 
-export const useTodoManager = createEntityHooks<TodoFormType>({
+const useTodoBase = createEntityHooks<TodoFormType>({
     ...todoConfig,
     service: todoService,
 });
+
+export const useTodoManager = useTodoBase;
+
+export const useTodoForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = useTodoBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};

--- a/src/entities/models/userName/hooks.ts
+++ b/src/entities/models/userName/hooks.ts
@@ -4,7 +4,46 @@ import type { UserNameFormType } from "./types";
 import { userNameConfig } from "./config";
 import { userNameService } from "./service";
 
-export const useUserNameForm = createEntityHooks<UserNameFormType>({
+const useUserNameBase = createEntityHooks<UserNameFormType>({
     ...userNameConfig,
     service: userNameService,
 });
+
+export const useUserNameManager = useUserNameBase;
+
+export const useUserNameForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = useUserNameBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};

--- a/src/entities/models/userProfile/hooks.ts
+++ b/src/entities/models/userProfile/hooks.ts
@@ -4,7 +4,46 @@ import type { UserProfileFormType } from "./types";
 import { userProfileConfig } from "./config";
 import { userProfileService } from "./service";
 
-export const useUserProfileForm = createEntityHooks<UserProfileFormType>({
+const useUserProfileBase = createEntityHooks<UserProfileFormType>({
     ...userProfileConfig,
     service: userProfileService,
 });
+
+export const useUserProfileManager = useUserProfileBase;
+
+export const useUserProfileForm = () => {
+    const {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } = useUserProfileBase();
+    return {
+        form,
+        mode,
+        dirty,
+        reset,
+        submit,
+        refresh,
+        setForm,
+        handleChange,
+        fields,
+        labels,
+        saveField,
+        clearField,
+        remove,
+        loading,
+        error,
+    } as const;
+};


### PR DESCRIPTION
## Description
- ajoute la génération d'un hook `use<Model>Form` encapsulant `createEntityHooks`
- nettoie le gabarit `form.ts` pour un code formaté
- exécute Prettier sur les fichiers générés

## Tests effectués
- `yarn gen:entities` *(échec : ERR_PACKAGE_PATH_NOT_EXPORTED)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689feb21e1d8832483590b1a79a6e06e