### PR TITLE
[Feat] typage du gestionnaire de tags

### DIFF
--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -11,11 +11,11 @@ import TagForm from "@components/Blog/manage/tags/TagForm";
 import TagList from "@components/Blog/manage/tags/TagList";
 import PostTagsRelationManager from "@components/Blog/manage/tags/PostTagsRelationManager";
 
-import { useTagForm } from "@entities/models/tag/hooks";
+import { useTagForm, type UseTagFormReturn } from "@entities/models/tag/hooks";
 
 export default function CreateTagPage() {
     const formRef = useRef<HTMLFormElement>(null);
-    const manager = useTagForm();
+    const manager: UseTagFormReturn = useTagForm();
 
     const {
         extras: { tags, posts, index },
@@ -27,7 +27,7 @@ export default function CreateTagPage() {
         tagsForPost,
         isTagLinked,
         toggle,
-    } = manager as any;
+    } = manager;
 
     useEffect(() => {
         void fetchAll?.();


### PR DESCRIPTION
## Description
- typage du gestionnaire de tags dans la page de création

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Blog/manage/tags/CreateTag.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3c89740c4832499bb277de09225b5