### PR TITLE
[Feat] création pseudo à l'inscription

### DIFF
--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -3,11 +3,27 @@
 import React from "react";
 import { Authenticator } from "@aws-amplify/ui-react";
 import "@aws-amplify/ui-react/styles.css";
+import { signUp } from "aws-amplify/auth";
 import { configureI18n, formFields } from "@entities/core";
+import { userNameService } from "@src/entities/models/userName";
 
 // Configure i18n uniquement
 configureI18n();
 
 export default function Authentication() {
-    return <Authenticator formFields={formFields} />;
+    const services = {
+        async handleSignUp(formData: Parameters<typeof signUp>[0]) {
+            const result = await signUp(formData);
+            try {
+                await userNameService.create({
+                    id: result.userId,
+                    userName: formData.username,
+                });
+            } catch (err) {
+                console.error("Erreur création pseudo", err);
+            }
+            return result;
+        },
+    };
+    return <Authenticator formFields={formFields} services={services} />;
 }

--- a/src/features/todo/CommentList.tsx
+++ b/src/features/todo/CommentList.tsx
@@ -4,8 +4,8 @@ import { CommentWithTodoId } from "@src/features/todo/useTodosWithComments";
 interface CommentListProps {
     comments: CommentWithTodoId[];
     onEditComment: (id: string, ownerId?: string) => void;
-    onDeleteComment: (id: string, ownerId?: string | group("ADMINS")) => void;
-    canModify: (ownerId?: string | group("ADMINS")) => boolean;
+    onDeleteComment: (id: string, ownerId?: string) => void;
+    canModify: (ownerId?: string) => boolean;
 }
 
 export default function CommentList({

--- a/src/features/todo/useTodosWithComments.ts
+++ b/src/features/todo/useTodosWithComments.ts
@@ -3,6 +3,7 @@ import type { Schema } from "@/amplify/data/resource";
 import { getCurrentUser } from "aws-amplify/auth";
 import { useTodoService, todoService } from "@src/entities/models/todo";
 import { useCommentService, commentService } from "@src/entities/models/comment";
+import { userNameService } from "@src/entities/models/userName";
 import { useCommentPermissions } from "@src/hooks/useCommentPermissions";
 
 export type CommentWithTodoId = {
@@ -57,6 +58,11 @@ export function useTodosWithComments() {
         const content = window.prompt("Contenu du commentaire ?");
         if (!content) return;
         const { userId: userNameId } = await getCurrentUser();
+        const { data } = await userNameService.get({ id: userNameId });
+        if (!data?.userName) {
+            window.alert("Pseudo manquant");
+            return;
+        }
         await commentService.create({ content, todoId, userNameId });
     };
 


### PR DESCRIPTION
## Description
- création d'un pseudo par défaut lors de l'inscription
- vérification de l'existence du pseudo avant l'ajout de commentaire

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Can't resolve '@/amplify_outputs.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b15645a88324903455cbb7d72c0e