### PR TITLE
[Feat] suppression parallèle des commentaires d'un todo

### DIFF
--- a/src/components/todo/useTodosWithComments.ts
+++ b/src/components/todo/useTodosWithComments.ts
@@ -114,9 +114,9 @@ export function useTodosWithComments() {
                 filter: { todoId: { eq: id } },
             });
             if (relatedComments) {
-                for (const comment of relatedComments) {
-                    await commentService.delete({ id: comment.id });
-                }
+                await Promise.all(
+                    relatedComments.map((comment) => commentService.delete({ id: comment.id }))
+                );
             }
             await todoService.delete({ id });
         }


### PR DESCRIPTION
## Résumé
- supprime les commentaires associés en parallèle lors de la suppression d'un todo

## Tests
- `yarn lint`
- `yarn build` *(échoue : The "use client" directive must be placed before other expressions)*

------
https://chatgpt.com/codex/tasks/task_e_68a232d163fc83249fd0878aca6f72d8