### PR TITLE
[Fix] Corriger le chemin d'import de app.css

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import type { Schema } from "@/amplify/data/resource";
 import { useTodoService } from "@src/entities/models/todo";
 import "@aws-amplify/ui-react/styles.css";
-import "./../app/app.css";
+import "./app.css";
 
 export default function TodosPublicPage() {
     const [todos, setTodos] = useState<Array<Schema["Todo"]["type"]>>([]);


### PR DESCRIPTION
## Description
- ajuster le chemin d'import de `app.css` dans `app/page.tsx`

## Tests effectués
- `yarn install`
- `yarn prettier --write app/page.tsx`
- `yarn lint`
- `yarn build` *(échoue : The "use client" directive must be placed before other expressions in `src/components/Blog/MarkdownRenderer.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68a23252494c83248d31408a2604ff41