### PR TITLE
[Feat] unifier la mise en page de l'éditeur de blog

### DIFF
--- a/src/components/Blog/manage/BlogEditorLayout.tsx
+++ b/src/components/Blog/manage/BlogEditorLayout.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface BlogEditorLayoutProps {
+    title: string;
+    children: React.ReactNode;
+}
+
+export default function BlogEditorLayout({ title, children }: BlogEditorLayoutProps) {
+    return (
+        <div className="p-6 max-w-5xl mx-auto space-y-6">
+            <h1 className="text-2xl font-bold">{title}</h1>
+            {children}
+        </div>
+    );
+}

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import RequireAdmin from "@components/RequireAdmin";
 import AuthorForm from "@components/Blog/manage/authors/AuthorForm";
 import AuthorList from "@components/Blog/manage/authors/AuthorList";
+import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import {
     type AuthorType,
     initialAuthorForm,
@@ -54,8 +55,7 @@ export default function AuthorManagerPage() {
 
     return (
         <RequireAdmin>
-            <div className="p-6 max-w-5xl mx-auto space-y-6">
-                <h1 className="text-2xl font-bold">Éditeur de blog : Auteurs</h1>
+            <BlogEditorLayout title="Éditeur de blog : Auteurs">
                 <AuthorForm ref={formRef} manager={manager} onSave={handleSave} />
                 <AuthorList
                     authors={authors}
@@ -68,7 +68,7 @@ export default function AuthorManagerPage() {
                     onCancel={handleCancel}
                     onDelete={handleDelete}
                 />
-            </div>
+            </BlogEditorLayout>
         </RequireAdmin>
     );
 }

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -5,6 +5,7 @@ import PostForm from "./PostForm";
 import { postService } from "@entities/models/post/service";
 import { type PostType } from "@entities/models/post/types";
 import RequireAdmin from "../../../RequireAdmin";
+import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 export default function PostManagerPage() {
     const [posts, setPosts] = useState<PostType[]>([]);
     const [editingPost, setEditingPost] = useState<PostType | null>(null);
@@ -46,8 +47,7 @@ export default function PostManagerPage() {
 
     return (
         <RequireAdmin>
-            <div className="p-4">
-                <h1 className="text-2xl font-bold mb-4">Gestion des Posts</h1>
+            <BlogEditorLayout title="Gestion des Posts">
                 <PostForm ref={formRef} post={editingPost} posts={posts} onSave={handleSave} />
                 <PostList
                     posts={posts}
@@ -60,7 +60,7 @@ export default function PostManagerPage() {
                     onCancel={handleCancel}
                     onDelete={handleDelete}
                 />
-            </div>
+            </BlogEditorLayout>
         </RequireAdmin>
     );
 }

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useRef } from "react";
 import RequireAdmin from "@components/RequireAdmin";
 import SectionForm from "./SectionsForm";
 import SectionList from "./SectionList";
+import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import { sectionService } from "@entities/models/section/service";
 import { type SectionTypes, initialSectionForm, useSectionForm } from "@entities/models/section";
 
@@ -50,8 +51,7 @@ export default function SectionManagerPage() {
 
     return (
         <RequireAdmin>
-            <div className="p-4">
-                <h1 className="text-2xl font-bold">Gestion des Sections</h1>
+            <BlogEditorLayout title="Gestion des Sections">
                 <SectionForm
                     ref={formRef}
                     manager={manager}
@@ -68,7 +68,7 @@ export default function SectionManagerPage() {
                     onCancel={handleCancel}
                     onDelete={handleDelete}
                 />
-            </div>
+            </BlogEditorLayout>
         </RequireAdmin>
     );
 }


### PR DESCRIPTION
## Description
- ajoute le composant `BlogEditorLayout`
- applique ce layout aux pages de création d'auteurs, de sections et de posts

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue: Type instantiation is excessively deep and possibly infinite)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ff799fb08324b9b9073a1de88c24