### PR TITLE
[Feat] tests des relations postTag/sectionPost

### DIFF
--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/setup";
+import { postTagService } from "@entities/relations/postTag/service";
+
+vi.mock("@entities/core/services/amplifyClient", () => {
+    const mockModel = {
+        list: (args?: unknown, opts?: unknown) =>
+            fetch("https://api.test/postTag/list", {
+                method: "POST",
+                body: JSON.stringify({ args, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("list error")))),
+        create: (data: unknown, opts?: unknown) =>
+            fetch("https://api.test/postTag/create", {
+                method: "POST",
+                body: JSON.stringify({ data, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("create error")))),
+        delete: (where: unknown, opts?: unknown) =>
+            fetch("https://api.test/postTag/delete", {
+                method: "POST",
+                body: JSON.stringify({ where, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("delete error")))),
+    };
+    return { client: { models: { PostTag: mockModel } } };
+});
+
+describe("postTagService", () => {
+    it("listByParent retourne les IDs tag", async () => {
+        server.use(
+            http.post("https://api.test/postTag/list", async ({ request }) => {
+                const body = await request.json();
+                if (body.args?.filter?.postId?.eq === "post1") {
+                    return HttpResponse.json({
+                        data: [
+                            { postId: "post1", tagId: "tag1" },
+                            { postId: "post1", tagId: "tag2" },
+                        ],
+                    });
+                }
+                return HttpResponse.json({ data: [] });
+            })
+        );
+        await expect(postTagService.listByParent("post1")).resolves.toEqual(["tag1", "tag2"]);
+    });
+
+    it("listByChild retourne les IDs post", async () => {
+        server.use(
+            http.post("https://api.test/postTag/list", async ({ request }) => {
+                const body = await request.json();
+                if (body.args?.filter?.tagId?.eq === "tag1") {
+                    return HttpResponse.json({
+                        data: [
+                            { postId: "post1", tagId: "tag1" },
+                            { postId: "post2", tagId: "tag1" },
+                        ],
+                    });
+                }
+                return HttpResponse.json({ data: [] });
+            })
+        );
+        await expect(postTagService.listByChild("tag1")).resolves.toEqual(["post1", "post2"]);
+    });
+
+    it("create envoie les IDs corrects", async () => {
+        let received: any;
+        server.use(
+            http.post("https://api.test/postTag/create", async ({ request }) => {
+                received = await request.json();
+                return HttpResponse.json({ data: {} });
+            })
+        );
+        await expect(postTagService.create("post1", "tag3")).resolves.toBeUndefined();
+        expect(received.data).toEqual({ postId: "post1", tagId: "tag3" });
+    });
+
+    it("delete envoie les IDs corrects", async () => {
+        let received: any;
+        server.use(
+            http.post("https://api.test/postTag/delete", async ({ request }) => {
+                received = await request.json();
+                return HttpResponse.json({ data: {} });
+            })
+        );
+        await expect(postTagService.delete("post1", "tag2")).resolves.toBeUndefined();
+        expect(received.where).toEqual({ postId: "post1", tagId: "tag2" });
+    });
+
+    it("échoue avec authMode public", async () => {
+        let received: any;
+        server.use(
+            http.post("https://api.test/postTag/create", async ({ request }) => {
+                received = await request.json();
+                return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
+            })
+        );
+        await expect(
+            postTagService.create("post1", "tag1", { authMode: "public" })
+        ).rejects.toThrow();
+        expect(received.opts.authMode).toBe("public");
+    });
+
+    it("échoue avec authMode userPool", async () => {
+        let received: any;
+        server.use(
+            http.post("https://api.test/postTag/delete", async ({ request }) => {
+                received = await request.json();
+                return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
+            })
+        );
+        await expect(
+            postTagService.delete("post1", "tag2", { authMode: "userPool" })
+        ).rejects.toThrow();
+        expect(received.opts.authMode).toBe("userPool");
+    });
+});


### PR DESCRIPTION
## Description
- ajoute des tests unitaires pour postTagService et sectionPostService
- couvre listByParent, listByChild, création/suppression et échecs d'authentification

## Tests effectués
- `yarn prettier --write src/entities/relations/postTag/__tests__/service.test.ts src/entities/relations/sectionPost/__tests__/service.test.ts`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a393d78ae48324841b5651d390098e