### PR TITLE
[Feat] tests services comment et todo

### DIFF
--- a/src/entities/models/comment/__tests__/service.test.ts
+++ b/src/entities/models/comment/__tests__/service.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { commentService } from "@entities/models/comment";
+import { http, HttpResponse } from "msw";
+import { server } from "@test/setup";
+
+vi.mock("@entities/core/services/amplifyClient", () => {
+    const baseFetch = (op: string, { authMode, body }: { authMode?: string; body?: unknown }) =>
+        fetch(`http://test.local/${op}`, {
+            method: "POST",
+            headers: { "x-auth-mode": authMode ?? "" },
+            body: body ? JSON.stringify(body) : undefined,
+        }).then(async (res) => {
+            if (!res.ok) throw new Error(res.statusText);
+            return res.json();
+        });
+
+    const models = {
+        Comment: {
+            get: (args: unknown, opts?: unknown) =>
+                baseFetch("get", { ...(opts as any), body: args }),
+            create: (data: unknown, opts?: unknown) =>
+                baseFetch("create", { ...(opts as any), body: data }),
+            update: (data: unknown, opts?: unknown) =>
+                baseFetch("update", { ...(opts as any), body: data }),
+            delete: (args: unknown, opts?: unknown) =>
+                baseFetch("delete", { ...(opts as any), body: args }),
+        },
+    };
+
+    return { client: { models }, Schema: { Comment: { type: {} as any } } };
+});
+
+vi.mock("@entities/core/auth", () => ({ canAccess: () => true }));
+
+beforeEach(() => {
+    server.use(
+        http.post("http://test.local/get", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode === "apiKey") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        }),
+        http.post("http://test.local/create", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode !== "userPool") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        }),
+        http.post("http://test.local/update", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode !== "userPool") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        }),
+        http.post("http://test.local/delete", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode !== "userPool") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        })
+    );
+});
+
+describe("commentService", () => {
+    it("get utilise le fallback d'authentification", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await commentService.get({ id: "1" } as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("apiKey");
+        expect((fetchSpy.mock.calls[1][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+
+    it("create utilise userPool", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await commentService.create({} as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+
+    it("update utilise userPool", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await commentService.update({ id: "1" } as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+
+    it("delete utilise userPool", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await commentService.delete({ id: "1" } as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+});

--- a/src/entities/models/todo/__tests__/service.test.ts
+++ b/src/entities/models/todo/__tests__/service.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { todoService } from "@entities/models/todo";
+import { http, HttpResponse } from "msw";
+import { server } from "@test/setup";
+
+vi.mock("@entities/core/services/amplifyClient", () => {
+    const baseFetch = (op: string, { authMode, body }: { authMode?: string; body?: unknown }) =>
+        fetch(`http://test.local/${op}`, {
+            method: "POST",
+            headers: { "x-auth-mode": authMode ?? "" },
+            body: body ? JSON.stringify(body) : undefined,
+        }).then(async (res) => {
+            if (!res.ok) throw new Error(res.statusText);
+            return res.json();
+        });
+
+    const models = {
+        Todo: {
+            get: (args: unknown, opts?: unknown) =>
+                baseFetch("get", { ...(opts as any), body: args }),
+            create: (data: unknown, opts?: unknown) =>
+                baseFetch("create", { ...(opts as any), body: data }),
+            update: (data: unknown, opts?: unknown) =>
+                baseFetch("update", { ...(opts as any), body: data }),
+            delete: (args: unknown, opts?: unknown) =>
+                baseFetch("delete", { ...(opts as any), body: args }),
+        },
+    };
+
+    return { client: { models }, Schema: { Todo: { type: {} as any } } };
+});
+
+vi.mock("@entities/core/auth", () => ({ canAccess: () => true }));
+
+beforeEach(() => {
+    server.use(
+        http.post("http://test.local/get", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode === "apiKey") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        }),
+        http.post("http://test.local/create", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode !== "userPool") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        }),
+        http.post("http://test.local/update", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode !== "userPool") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        }),
+        http.post("http://test.local/delete", ({ request }) => {
+            const mode = request.headers.get("x-auth-mode");
+            if (mode !== "userPool") return HttpResponse.text("denied", { status: 401 });
+            return HttpResponse.json({ data: { id: 1 } });
+        })
+    );
+});
+
+describe("todoService", () => {
+    it("get utilise le fallback d'authentification", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await todoService.get({ id: "1" } as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("apiKey");
+        expect((fetchSpy.mock.calls[1][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+
+    it("create utilise userPool", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await todoService.create({} as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+
+    it("update utilise userPool", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await todoService.update({ id: "1" } as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+
+    it("delete utilise userPool", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch");
+        const res = await todoService.delete({ id: "1" } as any);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect((fetchSpy.mock.calls[0][1] as any).headers["x-auth-mode"]).toBe("userPool");
+        expect(res.data).toEqual({ id: 1 });
+        fetchSpy.mockRestore();
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     resolve: {
         alias: {
             "@": resolve(__dirname, "."),
+            "@src": resolve(__dirname, "src"),
             "@entities": resolve(__dirname, "src/entities"),
             "@test": resolve(__dirname, "test"),
         },


### PR DESCRIPTION
## Description
- ajoute des tests unitaires pour `commentService` et `todoService`
- configure l'alias `@src` pour Vitest

## Tests effectués
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a393ca439c8324810eebfa6e61b067