### PR TITLE
[Feat] harmonise les en-têtes de gestion du blog

### DIFF
--- a/src/components/Blog/manage/SectionHeader.tsx
+++ b/src/components/Blog/manage/SectionHeader.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface Props {
+    children: React.ReactNode;
+    loading?: boolean;
+    className?: string;
+}
+
+export default function SectionHeader({ children, loading = false, className = "" }: Props) {
+    return (
+        <h2 className={`text-xl font-semibold mb-4 border-b ${className}`}>
+            {children}
+            {loading && <span className=" ml-2 animate-pulse">Actualisation…</span>}
+        </h2>
+    );
+}

--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -31,7 +31,6 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
 
     return (
         <div className="mb-6">
-            <h2 className="text-xl font-semibold mb-4 mt-8 border-b">Nouvel auteur</h2>
             <form ref={ref} onSubmit={handleSubmit} className="grid gap-2">
                 <EditableField
                     name="authorName"

--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -7,7 +7,6 @@ import FormActionButtons from "@components/Blog/manage/components/FormActionButt
 interface Props {
     authors: AuthorType[];
     editingIndex: number | null;
-    loading: boolean;
     onEdit: (idx: number) => void;
     onSave: () => void;
     onCancel: () => void;
@@ -17,45 +16,37 @@ interface Props {
 export default function AuthorList({
     authors,
     editingIndex,
-    loading,
     onEdit,
     onSave,
     onCancel,
     onDelete,
 }: Props) {
     return (
-        <div className="mb-6">
-            <h2 className="text-xl font-semibold mb-4 border-b">
-                {loading && <span className=" ml-2 animate-pulse">Actualisation…</span>}
-                Liste d&apos;auteurs
-            </h2>
-
-            <ul className="mt-4 space-y-2">
-                {authors.map((author, idx) => {
-                    const active = editingIndex === idx;
-                    return (
-                        <li
-                            key={author.id}
-                            className={`flex justify-between items-center p-2 transition-colors duration-300 ${
-                                active ? "bg-yellow-100 shadow-sm " : "bg-white "
-                            }`}
-                        >
-                            <div>
-                                <strong>{author.authorName}</strong> — {author.email}
-                            </div>
-                            <FormActionButtons
-                                editingIndex={editingIndex}
-                                currentIndex={idx}
-                                onEdit={() => onEdit(idx)}
-                                onSave={onSave}
-                                onCancel={onCancel}
-                                onDelete={() => onDelete(idx)}
-                                isFormNew={false}
-                            />
-                        </li>
-                    );
-                })}
-            </ul>
-        </div>
+        <ul className="mt-4 mb-6 space-y-2">
+            {authors.map((author, idx) => {
+                const active = editingIndex === idx;
+                return (
+                    <li
+                        key={author.id}
+                        className={`flex justify-between items-center p-2 transition-colors duration-300 ${
+                            active ? "bg-yellow-100 shadow-sm " : "bg-white "
+                        }`}
+                    >
+                        <div>
+                            <strong>{author.authorName}</strong> — {author.email}
+                        </div>
+                        <FormActionButtons
+                            editingIndex={editingIndex}
+                            currentIndex={idx}
+                            onEdit={() => onEdit(idx)}
+                            onSave={onSave}
+                            onCancel={onCancel}
+                            onDelete={() => onDelete(idx)}
+                            isFormNew={false}
+                        />
+                    </li>
+                );
+            })}
+        </ul>
     );
 }

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -5,6 +5,7 @@ import RequireAdmin from "@components/RequireAdmin";
 import AuthorForm from "@components/Blog/manage/authors/AuthorForm";
 import AuthorList from "@components/Blog/manage/authors/AuthorList";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
+import SectionHeader from "@components/Blog/manage/SectionHeader";
 import {
     type AuthorType,
     initialAuthorForm,
@@ -56,11 +57,12 @@ export default function AuthorManagerPage() {
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
+                <SectionHeader className="mt-8">Nouvel auteur</SectionHeader>
                 <AuthorForm ref={formRef} manager={manager} onSave={handleSave} />
+                <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}
                     editingIndex={editingIndex}
-                    loading={loading}
                     onEdit={handleEdit}
                     onSave={() => {
                         formRef.current?.requestSubmit();

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -6,6 +6,7 @@ import { postService } from "@entities/models/post/service";
 import { type PostType } from "@entities/models/post/types";
 import RequireAdmin from "../../../RequireAdmin";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
+import SectionHeader from "@components/Blog/manage/SectionHeader";
 export default function PostManagerPage() {
     const [posts, setPosts] = useState<PostType[]>([]);
     const [editingPost, setEditingPost] = useState<PostType | null>(null);
@@ -48,7 +49,9 @@ export default function PostManagerPage() {
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Gestion des Posts">
+                <SectionHeader className="mt-8">Nouvel article</SectionHeader>
                 <PostForm ref={formRef} post={editingPost} posts={posts} onSave={handleSave} />
+                <SectionHeader>Liste des articles</SectionHeader>
                 <PostList
                     posts={posts}
                     editingIndex={editingIndex}

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -101,7 +101,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
     }
 
     return (
-        <form ref={ref} onSubmit={handleSubmit} className="mb-4 space-y-2">
+        <form ref={ref} onSubmit={handleSubmit} className="mb-6 space-y-2">
             <EditableField
                 name="title"
                 label="Titre"

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -5,6 +5,7 @@ import RequireAdmin from "@components/RequireAdmin";
 import SectionForm from "./SectionsForm";
 import SectionList from "./SectionList";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
+import SectionHeader from "@components/Blog/manage/SectionHeader";
 import { sectionService } from "@entities/models/section/service";
 import { type SectionTypes, initialSectionForm, useSectionForm } from "@entities/models/section";
 
@@ -52,12 +53,14 @@ export default function SectionManagerPage() {
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Gestion des Sections">
+                <SectionHeader className="mt-8">Nouvelle section</SectionHeader>
                 <SectionForm
                     ref={formRef}
                     manager={manager}
                     editingIndex={editingIndex}
                     onSave={handleSave}
                 />
+                <SectionHeader>Liste des sections</SectionHeader>
                 <SectionList
                     sections={sections}
                     editingIndex={editingIndex}

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -86,7 +86,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
     }
 
     return (
-        <form ref={ref} onSubmit={handleSubmit} className="space-y-2">
+        <form ref={ref} onSubmit={handleSubmit} className="space-y-2 mb-6">
             <EditableField
                 name="title"
                 label="Titre"


### PR DESCRIPTION
## Description
- ajoute un composant `SectionHeader` commun
- utilise ce composant dans les pages auteurs, sections et articles

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Blog/manage/SectionHeader.tsx src/components/Blog/manage/authors/AuthorForm.tsx src/components/Blog/manage/authors/AuthorList.tsx src/components/Blog/manage/authors/CreateAuthor.tsx src/components/Blog/manage/sections/SectionsForm.tsx src/components/Blog/manage/sections/CreateSection.tsx src/components/Blog/manage/posts/PostForm.tsx src/components/Blog/manage/posts/CreatePost.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a302cd03c08324a74122b94320d98a