### PR TITLE
[Feat] ajoute type de création pour commentaire

### DIFF
--- a/src/components/todo/useTodosWithComments.ts
+++ b/src/components/todo/useTodosWithComments.ts
@@ -5,6 +5,7 @@ import { useTodoService, todoService } from "@src/entities/models/todo";
 import { useCommentService, commentService } from "@src/entities/models/comment";
 import { userNameService } from "@src/entities/models/userName";
 import { useCommentPermissions } from "@src/hooks/useCommentPermissions";
+import type { CommentCreateInput } from "@src/types/models/comment";
 
 export type CommentWithTodoId = {
     id: string;
@@ -91,7 +92,8 @@ export default function useTodosWithComments() {
             window.alert("Pseudo manquant");
             return;
         }
-        await commentService.create({ content, todoId, userNameId });
+        const input: CommentCreateInput = { content, todoId, userNameId };
+        await commentService.create(input);
     };
 
     const editComment = async (id: string, ownerId?: string) => {

--- a/src/types/models/comment.ts
+++ b/src/types/models/comment.ts
@@ -1,6 +1,11 @@
-import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+import type { BaseModel, UpdateInput, ModelForm } from "@entities/core";
 
 export type CommentModel = BaseModel<"Comment">;
-export type CommentCreateInput = CreateOmit<"Comment">;
+export type CommentCreateInput = {
+    content: string;
+    todoId?: string;
+    postId?: string;
+    userNameId: string;
+};
 export type CommentUpdateInput = UpdateInput<"Comment">;
 export type CommentFormType = ModelForm<"Comment">;


### PR DESCRIPTION
## Description
- ajoute un type `CommentCreateInput` explicite
- typage de l'ajout de commentaires dans le hook des todos

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a2f1549e0c8324a18dfdf029264fc9