### PR TITLE
[Fix] restreindre les fichiers pris en compte par Vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
     test: {
         environment: "jsdom",
         setupFiles: ["./test/setup.ts"],
-        exclude: ["e2e/**"],
-        include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+        include: ["src/**/*.test.ts", "src/**/*.test.tsx", "test/**/*.test.ts"],
+        exclude: ["**/node_modules/**", "e2e/**"],
         coverage: {
             provider: "v8",
             reporter: ["cobertura", "text-summary"],


### PR DESCRIPTION
## Description
- limite l'exécution des tests à ceux de l'application

## Tests effectués
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a38790c358832498e83c93b3429515