### PR TITLE
Feat: simplifier hooks d'entité

### DIFF
--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -1,7 +1,7 @@
 // AUTO-GENERATED – DO NOT EDIT
 import type { PostType, PostFormType, PostTypeOmit } from "./types";
 import { createModelForm } from "@src/entities/core";
-import { initialSeoForm, toSeoForm, toSeoInput } from "@src/entities/customTypes/seo/form";
+import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
 
 export const initialPostForm: PostFormType = {
     id: "",

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -1,7 +1,7 @@
 // AUTO-GENERATED – DO NOT EDIT
 import type { SectionType, SectionFormType, SectionTypeOmit } from "./types";
 import { createModelForm } from "@src/entities/core";
-import { initialSeoForm, toSeoForm, toSeoInput } from "@src/entities/customTypes/seo/form";
+import { initialSeoForm, toSeoForm } from "@src/entities/customTypes/seo/form";
 
 export const initialSectionForm: SectionFormType = {
     id: "",

--- a/src/entities/models/userName/hooks.ts
+++ b/src/entities/models/userName/hooks.ts
@@ -4,46 +4,7 @@ import type { UserNameFormType } from "./types";
 import { userNameConfig } from "./config";
 import { userNameService } from "./service";
 
-const useUserNameBase = createEntityHooks<UserNameFormType>({
+export const useUserNameForm = createEntityHooks<UserNameFormType>({
     ...userNameConfig,
     service: userNameService,
 });
-
-export const useUserNameManager = useUserNameBase;
-
-export const useUserNameForm = () => {
-    const {
-        form,
-        mode,
-        dirty,
-        reset,
-        submit,
-        refresh,
-        setForm,
-        handleChange,
-        fields,
-        labels,
-        saveField,
-        clearField,
-        remove,
-        loading,
-        error,
-    } = useUserNameBase();
-    return {
-        form,
-        mode,
-        dirty,
-        reset,
-        submit,
-        refresh,
-        setForm,
-        handleChange,
-        fields,
-        labels,
-        saveField,
-        clearField,
-        remove,
-        loading,
-        error,
-    } as const;
-};

--- a/src/entities/models/userProfile/hooks.ts
+++ b/src/entities/models/userProfile/hooks.ts
@@ -4,46 +4,7 @@ import type { UserProfileFormType } from "./types";
 import { userProfileConfig } from "./config";
 import { userProfileService } from "./service";
 
-const useUserProfileBase = createEntityHooks<UserProfileFormType>({
+export const useUserProfileForm = createEntityHooks<UserProfileFormType>({
     ...userProfileConfig,
     service: userProfileService,
 });
-
-export const useUserProfileManager = useUserProfileBase;
-
-export const useUserProfileForm = () => {
-    const {
-        form,
-        mode,
-        dirty,
-        reset,
-        submit,
-        refresh,
-        setForm,
-        handleChange,
-        fields,
-        labels,
-        saveField,
-        clearField,
-        remove,
-        loading,
-        error,
-    } = useUserProfileBase();
-    return {
-        form,
-        mode,
-        dirty,
-        reset,
-        submit,
-        refresh,
-        setForm,
-        handleChange,
-        fields,
-        labels,
-        saveField,
-        clearField,
-        remove,
-        loading,
-        error,
-    } as const;
-};


### PR DESCRIPTION
## Objectif
- Renommer les hooks des entités `userProfile` et `userName` pour exposer directement `useUserProfileForm` et `useUserNameForm`.
- Nettoyer les imports inutilisés pour que le lint passe.

## Tests effectués
- `yarn prettier --write src/entities/models/userProfile/hooks.ts src/entities/models/userName/hooks.ts src/entities/models/post/form.ts src/entities/models/section/form.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a05f5a1f9c832481577000447d53dc