### PR TITLE
[Fix] stabilize service types

### DIFF
--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -14,9 +14,11 @@ export default function Authentication() {
     const services = {
         async handleSignUp(formData: Parameters<typeof signUp>[0]) {
             const result = await signUp(formData);
+            const { userId } = result;
+            if (!userId) throw new Error("userId manquant");
             try {
                 await userNameService.create({
-                    id: result.userId,
+                    id: userId,
                     userName: formData.username,
                 });
             } catch (err) {

--- a/src/entities/core/services/crudService.ts
+++ b/src/entities/core/services/crudService.ts
@@ -60,10 +60,13 @@ async function tryModes<T>(
     throw lastErr;
 }
 
-export function crudService<K extends ClientModelKey>(
-    key: K,
-    opts?: { auth?: CrudAuth; rules?: AuthRule[] }
-) {
+export function crudService<
+    K extends ClientModelKey,
+    C = CreateArg<K>,
+    U = UpdateArg<K>,
+    G = GetArg<K>,
+    D = DeleteArg<K>,
+>(key: K, opts?: { auth?: CrudAuth; rules?: AuthRule[] }) {
     const model = getModelClient(key);
     const rules = opts?.rules ?? [{ allow: "public" }];
     const readModes = toArray(opts?.auth?.read);
@@ -80,10 +83,10 @@ export function crudService<K extends ClientModelKey>(
             return { data: data.filter((item) => canAccess(null, item, rules)) };
         },
 
-        async get(args: GetArg<K>) {
+        async get(args: G) {
             const res = await tryModes(readModes, (authMode) =>
                 model.get(
-                    args,
+                    args as GetArg<K>,
                     (authMode ? { authMode } : undefined) as AmplifyOpOptions | undefined
                 )
             );
@@ -91,28 +94,28 @@ export function crudService<K extends ClientModelKey>(
             return res;
         },
 
-        async create(data: CreateArg<K>) {
+        async create(data: C) {
             return tryModes(writeModes, (authMode) =>
                 model.create(
-                    data,
+                    data as CreateArg<K>,
                     (authMode ? { authMode } : undefined) as AmplifyOpOptions | undefined
                 )
             );
         },
 
-        async update(data: UpdateArg<K>) {
+        async update(data: U) {
             return tryModes(writeModes, (authMode) =>
                 model.update(
-                    data,
+                    data as UpdateArg<K>,
                     (authMode ? { authMode } : undefined) as AmplifyOpOptions | undefined
                 )
             );
         },
 
-        async delete(args: DeleteArg<K>) {
+        async delete(args: D) {
             return tryModes(writeModes, (authMode) =>
                 model.delete(
-                    args,
+                    args as DeleteArg<K>,
                     (authMode ? { authMode } : undefined) as AmplifyOpOptions | undefined
                 )
             );

--- a/src/entities/models/author/service.ts
+++ b/src/entities/models/author/service.ts
@@ -1,5 +1,12 @@
 import { crudService } from "@entities/core";
+import type { AuthorTypeOmit, AuthorTypeUpdateInput } from "@entities/models/author/types";
 
-export const authorService = crudService("Author", {
+export const authorService = crudService<
+    "Author",
+    Omit<AuthorTypeOmit, "posts">,
+    AuthorTypeUpdateInput & { id: string },
+    { id: string },
+    { id: string }
+>("Author", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });

--- a/src/entities/models/comment/service.ts
+++ b/src/entities/models/comment/service.ts
@@ -1,6 +1,13 @@
 import { client, crudService } from "@src/entities/core";
+import type { CommentCreateInput, CommentUpdateInput } from "@src/types/models/comment";
 
-export const commentService = crudService("Comment", {
+export const commentService = crudService<
+    "Comment",
+    CommentCreateInput,
+    CommentUpdateInput & { id: string },
+    { id: string },
+    { id: string }
+>("Comment", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
 

--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -1,5 +1,12 @@
 import { crudService } from "@entities/core";
+import type { PostTypeOmit, PostTypeUpdateInput } from "@entities/models/post/types";
 
-export const postService = crudService("Post", {
+export const postService = crudService<
+    "Post",
+    Omit<PostTypeOmit, "comments" | "author" | "sections" | "tags">,
+    PostTypeUpdateInput & { id: string },
+    { id: string },
+    { id: string }
+>("Post", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });

--- a/src/entities/models/todo/service.ts
+++ b/src/entities/models/todo/service.ts
@@ -1,6 +1,13 @@
 import { client, crudService } from "@src/entities/core";
+import type { TodoCreateInput, TodoUpdateInput } from "@src/types/models/todo";
 
-export const todoService = crudService("Todo", {
+export const todoService = crudService<
+    "Todo",
+    TodoCreateInput,
+    TodoUpdateInput & { id: string },
+    { id: string },
+    { id: string }
+>("Todo", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
 

--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -9,7 +9,7 @@ import {
     toUserNameCreate,
     toUserNameUpdate,
 } from "@entities/models/userName/form";
-import { type UserNameFormType } from "@entities/models/userName/types";
+import { type UserNameFormType, type UserNameTypeOmit } from "@entities/models/userName/types";
 
 export function useUserNameForm() {
     const { user } = useAuthenticator();
@@ -29,7 +29,7 @@ export function useUserNameForm() {
             const { data, errors } = await userNameService.create({
                 id: sub,
                 ...toUserNameCreate(form),
-            } as unknown as Parameters<typeof userNameService.create>[0]);
+            } as UserNameTypeOmit & { id: string });
             if (!data) throw new Error(errors?.[0]?.message ?? "Erreur création pseudo");
             return data.id;
         },
@@ -56,10 +56,13 @@ export function useUserNameForm() {
         if (!sub) return;
         try {
             setMessage(null);
-            const { errors } = await userNameService.update({ id: sub, [field]: value } as never);
+            const { errors } = await userNameService.update({
+                id: sub,
+                [field]: value as string,
+            });
             if (errors?.length) throw new Error(errors[0].message);
             // Optimiste + re-fetch pour la vérité serveur
-            setForm((f) => ({ ...f, [field]: value as never }));
+            setForm((f) => ({ ...f, [field]: value }));
             await refresh();
         } catch (err) {
             setMessage(err instanceof Error ? err.message : String(err));

--- a/src/entities/models/userName/service.ts
+++ b/src/entities/models/userName/service.ts
@@ -1,7 +1,14 @@
 // src/entities/models/userName/service.ts
 import { crudService } from "@entities/core/services/crudService";
+import type { UserNameTypeOmit, UserNameTypeUpdateInput } from "@entities/models/userName/types";
 
 // ✅ Lecture en public (API key), écritures avec User Pool
-export const userNameService = crudService("UserName", {
+export const userNameService = crudService<
+    "UserName",
+    UserNameTypeOmit & { id: string },
+    UserNameTypeUpdateInput & { id: string },
+    { id: string },
+    { id: string }
+>("UserName", {
     auth: { read: "apiKey", write: "userPool" },
 });


### PR DESCRIPTION
## Summary
- simplify CRUD service to allow custom arg types
- adjust model services and hooks to avoid deep type instantiation
- validate signup id and clean field updates

## Testing
- `yarn lint`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn tsc --noEmit`
- `NODE_OPTIONS=--max-old-space-size=12000 yarn build` *(fails: Next.js build worker exited with SIGKILL)*

------
https://chatgpt.com/codex/tasks/task_e_68a3020574a08324ad57e097ccf0df9a