### PR TITLE
[Fix] corrige les dépendances des useEffect

### DIFF
--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -13,6 +13,7 @@ import { type UserProfileMinimalType } from "@entities/models/userProfile/types"
 export default function UserProfileManager() {
     const { user } = useAuthenticator();
     const profile = useUserProfileForm();
+    const { fetchProfile } = profile;
 
     const getIcon = (field: keyof UserProfileMinimalType) => {
         switch (field) {
@@ -54,10 +55,9 @@ export default function UserProfileManager() {
     };
     useEffect(() => {
         if (user) {
-            void profile.fetchProfile();
+            void fetchProfile();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [user]);
+    }, [user, fetchProfile]);
 
     if (!user) return null;
 

--- a/src/components/todo/useTodosWithComments.ts
+++ b/src/components/todo/useTodosWithComments.ts
@@ -76,7 +76,7 @@ export default function useTodosWithComments() {
             todoSub?.unsubscribe();
             commentSub?.unsubscribe();
         };
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [todoClient, commentClient]);
 
     const createTodo = () => {
         const content = window.prompt("Contenu du Todo ?");

--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -167,14 +167,12 @@ export default function useModelForm<
     // auto-load au mount
     useEffect(() => {
         if (autoLoad && load) void refresh();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [autoLoad, load]);
+    }, [autoLoad, load, refresh]);
 
     // auto-loadExtras au mount
     useEffect(() => {
         if (autoLoadExtras && loadExtras) void refreshExtras();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [autoLoadExtras, loadExtras]);
+    }, [autoLoadExtras, loadExtras, refreshExtras]);
 
     const setCreate = useCallback(
         (next?: F) => {


### PR DESCRIPTION
## Description
- ajuste les tableaux de dépendances pour supprimer les commentaires `eslint-disable`

## Tests effectués
- `yarn prettier --write src/components/Profile/UserProfileManager.tsx src/components/todo/useTodosWithComments.ts src/entities/core/hooks/useModelForm.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd9b63548324a696ee831e355d68