### PR TITLE
[Feat] gestion des tags améliorée

### DIFF
--- a/src/components/Blog/manage/components/tag/TagManager.tsx
+++ b/src/components/Blog/manage/components/tag/TagManager.tsx
@@ -1,32 +1,27 @@
-import React from "react";
-import { AddButton, EditButton, DeleteButton, SaveButton, CancelButton } from "@components/buttons";
-import type { TagType } from "@entities/models/tag/types";
-import type { UseTagFormReturn } from "@entities/models/tag/hooks";
+"use client";
 
-interface TagCrudManagerProps {
-    tags: TagType[];
-    modelForm: UseTagFormReturn;
-    onEdit: (id: string) => void;
-    onCancel: () => void;
-    onDelete: (id: string) => void;
-    fetchAll: () => Promise<void>;
+import React from "react";
+import { AddButton } from "@components/buttons";
+import GenericList from "@components/Blog/manage/GenericList";
+import { byAlpha } from "@components/Blog/manage/sorters";
+import type { UseTagFormReturn } from "@entities/models/tag/hooks";
+import type { TagType } from "@entities/models/tag/types";
+
+interface Props {
+    manager: UseTagFormReturn;
 }
 
-export default function TagCrudManager({
-    tags,
-    modelForm,
-    onEdit,
-    onCancel,
-    onDelete,
-    fetchAll,
-}: TagCrudManagerProps): React.ReactElement {
-    const { form, mode, setForm, submit } = modelForm;
-
-    async function handleSubmit(): Promise<void> {
-        await submit();
-        await fetchAll();
-        onCancel();
-    }
+export default function TagManager({ manager }: Props) {
+    const {
+        form,
+        setForm,
+        mode,
+        extras: { tags, index },
+        save,
+        edit,
+        cancel,
+        remove,
+    } = manager;
 
     return (
         <fieldset className="border p-4 rounded-md mt-4">
@@ -43,28 +38,21 @@ export default function TagCrudManager({
                     placeholder="Nom du tag"
                     className="border rounded p-2 flex-1 bg-white"
                 />
-
-                {mode === "create" ? (
-                    <AddButton label="Ajouter" onClick={handleSubmit} />
-                ) : (
-                    <>
-                        <SaveButton label="Enregistrer" onClick={handleSubmit} />
-                        <CancelButton label="Annuler" onClick={onCancel} />
-                    </>
-                )}
+                {mode === "create" && <AddButton label="Ajouter" onClick={save} />}
             </div>
-            <ul className="flex flex-wrap gap-2 mt-2">
-                {tags.map((tag) => (
-                    <li
-                        key={tag.id}
-                        className="flex gap-2 items-center px-4 py-1 bg-blue-50 border border-blue-100 rounded-lg"
-                    >
-                        <span className="font-semibold text-blue-700 px-2">{tag.name}</span>
-                        <EditButton label="" onClick={() => onEdit(tag.id)} color="#1976d2" />
-                        <DeleteButton label="" onClick={() => onDelete(tag.id)} />
-                    </li>
-                ))}
-            </ul>
+            <GenericList<TagType>
+                items={tags}
+                editingIndex={index}
+                getKey={(t) => t.id}
+                renderContent={(t) => (
+                    <span className="font-semibold text-blue-700 px-2">{t.name}</span>
+                )}
+                sortBy={byAlpha((t) => t.name)}
+                onEdit={edit}
+                onSave={save}
+                onCancel={cancel}
+                onDelete={remove}
+            />
         </fieldset>
     );
 }

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -1,25 +1,22 @@
 "use client";
 import React from "react";
-import RequireAdmin from "../../../RequireAdmin";
+import RequireAdmin from "@components/RequireAdmin";
 import { RefreshButton } from "@components/buttons";
 
-import TagCrudManager from "../components/tag/TagManager";
-import PostTagsManager from "../components/tag/PostTagsManager";
+import TagManager from "@components/Blog/manage/components/tag/TagManager";
+import PostTagsManager from "@components/Blog/manage/components/tag/PostTagsManager";
 import { useTagForm } from "@entities/models/tag/hooks";
 
 export default function PostsTagsManagerPage() {
-    const tagForm = useTagForm();
+    const manager = useTagForm();
     const {
         extras: { tags, posts },
         loading,
-        edit,
-        cancel,
-        remove,
         toggle,
         tagsForPost,
         isTagLinked,
         fetchAll,
-    } = tagForm;
+    } = manager;
 
     return (
         <RequireAdmin>
@@ -28,20 +25,7 @@ export default function PostsTagsManagerPage() {
                     <h1 className="text-2xl font-bold flex-1">Gestion des tags par article</h1>
                     <RefreshButton onClick={fetchAll} label="Rafraîchir" />
                 </div>
-                <TagCrudManager
-                    tags={tags}
-                    modelForm={tagForm}
-                    fetchAll={fetchAll}
-                    onEdit={(id: string) => {
-                        const idx = tags.findIndex((t) => t.id === id);
-                        if (idx !== -1) void edit(idx);
-                    }}
-                    onCancel={cancel}
-                    onDelete={(id: string) => {
-                        const idx = tags.findIndex((t) => t.id === id);
-                        if (idx !== -1) void remove(idx);
-                    }}
-                />
+                <TagManager manager={manager} />
                 <PostTagsManager
                     posts={posts}
                     tags={tags}

--- a/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TagType } from "@entities/models/tag/types";
+import type { PostType } from "@entities/models/post/types";
+
+vi.mock("@entities/models/tag/service", () => ({
+    tagService: {
+        list: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+vi.mock("@entities/models/post/service", () => ({
+    postService: {
+        list: vi.fn(),
+    },
+}));
+
+vi.mock("@entities/relations/postTag/service", () => ({
+    postTagService: {
+        list: vi.fn(),
+        listByChild: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+import { tagService } from "@entities/models/tag/service";
+import { postService } from "@entities/models/post/service";
+import { postTagService } from "@entities/relations/postTag/service";
+import { useTagForm } from "@entities/models/tag/hooks";
+
+const tags: TagType[] = [
+    { id: "t1", name: "Tag1" } as TagType,
+    { id: "t2", name: "Tag2" } as TagType,
+];
+const posts: PostType[] = [{ id: "p1", title: "Post1" } as PostType];
+const postTags = [{ postId: "p1", tagId: "t1" }];
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    (tagService.list as ReturnType<typeof vi.fn>).mockResolvedValue({ data: tags });
+    (postService.list as ReturnType<typeof vi.fn>).mockResolvedValue({ data: posts });
+    (postTagService.list as ReturnType<typeof vi.fn>).mockResolvedValue({ data: postTags });
+});
+
+describe("useTagForm", () => {
+    it("fetchAll charge tags, posts et liaisons", async () => {
+        const { result } = renderHook(() => useTagForm());
+        await act(async () => {
+            await result.current.fetchAll();
+        });
+        expect(result.current.extras.tags).toEqual(tags);
+        expect(result.current.extras.posts).toEqual(posts);
+        expect(result.current.extras.postTags).toEqual(postTags);
+    });
+
+    it("toggle ajoute puis retire une liaison", async () => {
+        const createMock = postTagService.create as ReturnType<typeof vi.fn>;
+        const deleteMock = postTagService.delete as ReturnType<typeof vi.fn>;
+        createMock.mockResolvedValue({});
+        deleteMock.mockResolvedValue({});
+        const { result } = renderHook(() => useTagForm());
+        await act(async () => {
+            await result.current.fetchAll();
+        });
+        await act(async () => {
+            await result.current.toggle("p1", "t2");
+        });
+        expect(createMock).toHaveBeenCalledWith("p1", "t2");
+        expect(result.current.extras.postTags).toContainEqual({ postId: "p1", tagId: "t2" });
+        await act(async () => {
+            await result.current.toggle("p1", "t2");
+        });
+        expect(deleteMock).toHaveBeenCalledWith("p1", "t2");
+        expect(result.current.extras.postTags).not.toContainEqual({ postId: "p1", tagId: "t2" });
+    });
+});

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -13,13 +13,13 @@ import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
 type PostTagLink = { postId: string; tagId: string };
 
 interface Extras extends Record<string, unknown> {
-    index?: string; // purement UI, optionnel
+    index: number | null; // purement UI, optionnel
     tags: TagType[];
     posts: PostType[];
     postTags: PostTagLink[]; // ⚠️ paires d'IDs uniquement côté UI
 }
 
-const initialExtras: Extras = { index: "", tags: [], posts: [], postTags: [] };
+const initialExtras: Extras = { index: null, tags: [], posts: [], postTags: [] };
 
 export function useTagForm() {
     const currentId = useRef<string | null>(null);
@@ -90,15 +90,17 @@ export function useTagForm() {
             currentId.current = tag.id;
             setForm(toTagForm(tag, postIds));
             setMode("edit");
+            setExtras((prev) => ({ ...prev, index: idx }));
         },
-        [extras.tags, setForm, setMode]
+        [extras.tags, setForm, setMode, setExtras]
     );
 
     const cancel = useCallback(() => {
         currentId.current = null;
         setForm(initialTagForm);
         setMode("create");
-    }, [setForm, setMode]);
+        setExtras((prev) => ({ ...prev, index: null }));
+    }, [setForm, setMode, setExtras]);
 
     const remove = useCallback(
         async (idx: number) => {


### PR DESCRIPTION
## Résumé
- enrichit useTagForm avec index courant et actions CRUD
- refactorise TagManager avec GenericList et tri alpha
- normalise les imports de CreateTag et ajoute des tests de liaison Post↔Tag

## Tests
- `yarn lint`
- `yarn test`
- `yarn build` *(échoue: File '@testing-library/jest-dom/types/index.d.ts' is not a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a397fa820c832499d21d308f6d7a2a