### PR TITLE
[Fix] handle Promise.all errors in blog service

### DIFF
--- a/src/services/blogDataService.ts
+++ b/src/services/blogDataService.ts
@@ -9,101 +9,105 @@ import { sectionPostService } from "@src/entities/relations/sectionPost/service"
 import type { BlogData, Author, Post, Section } from "@src/types/blog";
 
 export async function fetchBlogData(): Promise<BlogData> {
-    const [authorsRes, sectionsRes, postsRes, tagsRes, postTagsRes, sectionPostsRes] =
-        await Promise.all([
-            authorService.list({ authMode: "apiKey" }),
-            sectionService.list({ authMode: "apiKey" }),
-            postService.list({ authMode: "apiKey" }),
-            tagService.list({ authMode: "apiKey" }),
-            postTagService.list({ authMode: "apiKey" }),
-            sectionPostService.list({ authMode: "apiKey" }),
-        ]);
+    try {
+        const [authorsRes, sectionsRes, postsRes, tagsRes, postTagsRes, sectionPostsRes] =
+            await Promise.all([
+                authorService.list({ authMode: "apiKey" }),
+                sectionService.list({ authMode: "apiKey" }),
+                postService.list({ authMode: "apiKey" }),
+                tagService.list({ authMode: "apiKey" }),
+                postTagService.list({ authMode: "apiKey" }),
+                sectionPostService.list({ authMode: "apiKey" }),
+            ]);
 
-    const publicRule: AuthRule[] = [{ allow: "public" }];
+        const publicRule: AuthRule[] = [{ allow: "public" }];
 
-    const authorData = authorsRes.data.filter((a) => canAccess(null, a, publicRule));
-    const sectionData = sectionsRes.data.filter((s) => canAccess(null, s, publicRule));
-    const postData = postsRes.data.filter((p) => canAccess(null, p, publicRule));
+        const authorData = authorsRes.data.filter((a) => canAccess(null, a, publicRule));
+        const sectionData = sectionsRes.data.filter((s) => canAccess(null, s, publicRule));
+        const postData = postsRes.data.filter((p) => canAccess(null, p, publicRule));
 
-    const tagsById: Record<string, string> = {};
-    tagsRes.data.forEach((t) => {
-        tagsById[t.id] = t.name;
-    });
+        const tagsById: Record<string, string> = {};
+        tagsRes.data.forEach((t) => {
+            tagsById[t.id] = t.name;
+        });
 
-    const posts: Post[] = postData.map((p) => ({
-        postJsonId: p.id,
-        title: p.title ?? "",
-        slug: p.slug ?? "",
-        excerpt: p.excerpt ?? "",
-        content: p.content ?? "",
-        authorJsonId: p.authorId,
-        sectionJsonIds: [],
-        relatedPostJsonIds: [],
-        videoUrl: p.videoUrl ?? null,
-        tags: [],
-        type: p.type ?? "",
-        status: p.status ?? "",
-        seo: {
-            title: p.seo?.title ?? "",
-            description: p.seo?.description ?? "",
-            image: p.seo?.image ?? null,
-        },
-        createdAt: p.createdAt ?? "",
-        updatedAt: p.updatedAt ?? "",
-    }));
+        const posts: Post[] = postData.map((p) => ({
+            postJsonId: p.id,
+            title: p.title ?? "",
+            slug: p.slug ?? "",
+            excerpt: p.excerpt ?? "",
+            content: p.content ?? "",
+            authorJsonId: p.authorId,
+            sectionJsonIds: [],
+            relatedPostJsonIds: [],
+            videoUrl: p.videoUrl ?? null,
+            tags: [],
+            type: p.type ?? "",
+            status: p.status ?? "",
+            seo: {
+                title: p.seo?.title ?? "",
+                description: p.seo?.description ?? "",
+                image: p.seo?.image ?? null,
+            },
+            createdAt: p.createdAt ?? "",
+            updatedAt: p.updatedAt ?? "",
+        }));
 
-    const postsById: Record<string, Post> = {};
-    posts.forEach((p) => {
-        postsById[p.postJsonId] = p;
-    });
+        const postsById: Record<string, Post> = {};
+        posts.forEach((p) => {
+            postsById[p.postJsonId] = p;
+        });
 
-    const sections: Section[] = sectionData.map((s) => ({
-        sectionJsonId: s.id,
-        title: s.title ?? "",
-        slug: s.slug ?? "",
-        description: s.description ?? "",
-        order: s.order ?? 0,
-        postJsonIds: [],
-        seo: s.seo
-            ? {
-                  title: s.seo.title ?? "",
-                  description: s.seo.description ?? "",
-                  image: s.seo.image || undefined,
-              }
-            : undefined,
-    }));
+        const sections: Section[] = sectionData.map((s) => ({
+            sectionJsonId: s.id,
+            title: s.title ?? "",
+            slug: s.slug ?? "",
+            description: s.description ?? "",
+            order: s.order ?? 0,
+            postJsonIds: [],
+            seo: s.seo
+                ? {
+                      title: s.seo.title ?? "",
+                      description: s.seo.description ?? "",
+                      image: s.seo.image || undefined,
+                  }
+                : undefined,
+        }));
 
-    const sectionsById: Record<string, Section> = {};
-    sections.forEach((s) => {
-        sectionsById[s.sectionJsonId] = s;
-    });
+        const sectionsById: Record<string, Section> = {};
+        sections.forEach((s) => {
+            sectionsById[s.sectionJsonId] = s;
+        });
 
-    // Map SectionPost relationships
-    sectionPostsRes.data.forEach((sp) => {
-        const post = postsById[sp.postId];
-        if (post) {
-            post.sectionJsonIds.push(sp.sectionId);
-        }
-        const section = sectionsById[sp.sectionId];
-        if (section) {
-            section.postJsonIds.push(sp.postId);
-        }
-    });
+        // Map SectionPost relationships
+        sectionPostsRes.data.forEach((sp) => {
+            const post = postsById[sp.postId];
+            if (post) {
+                post.sectionJsonIds.push(sp.sectionId);
+            }
+            const section = sectionsById[sp.sectionId];
+            if (section) {
+                section.postJsonIds.push(sp.postId);
+            }
+        });
 
-    // Map PostTag relationships
-    postTagsRes.data.forEach((pt) => {
-        const post = postsById[pt.postId];
-        const tagName = tagsById[pt.tagId];
-        if (post && tagName) {
-            post.tags.push(tagName);
-        }
-    });
+        // Map PostTag relationships
+        postTagsRes.data.forEach((pt) => {
+            const post = postsById[pt.postId];
+            const tagName = tagsById[pt.tagId];
+            if (post && tagName) {
+                post.tags.push(tagName);
+            }
+        });
 
-    const authors: Author[] = authorData.map((a) => ({
-        authorJsonId: a.id,
-        authorName: a.authorName ?? "",
-        avatar: a.avatar ?? "",
-    }));
+        const authors: Author[] = authorData.map((a) => ({
+            authorJsonId: a.id,
+            authorName: a.authorName ?? "",
+            avatar: a.avatar ?? "",
+        }));
 
-    return { sections, posts, authors };
+        return { sections, posts, authors };
+    } catch (error) {
+        throw new Error(`Failed to fetch blog data: ${(error as Error).message}`);
+    }
 }


### PR DESCRIPTION
## Summary
- wrap blog data fetching in try/catch
- propagate descriptive error when loading blog data fails

## Testing
- `yarn install`
- `yarn prettier --write src/services/blogDataService.ts`
- `yarn lint`
- `yarn build` *(fails: The "use client" directive must be placed before other expressions in MarkdownRenderer.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a2322fedb48324b30e52d8c71d9eaf