### PR TITLE
[Fix] sécurise OperationArg

### DIFF
--- a/src/components/Blog/manage/GenericList.tsx
+++ b/src/components/Blog/manage/GenericList.tsx
@@ -27,7 +27,7 @@ export interface GenericListProps<T> {
 
     /** Style */
     className?: string;
-    className?: string;
+    itemWrapperClassName?: string;
     itemClassName?: (active: boolean) => string;
     /** Arrondis/ombres cohérents */
     rounded?: boolean;
@@ -44,7 +44,7 @@ export default function GenericList<T>({
     onCancel,
     onDelete,
     className,
-    classNameD,
+    itemWrapperClassName,
     itemClassName,
     rounded = true,
 }: GenericListProps<T>) {
@@ -66,7 +66,7 @@ export default function GenericList<T>({
                 return (
                     <li
                         key={String(getKey(item, originalIdx))}
-                        className={`${liClass} ${classNameD}`}
+                        className={`${liClass} ${itemWrapperClassName ?? ""}`}
                     >
                         <div className="self-center">{renderContent(item, originalIdx)}</div>
                         <FormActionButtons

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -155,7 +155,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
             />
             <OrderSelector
                 sections={posts}
-                currentIndex={posts.findIndex((p) => p.id === form.id)}
+                currentIndex={-1}
                 value={form.order ?? 1}
                 onReorder={(_, newOrder) => handleChange("order", newOrder)}
             />

--- a/src/entities/core/services/crudService.ts
+++ b/src/entities/core/services/crudService.ts
@@ -9,7 +9,7 @@ type ClientModelKey = keyof ClientModels;
 
 type BaseModel<K extends ClientModelKey> = Schema[K]["type"];
 type OperationArg<T, M extends PropertyKey> =
-    T extends Record<M, (arg: infer A, ...rest: any[]) => any> ? A : never;
+    T extends Record<M, (arg: infer A, ...rest: unknown[]) => unknown> ? A : never;
 
 type CreateArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "create">;
 type UpdateArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "update">;


### PR DESCRIPTION
## Summary
- sécurise OperationArg en utilisant `unknown`
- corrige GenericList en renommant la seconde prop `className` en `itemWrapperClassName`
- évite l'utilisation d'un id inexistant dans PostForm

## Testing
- `yarn lint`
- `yarn build` *(échoué : Argument of type '{ order?: Nullable<number> | undefined; title: string; description?: Nullable<string> | undefined; slug: string; seo: SeoTypeOmit; }' is not assignable to parameter of type 'never'.)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd6cf9b483249b35d5646eb06db9