### PR TITLE
[Fix] declare global expect in vitest setup

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,8 +1,11 @@
 import { expect, beforeAll, afterEach, afterAll } from "vitest";
 import { setupServer } from "msw/node";
 import "whatwg-fetch";
+declare global {
+    var expect: (typeof import("vitest"))["expect"];
+}
 
-(globalThis as any).expect = expect;
+globalThis.expect = expect;
 await import("@testing-library/jest-dom");
 
 export const server = setupServer();


### PR DESCRIPTION
## Résumé
- déclare la variable globale `expect` pour Vitest
- évite le cast `any` lors de l'assignation à `globalThis`

## Tests effectués
- `yarn install`
- `yarn prettier --write test/setup.ts`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c89822fc8324bbbbc5f66cb04ffc