### PR TITLE
[Feat] ajout tests e2e authentification et sections

### DIFF
--- a/e2e/section-management.spec.ts
+++ b/e2e/section-management.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "playwright/test";
+import { sectionService } from "@entities/models/section/service";
+import { signInUser, signOutUser, requireCredentials } from "./utils/auth";
+
+test.describe("Section", () => {
+    test("création, édition, suppression", async () => {
+        requireCredentials();
+        await signInUser();
+
+        const slug = `e2e-section-${Date.now()}`;
+        const title = `E2E Section ${Date.now()}`;
+        const created = await sectionService.create({
+            slug,
+            title,
+            description: "desc",
+            order: 1,
+        });
+        expect(created.data.title).toBe(title);
+
+        const id = created.data.id;
+        const updatedTitle = `${title}-updated`;
+        const updated = await sectionService.update({ id, title: updatedTitle });
+        expect(updated.data.title).toBe(updatedTitle);
+
+        await sectionService.delete({ id });
+        await signOutUser();
+    });
+});

--- a/e2e/tag-post.spec.ts
+++ b/e2e/tag-post.spec.ts
@@ -1,44 +1,14 @@
 import { test, expect } from "playwright/test";
-import { signIn, signOut } from "@aws-amplify/auth";
 import { tagService } from "@entities/models/tag/service";
 import { postService } from "@src/entities/models/post/service";
 import { authorService } from "@entities/models/author/service";
 import { postTagService } from "@entities/relations/postTag/service";
-
-// Ces tests nécessitent des identifiants d'un utilisateur admin
-const email = process.env.E2E_USER_EMAIL;
-const password = process.env.E2E_USER_PASSWORD;
-
-const requireCredentials = () => {
-    if (!email || !password) {
-        test.skip(true, "Identifiants E2E manquants");
-    }
-};
+import { signInUser, signOutUser, requireCredentials } from "./utils/auth";
 
 test.describe("Tag & Post", () => {
-    test("connexion apiKey vs userPool", async () => {
-        // Lecture publique via apiKey
-        const resApi = await tagService.list({ authMode: "apiKey" });
-        expect(Array.isArray(resApi.data)).toBe(true);
-
-        // Création sans connexion (mode userPool) -> échec
-        await expect(tagService.create({ name: `e2e-auth-${Date.now()}` })).rejects.toThrow();
-
-        if (email && password) {
-            await signIn({ username: email, password });
-            const tagName = `e2e-auth-${Date.now()}`;
-            const created = await tagService.create({ name: tagName });
-            expect(created.data.name).toBe(tagName);
-            await tagService.delete({ id: created.data.id });
-            await signOut();
-        }
-    });
-
     test("création de tag et post puis synchronisation", async () => {
-        if (!email || !password) {
-            test.skip(true, "Identifiants E2E manquants");
-        }
-        await signIn({ username: email!, password: password! });
+        requireCredentials();
+        await signInUser();
 
         // Création du tag
         const tagName = `e2e-tag-${Date.now()}`;
@@ -74,6 +44,6 @@ test.describe("Tag & Post", () => {
         await postTagService.delete(postId, tagId);
         await postService.delete({ id: postId });
         await tagService.delete({ id: tagId });
-        await signOut();
+        await signOutUser();
     });
 });

--- a/e2e/user-login.spec.ts
+++ b/e2e/user-login.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "playwright/test";
+import { tagService } from "@entities/models/tag/service";
+import { email, password, signInUser, signOutUser } from "./utils/auth";
+
+test.describe("Authentification", () => {
+    test("apiKey vs userPool", async () => {
+        const resApi = await tagService.list({ authMode: "apiKey" });
+        expect(Array.isArray(resApi.data)).toBe(true);
+
+        await expect(tagService.create({ name: `e2e-auth-${Date.now()}` })).rejects.toThrow();
+
+        if (email && password) {
+            await signInUser();
+            const tagName = `e2e-auth-${Date.now()}`;
+            const created = await tagService.create({ name: tagName });
+            expect(created.data.name).toBe(tagName);
+            await tagService.delete({ id: created.data.id });
+            await signOutUser();
+        }
+    });
+});

--- a/e2e/utils/auth.ts
+++ b/e2e/utils/auth.ts
@@ -1,0 +1,20 @@
+import { signIn, signOut } from "@aws-amplify/auth";
+import { test } from "playwright/test";
+
+export const email = process.env.E2E_USER_EMAIL;
+export const password = process.env.E2E_USER_PASSWORD;
+
+export const requireCredentials = () => {
+    if (!email || !password) {
+        test.skip(true, "Identifiants E2E manquants");
+    }
+};
+
+export const signInUser = async () => {
+    requireCredentials();
+    await signIn({ username: email!, password: password! });
+};
+
+export const signOutUser = async () => {
+    await signOut();
+};


### PR DESCRIPTION
## Description
- factorisation des utilitaires d'authentification pour les tests e2e
- ajout des scénarios e2e : connexion utilisateur et gestion des sections
- mise à jour du test tag/post pour réutiliser les utilitaires

## Tests effectués
- `yarn prettier --write e2e`
- `yarn lint`
- `yarn e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a393d92668832485db2aa7f3cca6b8