### PR TITLE
[Feat] Ajoute comparateurs de tri

### DIFF
--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -2,7 +2,8 @@
 "use client";
 
 import React from "react";
-import GenericList from "../GenericList";
+import GenericList from "@components/Blog/manage/GenericList";
+import { byAlpha } from "@components/Blog/manage/sorters";
 import { type AuthorType } from "@entities/models/author";
 
 interface Props {
@@ -25,6 +26,7 @@ export default function AuthorList(props: Props) {
                     <strong>{a.authorName}</strong> — {a.email}
                 </p>
             )}
+            sortBy={byAlpha((a) => a.authorName)}
             onEdit={props.onEdit}
             onSave={props.onSave}
             onCancel={props.onCancel}

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -9,7 +9,8 @@ import EditableTextArea from "@components/forms/EditableTextArea";
 import SeoFields from "@components/forms/SeoFields";
 import OrderSelector from "@components/forms/OrderSelector";
 import SelectField from "@components/forms/SelectField";
-import EntityFormShell from "../EntityFormShell";
+import EntityFormShell from "@components/Blog/manage/EntityFormShell";
+import { byAlpha, byOptionalOrder } from "@components/Blog/manage/sorters";
 import { type SeoFormType } from "@entities/customTypes/seo/types";
 import { type PostFormType } from "@entities/models/post/types";
 import { type PostType } from "@entities/models/post";
@@ -166,7 +167,10 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 onChange={onChange}
                 options={[
                     { value: "", label: "Sélectionner un auteur" },
-                    ...authors.map((a) => ({ value: a.id, label: a.authorName })),
+                    ...authors
+                        .slice()
+                        .sort(byAlpha((a) => a.authorName))
+                        .map((a) => ({ value: a.id, label: a.authorName })),
                 ]}
             />
             <OrderSelector
@@ -179,7 +183,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 <legend className="font-semibold">Tags</legend>
                 {tags
                     .slice()
-                    .sort((a, b) => a.name.localeCompare(b.name))
+                    .sort(byAlpha((a) => a.name))
                     .map((tag) => (
                         <label key={tag.id} className="block">
                             <input
@@ -195,7 +199,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 <legend className="font-semibold">Sections</legend>
                 {sections
                     .slice()
-                    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+                    .sort(byOptionalOrder)
                     .map((section) => (
                         <label key={section.id} className="block">
                             <input

--- a/src/components/Blog/manage/sorters.ts
+++ b/src/components/Blog/manage/sorters.ts
@@ -1,3 +1,15 @@
-// src/components/common/sorters.ts
-export const byOptionalOrder = <T extends { order?: number | null }>(a: T, b: T) =>
-    (a.order ?? 0) - (b.order ?? 0);
+// src/components/Blog/manage/sorters.ts
+
+export const byOptionalOrder = <T extends { order?: number | null }>(a: T, b: T) => {
+    const ao = a.order;
+    const bo = b.order;
+    if (ao == null && bo == null) return 0;
+    if (ao == null) return 1;
+    if (bo == null) return -1;
+    return ao - bo;
+};
+
+export const byAlpha =
+    <T>(pick: (item: T) => string) =>
+    (a: T, b: T) =>
+        pick(a).localeCompare(pick(b), undefined, { sensitivity: "base" });


### PR DESCRIPTION
## Description
- implémente `byOptionalOrder` et `byAlpha`
- applique les comparateurs dans les listes d'auteurs et le formulaire d'article

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Blog/manage/sorters.ts src/components/Blog/manage/authors/AuthorList.tsx src/components/Blog/manage/posts/PostForm.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a37ed11be883248ed533c833bd2e14