### PR TITLE
[Fix] Renommer TodoPage et supprimer un fragment vide

### DIFF
--- a/app/todo/page.tsx
+++ b/app/todo/page.tsx
@@ -5,11 +5,10 @@ import CommentsPage from "./CommentsPage";
 import "@aws-amplify/ui-react/styles.css";
 import AuthProvider from "@components/Authentication/auth-provider";
 
-export default function No() {
+export default function TodoPage() {
     return (
         <AuthProvider>
             <CommentsPage />
-            <></>
         </AuthProvider>
     );
 }


### PR DESCRIPTION
## Description
- renomme la fonction exportée `No` en `TodoPage`
- supprime le fragment React vide sur la page Todo

## Tests effectués
- `yarn prettier app/todo/page.tsx --write`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a23222f6f08324b1b7aafb7ab915e6