### PR TITLE
[Fix] conserve le type générique d’EntityFormShell

### DIFF
--- a/src/components/Blog/manage/EntityFormShell.tsx
+++ b/src/components/Blog/manage/EntityFormShell.tsx
@@ -1,7 +1,8 @@
 // src/components/blog/manage/EntityFormShell.tsx
 "use client";
 
-import React, { forwardRef, type FormEvent } from "react";
+import React, { forwardRef, type FormEvent, type Ref } from "react";
+import type { JSX } from "react";
 
 export interface EntityFormManager<F> {
     form: F;
@@ -22,7 +23,7 @@ interface Props<F> {
     className?: string;
 }
 
-const EntityFormShell = <F,>(
+const EntityFormShellInner = <F,>(
     {
         manager,
         initialForm,
@@ -68,4 +69,6 @@ const EntityFormShell = <F,>(
     );
 };
 
-export default forwardRef(EntityFormShell);
+export default forwardRef(EntityFormShellInner) as <F>(
+    props: Props<F> & { ref?: Ref<HTMLFormElement> }
+) => JSX.Element;

--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -3,7 +3,7 @@
 import React, { forwardRef, type ChangeEvent } from "react";
 import EditableField from "@components/forms/EditableField";
 import EditableTextArea from "@components/forms/EditableTextArea";
-import EntityFormShell from "../EntityFormShell";
+import EntityFormShell from "@components/Blog/manage/EntityFormShell";
 import { type AuthorFormType, initialAuthorForm, useAuthorForm } from "@entities/models/author";
 
 interface Props {


### PR DESCRIPTION
## Description
- conserve le paramètre générique `F` dans `EntityFormShell` via une fonction interne et un `forwardRef` typé
- ajuste `AuthorForm` pour utiliser `EntityFormShell` générique

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Type error in src/components/todo/useTodosWithComments.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68a3caef8cf48324b6e7c71088a07994