### PR TITLE
[Fix] disable unused module rule for Next.js app files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,4 +13,20 @@ module.exports = {
         "unused-imports/no-unused-vars": ["warn", { args: "none" }],
         "import/no-unused-modules": ["warn", { unusedExports: true }],
     },
+    overrides: [
+        {
+            files: [
+                "app/**/page.{ts,tsx}",
+                "app/**/layout.{ts,tsx}",
+                "app/**/template.{ts,tsx}",
+                "app/**/error.{ts,tsx}",
+                "app/**/loading.{ts,tsx}",
+                "app/**/not-found.{ts,tsx}",
+                "app/**/route.{ts,tsx}",
+            ],
+            rules: {
+                "import/no-unused-modules": "off",
+            },
+        },
+    ],
 };


### PR DESCRIPTION
## Summary
- disable `import/no-unused-modules` for Next.js app router files

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2caa4fd388324a864de088527de84