### PR TITLE
[Fix] centraliser les tris de listes

### DIFF
--- a/src/components/Blog/Blog.tsx
+++ b/src/components/Blog/Blog.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Section, Post, Author } from "@src/types/blog";
 import BlogSectionCard from "./BlogSectionCard";
 import PostContent from "./PostContent";
+import { byOptionalOrder } from "@components/Blog/manage/sorters";
 
 type BlogProps = {
     data: {
@@ -33,7 +34,8 @@ const Blog: React.FC<BlogProps> = ({ data, singlePost, noWrapper }) => {
         <>
             <h1 className="text-4xl font-bold mb-8">Blog</h1>
             {sections
-                .sort((a, b) => a.order - b.order)
+                .slice()
+                .sort(byOptionalOrder)
                 .map((section) => {
                     const postsInSection = publishedPosts.filter((p) =>
                         p.sectionJsonIds.includes(section.sectionJsonId)

--- a/src/components/Blog/manage/GenericList.tsx
+++ b/src/components/Blog/manage/GenericList.tsx
@@ -50,7 +50,7 @@ export default function GenericList<T>({
 }: GenericListProps<T>) {
     const sorted = useMemo(() => {
         const indexed = items.map((item, idx) => ({ item, idx }));
-        return sortBy ? indexed.sort((a, b) => sortBy(a.item, b.item)) : indexed;
+        return sortBy ? indexed.slice().sort((a, b) => sortBy(a.item, b.item)) : indexed;
     }, [items, sortBy]);
 
     return (

--- a/src/components/forms/ItemSelector.tsx
+++ b/src/components/forms/ItemSelector.tsx
@@ -1,3 +1,5 @@
+import { byOptionalOrder } from "@components/Blog/manage/sorters";
+
 interface ItemSelectorProps<
     T extends Record<K, string> & { order?: number | null },
     K extends keyof T,
@@ -23,7 +25,7 @@ export default function ItemSelector<
     };
 
     // On trie par order si présent, sinon on garde l'ordre initial
-    const sortedItems = [...items].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    const sortedItems = items.slice().sort(byOptionalOrder);
 
     return (
         <div className="mb-4">


### PR DESCRIPTION
## Summary
- utilise `byOptionalOrder` pour trier les sections du blog
- applique les comparateurs de `sorters.ts` dans `ItemSelector`
- protège l'immuabilité des listes génériques

## Testing
- `yarn install`
- `yarn prettier --write src/components/Blog/Blog.tsx src/components/forms/ItemSelector.tsx src/components/Blog/manage/GenericList.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3cf95c81c83248c6e5620ba99b1db