### PR TITLE
[Feat] Ajout de l’alias refresh pour les entités

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -17,13 +17,13 @@ const fields: (keyof UserNameFormType)[] = ["userName"];
 export default function UserNameManager() {
     const { user } = useAuthenticator();
     const manager = useUserNameForm();
+    const { refresh } = manager;
 
     useEffect(() => {
         if (user) {
-            void manager.refresh(); // 🔄 charge/rafraîchit au montage et quand l'user change
+            void refresh(); // 🔄 charge/rafraîchit au montage et quand l'user change
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [user]);
+    }, [user, refresh]);
 
     if (!user) return <Authenticator />;
 

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -13,6 +13,7 @@ import { type UserProfileMinimalType } from "@entities/models/userProfile/types"
 export default function UserProfileManager() {
     const { user } = useAuthenticator();
     const profile = useUserProfileForm();
+    const { refresh } = profile;
 
     const getIcon = (field: keyof UserProfileMinimalType) => {
         switch (field) {
@@ -54,10 +55,9 @@ export default function UserProfileManager() {
     };
     useEffect(() => {
         if (user) {
-            void profile.refresh();
+            void refresh();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [user]);
+    }, [user, refresh]);
 
     if (!user) return null;
 

--- a/src/entities/core/utils/createEntityHooks.ts
+++ b/src/entities/core/utils/createEntityHooks.ts
@@ -123,13 +123,20 @@ export function createEntityHooks<T extends Record<string, string>>(
             }
         };
 
+        /**
+         * Recharge les données depuis le service.
+         * Alias pratique de `fetchData` exposé par `useEntityManager`.
+         */
+        const refresh = manager.fetchData;
+
         return {
             form: manager.formData,
             mode,
             dirty,
             reset,
             submit: manager.save,
-            refresh: manager.fetchData,
+            refresh,
+            fetchData: manager.fetchData,
             setForm: manager.setFormData,
             handleChange: manager.handleChange,
             fields: manager.fields,


### PR DESCRIPTION
## Résumé
- expose `refresh` comme alias de `fetchData`
- utilise `refresh()` dans les gestionnaires de profil et de pseudo

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue: Property 'extras' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689fee6683248324ab9ca0439263420d