### PR TITLE
[Feat] contrôle des permissions des commentaires

### DIFF
--- a/src/hooks/useCommentPermissions.ts
+++ b/src/hooks/useCommentPermissions.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchAuthSession, getCurrentUser } from "aws-amplify/auth";
+
+export function useCommentPermissions() {
+    const [userId, setUserId] = useState<string | null>(null);
+    const [groups, setGroups] = useState<string[]>([]);
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                const { userId } = await getCurrentUser();
+                setUserId(userId);
+            } catch {
+                setUserId(null);
+            }
+            try {
+                const session = await fetchAuthSession();
+                const payload = session.tokens?.accessToken?.payload;
+                const g = payload ? (payload["cognito:groups"] as string[] | undefined) : undefined;
+                setGroups(g ?? []);
+            } catch {
+                setGroups([]);
+            }
+        })();
+    }, []);
+
+    const isAdmin = groups.includes("admin");
+    const canModifyComment = useCallback(
+        (ownerId?: string | null) => isAdmin || (!!ownerId && ownerId === userId),
+        [isAdmin, userId]
+    );
+
+    return { userId, groups, isAdmin, canModifyComment };
+}


### PR DESCRIPTION
## Description
- ajoute le hook `useCommentPermissions`
- limite l'édition et la suppression des commentaires aux admins ou auteurs

## Tests effectués
- `yarn lint`
- `yarn tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a0a29035088324afcacd432987c711