### PR TITLE
[Feat] expose section list utilities

### DIFF
--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -6,7 +6,6 @@ import SectionForm from "./SectionsForm";
 import SectionList from "./SectionList";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
-import { sectionService } from "@entities/models/section/service";
 import { type SectionTypes, initialSectionForm, useSectionForm } from "@entities/models/section";
 
 export default function SectionManagerPage() {
@@ -16,14 +15,15 @@ export default function SectionManagerPage() {
     const manager = useSectionForm(editingSection);
     const {
         extras: { sections },
-        fetchSections,
+        fetchList,
+        remove,
         setForm,
         setMode,
     } = manager;
 
     useEffect(() => {
-        fetchSections();
-    }, [fetchSections]);
+        fetchList();
+    }, [fetchList]);
 
     const handleEdit = (idx: number) => {
         setEditingSection(sections[idx]);
@@ -31,14 +31,11 @@ export default function SectionManagerPage() {
     };
 
     const handleDelete = async (idx: number) => {
-        if (!confirm("Supprimer cette section ?")) return;
-        const id = sections[idx].id;
-        await sectionService.delete({ id });
-        await fetchSections();
+        await remove(idx);
     };
 
     const handleSave = async () => {
-        await fetchSections();
+        await fetchList();
         setEditingSection(null);
         setEditingIndex(null);
     };

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -1,9 +1,8 @@
-// src/components/Blog/manage/SectionList.tsx
 "use client";
 
 import React from "react";
-import GenericList from "../GenericList";
-import { byOptionalOrder } from "../sorters";
+import GenericList from "@components/Blog/manage/GenericList";
+import { byOptionalOrder } from "@components/Blog/manage/sorters";
 import { type SectionTypes } from "@entities/models/section";
 
 interface Props {

--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -45,20 +45,31 @@ export function useSectionForm(section: SectionTypes | null) {
         },
     });
 
-    const { setForm, setExtras, setMode } = modelForm;
+    const { extras, setForm, setExtras, setMode } = modelForm;
 
-    const fetchSections = useCallback(async () => {
+    const fetchList = useCallback(async () => {
         const { data } = await sectionService.list();
         setExtras((e) => ({ ...e, sections: data ?? [] }));
     }, [setExtras]);
+
+    const remove = useCallback(
+        async (idx: number) => {
+            const sectionItem = extras.sections[idx];
+            if (!sectionItem) return;
+            if (!window.confirm("Supprimer cette section ?")) return;
+            await sectionService.delete({ id: sectionItem.id });
+            await fetchList();
+        },
+        [extras.sections, fetchList]
+    );
 
     useEffect(() => {
         void (async () => {
             const { data } = await postService.list();
             setExtras((e) => ({ ...e, posts: data ?? [] }));
         })();
-        void fetchSections();
-    }, [setExtras, fetchSections]);
+        void fetchList();
+    }, [setExtras, fetchList]);
 
     useEffect(() => {
         void (async () => {
@@ -73,5 +84,5 @@ export function useSectionForm(section: SectionTypes | null) {
         })();
     }, [section, setForm, setMode]);
 
-    return { ...modelForm, fetchSections };
+    return { ...modelForm, fetchList, remove };
 }


### PR DESCRIPTION
## Summary
- expose fetchList and remove in section hook
- delegate section management UI to hook functions
- ensure SectionList relies on GenericList and byOptionalOrder

## Testing
- `yarn lint`
- `npx ampx test "Submit Section"` *(fails: Warning: Detected unsettled top-level await)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a394b1a0808324b51569dc0e2951b0