### PR TITLE
[Feat] ajoute le schéma SEO

### DIFF
--- a/src/entities/customTypes/seo/index.ts
+++ b/src/entities/customTypes/seo/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./form";
+export * from "./schema";

--- a/src/entities/customTypes/seo/schema.ts
+++ b/src/entities/customTypes/seo/schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const seoSchema = z.object({
+    title: z.string(),
+    description: z.string(),
+    image: z.string().optional(),
+});

--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -4,7 +4,7 @@ import {
     type PostFormType,
     type PostTypeUpdateInput,
 } from "@entities/models/post/types";
-import { toSeoForm, initialSeoForm } from "@entities/customTypes/seo/form";
+import { toSeoForm, initialSeoForm, seoSchema } from "@entities/customTypes/seo";
 import { createModelForm } from "@entities/core";
 
 export const {
@@ -30,7 +30,7 @@ export const {
         order: z.number(),
         videoUrl: z.string(),
         type: z.string(),
-        seo: z.any(),
+        seo: seoSchema,
         tagIds: z.array(z.string()),
         sectionIds: z.array(z.string()),
     }) as ZodType<PostFormType>,

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -4,7 +4,7 @@ import {
     type SectionFormTypes,
     type SectionTypesUpdateInput,
 } from "@entities/models/section/types";
-import { toSeoForm, initialSeoForm } from "@entities/customTypes/seo/form";
+import { toSeoForm, initialSeoForm, seoSchema } from "@entities/customTypes/seo";
 import { createModelForm } from "@entities/core";
 
 export const {
@@ -25,7 +25,7 @@ export const {
         title: z.string(),
         description: z.string(),
         order: z.number(),
-        seo: z.any(),
+        seo: seoSchema,
         postIds: z.array(z.string()),
     }) as ZodType<SectionFormTypes>,
     initialForm: {


### PR DESCRIPTION
## Description
- crée `seoSchema` et l'exporte
- remplace les `any` par `seoSchema` dans les formulaires `post` et `section`

## Tests effectués
- `yarn lint`
- `tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a08ee2515483248a663734023c2ace