### PR TITLE
[Feat] expose les types de modèles

### DIFF
--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -5,6 +5,7 @@ import {
     type PostTypeUpdateInput,
 } from "@entities/models/post/types";
 import { toSeoForm, initialSeoForm, seoSchema } from "@entities/customTypes/seo";
+import type { SeoType } from "@entities/customTypes/seo";
 import { createModelForm } from "@entities/core";
 
 export const {
@@ -58,7 +59,7 @@ export const {
         order: post.order ?? 1,
         videoUrl: post.videoUrl ?? "",
         type: post.type ?? "",
-        seo: toSeoForm(post.seo),
+        seo: toSeoForm((post.seo ?? {}) as SeoType),
         tagIds,
         sectionIds,
     }),

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -5,6 +5,7 @@ import {
     type SectionTypesUpdateInput,
 } from "@entities/models/section/types";
 import { toSeoForm, initialSeoForm, seoSchema } from "@entities/customTypes/seo";
+import type { SeoType } from "@entities/customTypes/seo";
 import { createModelForm } from "@entities/core";
 
 export const {
@@ -41,7 +42,7 @@ export const {
         title: section.title ?? "",
         description: section.description ?? "",
         order: section.order ?? 1,
-        seo: toSeoForm(section.seo),
+        seo: toSeoForm((section.seo ?? {}) as SeoType),
         postIds,
     }),
     toCreate: (form: SectionFormTypes): SectionTypesUpdateInput => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,7 @@
 
 export * from "./blog";
 export * from "./buttons";
+export * as CommentTypes from "./models/comment";
+export * as TodoTypes from "./models/todo";
+export * as UserNameTypes from "./models/userName";
+export * as UserProfileTypes from "./models/userProfile";

--- a/src/types/models/comment.ts
+++ b/src/types/models/comment.ts
@@ -1,0 +1,6 @@
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+
+export type CommentModel = BaseModel<"Comment">;
+export type CommentCreateInput = CreateOmit<"Comment">;
+export type CommentUpdateInput = UpdateInput<"Comment">;
+export type CommentFormType = ModelForm<"Comment">;

--- a/src/types/models/todo.ts
+++ b/src/types/models/todo.ts
@@ -1,0 +1,6 @@
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+
+export type TodoModel = BaseModel<"Todo">;
+export type TodoCreateInput = CreateOmit<"Todo">;
+export type TodoUpdateInput = UpdateInput<"Todo">;
+export type TodoFormType = ModelForm<"Todo">;

--- a/src/types/models/userName.ts
+++ b/src/types/models/userName.ts
@@ -1,0 +1,7 @@
+export type {
+    UserNameType as UserNameModel,
+    UserNameTypeOmit as UserNameCreateInput,
+    UserNameTypeUpdateInput as UserNameUpdateInput,
+    UserNameFormType,
+    UserNameMinimalType,
+} from "@entities/models/userName/types";

--- a/src/types/models/userProfile.ts
+++ b/src/types/models/userProfile.ts
@@ -1,0 +1,7 @@
+export type {
+    UserProfileType as UserProfileModel,
+    UserProfileTypeOmit as UserProfileCreateInput,
+    UserProfileTypeUpdateInput as UserProfileUpdateInput,
+    UserProfileFormType,
+    UserProfileMinimalType,
+} from "@entities/models/userProfile/types";


### PR DESCRIPTION
## Description
- réactive les exports de types et ajoute les modules manquants
- sécurise les formulaires Post et Section pour le champ SEO

## Tests effectués
- `yarn lint`
- `yarn tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a09660c5908324b0a803de137e3d3f