### PR TITLE
[Feat] tests de formulaires pour les modèles

### DIFF
--- a/src/entities/models/author/__tests__/form.test.ts
+++ b/src/entities/models/author/__tests__/form.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { faker } from "@faker-js/faker";
+import { toAuthorForm, toAuthorCreate, toAuthorUpdate } from "@entities/models/author/form";
+import type { AuthorType, AuthorFormType } from "@entities/models/author/types";
+
+describe("toAuthorForm", () => {
+    it("convertit AuthorType en AuthorFormType", () => {
+        const author = {
+            authorName: faker.person.fullName(),
+            avatar: faker.image.avatar(),
+            bio: faker.lorem.sentence(),
+            email: faker.internet.email(),
+        } as unknown as AuthorType;
+
+        const postIds = [faker.string.uuid(), faker.string.uuid()];
+        const form = toAuthorForm(author, postIds);
+        expect(form).toEqual({
+            authorName: author.authorName,
+            avatar: author.avatar,
+            bio: author.bio,
+            email: author.email,
+            postIds,
+        });
+    });
+});
+
+describe("toAuthorCreate / toAuthorUpdate", () => {
+    it("supprime postIds", () => {
+        const form: AuthorFormType = {
+            authorName: faker.person.fullName(),
+            avatar: faker.image.avatar(),
+            bio: faker.lorem.sentence(),
+            email: faker.internet.email(),
+            postIds: [faker.string.uuid()],
+        };
+
+        const expected = {
+            authorName: form.authorName,
+            avatar: form.avatar,
+            bio: form.bio,
+            email: form.email,
+        };
+
+        expect(toAuthorCreate(form)).toEqual(expected);
+        expect(toAuthorUpdate(form)).toEqual(expected);
+    });
+});

--- a/src/entities/models/post/__tests__/form.test.ts
+++ b/src/entities/models/post/__tests__/form.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { faker } from "@faker-js/faker";
+import { toPostForm, toPostCreate, toPostUpdate } from "@entities/models/post/form";
+import type { PostType, PostFormType } from "@entities/models/post/types";
+
+describe("toPostForm", () => {
+    it("convertit PostType en PostFormType", () => {
+        const post = {
+            slug: faker.lorem.slug(),
+            title: faker.lorem.words(3),
+            excerpt: faker.lorem.sentence(),
+            content: faker.lorem.paragraph(),
+            status: "draft",
+            authorId: faker.string.uuid(),
+            order: faker.number.int(),
+            videoUrl: faker.internet.url(),
+            type: faker.lorem.word(),
+            seo: {
+                title: faker.lorem.words(2),
+                description: faker.lorem.sentence(),
+                image: faker.image.url(),
+            },
+        } as unknown as PostType;
+
+        const tagIds = [faker.string.uuid(), faker.string.uuid()];
+        const sectionIds = [faker.string.uuid()];
+
+        const form = toPostForm(post, tagIds, sectionIds);
+        expect(form).toEqual({
+            slug: post.slug,
+            title: post.title,
+            excerpt: post.excerpt,
+            content: post.content,
+            status: post.status,
+            authorId: post.authorId,
+            order: post.order,
+            videoUrl: post.videoUrl,
+            type: post.type,
+            seo: post.seo,
+            tagIds,
+            sectionIds,
+        });
+    });
+});
+
+describe("toPostCreate / toPostUpdate", () => {
+    it("supprime tagIds et sectionIds", () => {
+        const form: PostFormType = {
+            slug: faker.lorem.slug(),
+            title: faker.lorem.words(3),
+            excerpt: faker.lorem.sentence(),
+            content: faker.lorem.paragraph(),
+            status: "published",
+            authorId: faker.string.uuid(),
+            order: faker.number.int(),
+            videoUrl: faker.internet.url(),
+            type: faker.lorem.word(),
+            seo: {
+                title: faker.lorem.words(2),
+                description: faker.lorem.sentence(),
+                image: faker.image.url(),
+            },
+            tagIds: [faker.string.uuid()],
+            sectionIds: [faker.string.uuid()],
+        };
+
+        const expected = {
+            slug: form.slug,
+            title: form.title,
+            excerpt: form.excerpt,
+            content: form.content,
+            status: form.status,
+            authorId: form.authorId,
+            order: form.order,
+            videoUrl: form.videoUrl,
+            type: form.type,
+            seo: form.seo,
+        };
+
+        expect(toPostCreate(form)).toEqual(expected);
+        expect(toPostUpdate(form)).toEqual(expected);
+    });
+});

--- a/src/entities/models/section/__tests__/form.test.ts
+++ b/src/entities/models/section/__tests__/form.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { faker } from "@faker-js/faker";
+import { toSectionForm, toSectionCreate, toSectionUpdate } from "@entities/models/section/form";
+import type { SectionTypes, SectionFormTypes } from "@entities/models/section/types";
+
+describe("toSectionForm", () => {
+    it("convertit SectionTypes en SectionFormTypes", () => {
+        const section = {
+            slug: faker.lorem.slug(),
+            title: faker.lorem.words(3),
+            description: faker.lorem.sentence(),
+            order: faker.number.int(),
+            seo: {
+                title: faker.lorem.words(2),
+                description: faker.lorem.sentence(),
+                image: faker.image.url(),
+            },
+        } as unknown as SectionTypes;
+
+        const postIds = [faker.string.uuid(), faker.string.uuid()];
+        const form = toSectionForm(section, postIds);
+        expect(form).toEqual({
+            slug: section.slug,
+            title: section.title,
+            description: section.description,
+            order: section.order,
+            seo: section.seo,
+            postIds,
+        });
+    });
+});
+
+describe("toSectionCreate / toSectionUpdate", () => {
+    it("supprime postIds", () => {
+        const form: SectionFormTypes = {
+            slug: faker.lorem.slug(),
+            title: faker.lorem.words(3),
+            description: faker.lorem.sentence(),
+            order: faker.number.int(),
+            seo: {
+                title: faker.lorem.words(2),
+                description: faker.lorem.sentence(),
+                image: faker.image.url(),
+            },
+            postIds: [faker.string.uuid()],
+        };
+
+        const expected = {
+            slug: form.slug,
+            title: form.title,
+            description: form.description,
+            order: form.order,
+            seo: form.seo,
+        };
+
+        expect(toSectionCreate(form)).toEqual(expected);
+        expect(toSectionUpdate(form)).toEqual(expected);
+    });
+});

--- a/src/entities/models/tag/__tests__/form.test.ts
+++ b/src/entities/models/tag/__tests__/form.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { faker } from "@faker-js/faker";
+import { toTagForm, toTagCreate, toTagUpdate } from "@entities/models/tag/form";
+import type { TagType, TagFormType } from "@entities/models/tag/types";
+
+describe("toTagForm", () => {
+    it("convertit TagType en TagFormType", () => {
+        const tag = {
+            name: faker.word.words(1),
+        } as unknown as TagType;
+
+        const postIds = [faker.string.uuid(), faker.string.uuid()];
+        const form = toTagForm(tag, postIds);
+        expect(form).toEqual({ name: tag.name, postIds });
+    });
+});
+
+describe("toTagCreate / toTagUpdate", () => {
+    it("supprime postIds", () => {
+        const form: TagFormType = {
+            name: faker.word.words(1),
+            postIds: [faker.string.uuid()],
+        };
+
+        const expected = { name: form.name };
+        expect(toTagCreate(form)).toEqual(expected);
+        expect(toTagUpdate(form)).toEqual(expected);
+    });
+});

--- a/src/entities/models/userName/__tests__/form.test.ts
+++ b/src/entities/models/userName/__tests__/form.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { faker } from "@faker-js/faker";
+import { toUserNameForm, toUserNameCreate, toUserNameUpdate } from "@entities/models/userName/form";
+import type { UserNameType, UserNameFormType } from "@entities/models/userName/types";
+
+describe("toUserNameForm", () => {
+    it("convertit UserNameType en UserNameFormType", () => {
+        const userName = {
+            userName: faker.internet.username(),
+        } as unknown as UserNameType;
+
+        const commentsIds = [faker.string.uuid()];
+        const postCommentsIds = [faker.string.uuid()];
+        const form = toUserNameForm(userName, commentsIds, postCommentsIds);
+        expect(form).toEqual({
+            userName: userName.userName,
+            commentsIds,
+            postCommentsIds,
+        });
+    });
+});
+
+describe("toUserNameCreate / toUserNameUpdate", () => {
+    it("supprime commentsIds et postCommentsIds", () => {
+        const form: UserNameFormType = {
+            userName: faker.internet.username(),
+            commentsIds: [faker.string.uuid()],
+            postCommentsIds: [faker.string.uuid()],
+        };
+
+        const expected = { userName: form.userName };
+        expect(toUserNameCreate(form)).toEqual(expected);
+        expect(toUserNameUpdate(form)).toEqual(expected);
+    });
+});

--- a/src/entities/models/userProfile/__tests__/form.test.ts
+++ b/src/entities/models/userProfile/__tests__/form.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { faker } from "@faker-js/faker";
+import {
+    toUserProfileForm,
+    toUserProfileCreate,
+    toUserProfileUpdate,
+} from "@entities/models/userProfile/form";
+import type { UserProfileType, UserProfileFormType } from "@entities/models/userProfile/types";
+
+describe("toUserProfileForm", () => {
+    it("convertit UserProfileType en UserProfileFormType", () => {
+        const profile = {
+            firstName: faker.person.firstName(),
+            familyName: faker.person.lastName(),
+            address: faker.location.streetAddress(),
+            postalCode: faker.location.zipCode(),
+            city: faker.location.city(),
+            country: faker.location.country(),
+            phoneNumber: faker.phone.number(),
+        } as unknown as UserProfileType;
+
+        const form = toUserProfileForm(profile);
+        expect(form).toEqual({
+            firstName: profile.firstName,
+            familyName: profile.familyName,
+            address: profile.address,
+            postalCode: profile.postalCode,
+            city: profile.city,
+            country: profile.country,
+            phoneNumber: profile.phoneNumber,
+        });
+    });
+});
+
+describe("toUserProfileCreate / toUserProfileUpdate", () => {
+    it("retourne l'objet tel quel", () => {
+        const form: UserProfileFormType = {
+            firstName: faker.person.firstName(),
+            familyName: faker.person.lastName(),
+            address: faker.location.streetAddress(),
+            postalCode: faker.location.zipCode(),
+            city: faker.location.city(),
+            country: faker.location.country(),
+            phoneNumber: faker.phone.number(),
+        };
+
+        expect(toUserProfileCreate(form)).toEqual(form);
+        expect(toUserProfileUpdate(form)).toEqual(form);
+    });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,9 @@
 import "whatwg-fetch";
-import "@testing-library/jest-dom";
-import { afterAll, afterEach, beforeAll } from "vitest";
+import { afterAll, afterEach, beforeAll, expect } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
 import { setupServer } from "msw/node";
+
+expect.extend(matchers);
 
 export const server = setupServer();
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,14 @@
 // vitest.config.ts
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            "@entities": path.resolve(__dirname, "src/entities"),
+            "@": path.resolve(__dirname, "."),
+        },
+    },
     test: {
         environment: "jsdom",
         // adapte le chemin si besoin


### PR DESCRIPTION
## Description
- ajoute des tests Vitest/Faker pour les helpers de formulaire (post, tag, author, section, userName, userProfile)
- configure Vitest pour les alias TS et jest-dom

## Tests effectués
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3033cff508324b39d82bf2dfeeeba