### PR TITLE
[Feat] configure Amplify client with multi-auth

### DIFF
--- a/src/entities/core/services/amplifyClient.ts
+++ b/src/entities/core/services/amplifyClient.ts
@@ -2,9 +2,12 @@
 
 import { Amplify } from "aws-amplify";
 import { generateClient } from "aws-amplify/data";
+import { AuthModeStrategyType } from "@aws-amplify/datastore";
 import outputs from "@/amplify_outputs.json";
 import type { Schema } from "@/amplify/data/resource";
 
 Amplify.configure(outputs);
-export const client = generateClient<Schema>();
+export const client = generateClient<Schema>({
+    authModeStrategyType: AuthModeStrategyType.MULTI,
+});
 export type { Schema } from "@/amplify/data/resource";


### PR DESCRIPTION
## Summary
- allow multi auth strategy via `AuthModeStrategyType.MULTI`
- ensure `amplify_outputs.json` exposes an API key

## Testing
- `yarn install`
- `yarn prettier --write src/entities/core/services/amplifyClient.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c402ca9c83249b81a945954ed66e