### PR TITLE
[Fix] Typage des variables d'environnement Amplify

### DIFF
--- a/amplify/env.d.ts
+++ b/amplify/env.d.ts
@@ -1,4 +1,3 @@
 declare module "$amplify/env/delete-todo" {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export const env: Record<string, any>;
+    export const env: Record<string, string>;
 }


### PR DESCRIPTION
## Résumé
- préciser que `env` utilise un `Record<string, string>`
- retirer le commentaire `eslint-disable`

## Tests
- `yarn prettier --write amplify/env.d.ts`
- `CI=1 NEXT_TELEMETRY_DISABLED=1 yarn lint`
- `CI=1 yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd74c69c8324bbdfb305effa0f28