### PR TITLE
[Fix] make EntityFormShell generic

### DIFF
--- a/src/components/Blog/manage/EntityFormShell.tsx
+++ b/src/components/Blog/manage/EntityFormShell.tsx
@@ -22,7 +22,7 @@ interface Props<F> {
     className?: string;
 }
 
-const EntityFormShell = forwardRef<HTMLFormElement, Props<any>>(function EntityFormShell(
+const EntityFormShell = <F,>(
     {
         manager,
         initialForm,
@@ -30,9 +30,9 @@ const EntityFormShell = forwardRef<HTMLFormElement, Props<any>>(function EntityF
         children,
         className,
         submitLabel = { create: "Créer", edit: "Mettre à jour" },
-    },
-    ref
-) {
+    }: Props<F>,
+    ref: React.ForwardedRef<HTMLFormElement>
+) => {
     const { submit, setForm, setMode, mode, saving, message } = manager;
 
     async function handleSubmit(e: FormEvent<HTMLFormElement>) {
@@ -66,6 +66,6 @@ const EntityFormShell = forwardRef<HTMLFormElement, Props<any>>(function EntityF
             )}
         </div>
     );
-});
+};
 
-export default EntityFormShell;
+export default forwardRef(EntityFormShell);


### PR DESCRIPTION
## Summary
- declare `EntityFormShell` as a generic component with forwarded ref

## Testing
- `yarn prettier --write src/components/Blog/manage/EntityFormShell.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd6b511083248a118e0acd6837bb