### PR TITLE
[Fix] support de l'apiKey pour observeQuery sans connexion

### DIFF
--- a/src/features/todo/CommentList.tsx
+++ b/src/features/todo/CommentList.tsx
@@ -4,8 +4,8 @@ import { CommentWithTodoId } from "@src/features/todo/useTodosWithComments";
 interface CommentListProps {
     comments: CommentWithTodoId[];
     onEditComment: (id: string, ownerId?: string) => void;
-    onDeleteComment: (id: string, ownerId?: string | group("ADMINS")) => void;
-    canModify: (ownerId?: string | group("ADMINS")) => boolean;
+    onDeleteComment: (id: string, ownerId?: string) => void;
+    canModify: (ownerId?: string) => boolean;
 }
 
 export default function CommentList({


### PR DESCRIPTION
## Résumé
- bascule vers l'authMode `apiKey` lorsqu'aucun utilisateur n'est authentifié pour `todoClient` et `commentClient`
- simplification des types dans `CommentList`

## Tests
- `yarn install`
- `yarn prettier --write src/features/todo/useTodosWithComments.ts src/features/todo/CommentList.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0b120f990832499324f42dc530940