### PR TITLE
[Fix] remove duplicate hooks export

### DIFF
--- a/src/entities/core/index.ts
+++ b/src/entities/core/index.ts
@@ -2,5 +2,4 @@ export * from "./hooks";
 export * from "./services";
 export * from "./utils";
 export * from "./types";
-export * from "./hooks";
 export * from "./auth";


### PR DESCRIPTION
## Summary
- remove duplicate hooks export from core index

## Testing
- `yarn prettier src/entities/core/index.ts --write`
- `yarn lint` (fails: Parsing error in src/features/todo/CommentList.tsx)
- `yarn build` (fails: module not found '@/amplify_outputs.json')

------
https://chatgpt.com/codex/tasks/task_e_68a0b08ecfc8832497f53ef0fccc3091