### PR TITLE
[Fix] retirer la réexportation de fieldLabel

### DIFF
--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -135,5 +135,3 @@ export function useUserProfileForm(): UserProfileFormResult {
         error,
     };
 }
-
-export { fieldLabel };


### PR DESCRIPTION
## Objectif
- supprimer `fieldLabel` des exports du module `userProfile/hooks`

## Tests effectués
- `yarn install`
- `yarn prettier --write src/entities/models/userProfile/hooks.tsx`
- `yarn lint` *(échoue: Parsing error dans `src/features/todo/CommentList.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b0a3e1ac8324b680476d9555b962