### PR TITLE
[Feat] services typés pour Todo et Comment

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,27 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { client } from "@entities/core";
 import type { Schema } from "@/amplify/data/resource";
+import { useTodoService } from "@src/entities/models/todo";
 import "@aws-amplify/ui-react/styles.css";
 import "./../app/app.css";
 
 export default function TodosPublicPage() {
     const [todos, setTodos] = useState<Array<Schema["Todo"]["type"]>>([]);
+    const todoClient = useTodoService();
 
     useEffect(() => {
-        const sub = client.models.Todo.observeQuery({
-            authMode: "apiKey", // 👈 force l'accès public même sans connexion
-        }).subscribe({
-            next: ({ items }) => setTodos(items),
-            error: (err) => console.error("observeQuery error", err),
-        });
+        const sub = todoClient
+            .observeQuery({
+                authMode: "apiKey", // 👈 force l'accès public même sans connexion
+            })
+            .subscribe({
+                next: ({ items }) => setTodos(items),
+                error: (err) => console.error("observeQuery error", err),
+            });
 
         return () => sub.unsubscribe();
-    }, []);
+    }, [todoClient]);
 
     return (
         <main>

--- a/src/entities/core/services/relationService.ts
+++ b/src/entities/core/services/relationService.ts
@@ -1,13 +1,24 @@
 // src/entities/core/services/relationService.ts
 import { client, Schema } from "./amplifyClient";
+import type { AuthMode } from "./crudService";
+
+type AmplifyOpOptions = { authMode?: AuthMode } & Record<string, unknown>;
 
 type ModelKey = keyof typeof client.models;
 type BaseModel<K extends ModelKey> = Schema[K]["type"];
 type CreateData<K extends ModelKey> = Omit<BaseModel<K>, "id" | "createdAt" | "updatedAt">;
 interface RelationCrudModel<K extends ModelKey> {
-    create: (data: Partial<CreateData<K>>) => Promise<{ data: BaseModel<K> }>;
-    delete: (where: Partial<CreateData<K>>) => Promise<{ data: BaseModel<K> }>;
-    list: (args?: { filter?: Record<string, unknown> }) => Promise<{ data: BaseModel<K>[] }>;
+    create: (
+        data: Partial<CreateData<K>>,
+        opts?: AmplifyOpOptions
+    ) => Promise<{ data: BaseModel<K> }>;
+    delete: (
+        where: Partial<CreateData<K>>,
+        opts?: AmplifyOpOptions
+    ) => Promise<{ data: BaseModel<K> }>;
+    list: (
+        args?: { filter?: Record<string, unknown> } & AmplifyOpOptions
+    ) => Promise<{ data: BaseModel<K>[] }>;
 }
 
 function getRelationClient<K extends ModelKey>(key: K): RelationCrudModel<K> {
@@ -22,32 +33,40 @@ export function relationService<
     const model = getRelationClient(modelName);
 
     return {
-        async create(parentId: string, childId: string) {
-            await model.create({
-                [parentIdKey]: parentId,
-                [childIdKey]: childId,
-            } as Partial<CreateData<K>>);
+        async create(parentId: string, childId: string, opts?: AmplifyOpOptions) {
+            await model.create(
+                {
+                    [parentIdKey]: parentId,
+                    [childIdKey]: childId,
+                } as Partial<CreateData<K>>,
+                opts
+            );
         },
 
-        async delete(parentId: string, childId: string) {
-            await model.delete({
-                [parentIdKey]: parentId,
-                [childIdKey]: childId,
-            } as Partial<CreateData<K>>);
+        async delete(parentId: string, childId: string, opts?: AmplifyOpOptions) {
+            await model.delete(
+                {
+                    [parentIdKey]: parentId,
+                    [childIdKey]: childId,
+                } as Partial<CreateData<K>>,
+                opts
+            );
         },
-        async list(args?: { filter?: Record<string, unknown> }) {
+        async list(args?: { filter?: Record<string, unknown> } & AmplifyOpOptions) {
             return model.list(args);
         },
-        async listByParent(parentId: string) {
+        async listByParent(parentId: string, opts?: AmplifyOpOptions) {
             const { data } = await model.list({
                 filter: { [parentIdKey]: { eq: parentId } },
+                ...(opts ?? {}),
             });
             return data.map((item) => item[childIdKey]) as string[];
         },
 
-        async listByChild(childId: string) {
+        async listByChild(childId: string, opts?: AmplifyOpOptions) {
             const { data } = await model.list({
                 filter: { [childIdKey]: { eq: childId } },
+                ...(opts ?? {}),
             });
             return data.map((item) => item[parentIdKey]) as string[];
         },

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -7,3 +7,5 @@ export * from "./models/author";
 export * from "./customTypes/seo";
 export * from "./models/userName";
 export * from "./models/userProfile";
+export * from "./models/todo";
+export * from "./models/comment";

--- a/src/entities/models/comment/index.ts
+++ b/src/entities/models/comment/index.ts
@@ -1,0 +1,1 @@
+export { commentService, useCommentService } from "./service";

--- a/src/entities/models/comment/service.ts
+++ b/src/entities/models/comment/service.ts
@@ -1,0 +1,9 @@
+import { client, crudService } from "@src/entities/core";
+
+export const commentService = crudService("Comment", {
+    auth: { read: ["apiKey", "userPool"], write: "userPool" },
+});
+
+export function useCommentService() {
+    return client.models.Comment;
+}

--- a/src/entities/models/todo/index.ts
+++ b/src/entities/models/todo/index.ts
@@ -1,0 +1,1 @@
+export { todoService, useTodoService } from "./service";

--- a/src/entities/models/todo/service.ts
+++ b/src/entities/models/todo/service.ts
@@ -1,0 +1,9 @@
+import { client, crudService } from "@src/entities/core";
+
+export const todoService = crudService("Todo", {
+    auth: { read: ["apiKey", "userPool"], write: "userPool" },
+});
+
+export function useTodoService() {
+    return client.models.Todo;
+}

--- a/src/services/blogDataService.ts
+++ b/src/services/blogDataService.ts
@@ -1,16 +1,22 @@
-import { client, canAccess, type AuthRule } from "@src/entities/core";
+import { canAccess, type AuthRule } from "@src/entities/core";
+import { authorService } from "@src/entities/models/author/service";
+import { sectionService } from "@src/entities/models/section/service";
+import { postService } from "@src/entities/models/post/service";
+import { tagService } from "@src/entities/models/tag/service";
+import { postTagService } from "@src/entities/relations/postTag/service";
+import { sectionPostService } from "@src/entities/relations/sectionPost/service";
 
 import type { BlogData, Author, Post, Section } from "@src/types/blog";
 
 export async function fetchBlogData(): Promise<BlogData> {
     const [authorsRes, sectionsRes, postsRes, tagsRes, postTagsRes, sectionPostsRes] =
         await Promise.all([
-            client.models.Author.list({ authMode: "apiKey" }),
-            client.models.Section.list({ authMode: "apiKey" }),
-            client.models.Post.list({ authMode: "apiKey" }),
-            client.models.Tag.list({ authMode: "apiKey" }),
-            client.models.PostTag.list({ authMode: "apiKey" }),
-            client.models.SectionPost.list({ authMode: "apiKey" }),
+            authorService.list({ authMode: "apiKey" }),
+            sectionService.list({ authMode: "apiKey" }),
+            postService.list({ authMode: "apiKey" }),
+            tagService.list({ authMode: "apiKey" }),
+            postTagService.list({ authMode: "apiKey" }),
+            sectionPostService.list({ authMode: "apiKey" }),
         ]);
 
     const publicRule: AuthRule[] = [{ allow: "public" }];


### PR DESCRIPTION
## Résumé
- ajoute des services typés pour Todo et Comment
- remplace l'accès direct aux modèles par ces services dans les pages concernées
- centralise les requêtes du blog via des services et étend relationService pour l'authentification

## Tests
- `yarn lint`
- `tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a08dcc8734832483a19fcc9db16609