### PR TITLE
[Feat] édition par identifiant

### DIFF
--- a/src/components/Blog/manage/GenericList.tsx
+++ b/src/components/Blog/manage/GenericList.tsx
@@ -6,9 +6,9 @@ import FormActionButtons from "./components/FormActionButtons";
 
 type IdLike = string | number;
 
-export interface GenericListProps<T> {
+interface GenericListProps<T> {
     items: T[];
-    editingIndex: number | null;
+    editingId: IdLike | null;
 
     /** Unique key pour chaque item */
     getKey: (item: T, index: number) => IdLike;
@@ -20,10 +20,10 @@ export interface GenericListProps<T> {
     sortBy?: (a: T, b: T) => number;
 
     /** Actions */
-    onEdit: (idx: number) => void;
+    onEdit: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
-    onDelete: (idx: number) => void;
+    onDelete: (id: IdLike) => void;
 
     /** Style */
     className?: string;
@@ -35,7 +35,7 @@ export interface GenericListProps<T> {
 
 export default function GenericList<T>({
     items,
-    editingIndex,
+    editingId,
     getKey,
     renderContent,
     sortBy,
@@ -56,7 +56,8 @@ export default function GenericList<T>({
     return (
         <ul className={`mt-4 mb-6 space-y-2 ${className ?? ""}`}>
             {sorted.map(({ item, idx: originalIdx }) => {
-                const active = editingIndex === originalIdx;
+                const id = getKey(item, originalIdx);
+                const active = editingId === id;
                 const base =
                     "flex justify-between items-center p-4 gap-4 transition-colors duration-300";
                 const activeCls = active ? "bg-yellow-100 shadow-sm" : "bg-white";
@@ -64,18 +65,15 @@ export default function GenericList<T>({
                 const liClass = itemClassName?.(active) ?? `${base} ${activeCls} ${radius}`;
 
                 return (
-                    <li
-                        key={String(getKey(item, originalIdx))}
-                        className={`${liClass} ${itemWrapperClassName ?? ""}`}
-                    >
+                    <li key={String(id)} className={`${liClass} ${itemWrapperClassName ?? ""}`}>
                         <div className="self-center">{renderContent(item, originalIdx)}</div>
                         <FormActionButtons
-                            editingIndex={editingIndex}
-                            currentIndex={originalIdx}
-                            onEdit={() => onEdit(originalIdx)}
+                            editingId={editingId}
+                            currentId={id}
+                            onEdit={() => onEdit(id)}
                             onSave={onSave}
                             onCancel={onCancel}
-                            onDelete={() => onDelete(originalIdx)}
+                            onDelete={() => onDelete(id)}
                             isFormNew={false}
                         />
                     </li>

--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -6,20 +6,22 @@ import GenericList from "@components/Blog/manage/GenericList";
 import { byAlpha } from "@components/Blog/manage/sorters";
 import { type AuthorType } from "@entities/models/author";
 
+type IdLike = string | number;
+
 interface Props {
     authors: AuthorType[];
-    editingIndex: number | null;
-    onEdit: (idx: number) => void;
+    editingId: IdLike | null;
+    onEditById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
-    onDelete: (idx: number) => void;
+    onDeleteById: (id: IdLike) => void;
 }
 
 export default function AuthorList(props: Props) {
     return (
         <GenericList<AuthorType>
             items={props.authors}
-            editingIndex={props.editingIndex}
+            editingId={props.editingId}
             getKey={(a) => a.id}
             renderContent={(a) => (
                 <p className="self-center">
@@ -27,10 +29,10 @@ export default function AuthorList(props: Props) {
                 </p>
             )}
             sortBy={byAlpha((a) => a.authorName)}
-            onEdit={props.onEdit}
+            onEdit={props.onEditById}
             onSave={props.onSave}
             onCancel={props.onCancel}
-            onDelete={props.onDelete}
+            onDelete={props.onDeleteById}
         />
     );
 }

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -15,7 +15,7 @@ import {
 
 export default function AuthorManagerPage() {
     const [editingAuthor, setEditingAuthor] = useState<AuthorType | null>(null);
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const [editingId, setEditingId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
     const manager = useAuthorForm(editingAuthor);
     const {
@@ -29,14 +29,15 @@ export default function AuthorManagerPage() {
         fetchAuthors();
     }, [fetchAuthors]);
 
-    const handleEdit = (idx: number) => {
-        setEditingAuthor(authors[idx]);
-        setEditingIndex(idx);
+    const handleEditById = (id: string) => {
+        const author = authors.find((a) => a.id === id);
+        if (!author) return;
+        setEditingAuthor(author);
+        setEditingId(id);
     };
 
-    const handleDelete = async (idx: number) => {
+    const handleDeleteById = async (id: string) => {
         if (!confirm("Supprimer cet auteur ?")) return;
-        const id = authors[idx].id;
         await authorService.delete({ id });
         await fetchAuthors();
     };
@@ -44,12 +45,12 @@ export default function AuthorManagerPage() {
     const handleSave = async () => {
         await fetchAuthors();
         setEditingAuthor(null);
-        setEditingIndex(null);
+        setEditingId(null);
     };
 
     const handleCancel = () => {
         setEditingAuthor(null);
-        setEditingIndex(null);
+        setEditingId(null);
         setMode("create");
         setForm(initialAuthorForm);
     };
@@ -62,13 +63,13 @@ export default function AuthorManagerPage() {
                 <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}
-                    editingIndex={editingIndex}
-                    onEdit={handleEdit}
+                    editingId={editingId}
+                    onEditById={handleEditById}
                     onSave={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}
-                    onDelete={handleDelete}
+                    onDeleteById={handleDeleteById}
                 />
             </BlogEditorLayout>
         </RequireAdmin>

--- a/src/components/Blog/manage/components/FormActionButtons.tsx
+++ b/src/components/Blog/manage/components/FormActionButtons.tsx
@@ -1,9 +1,11 @@
 import ActionButtons from "./buttons/ActionButtons";
 import { EditButton, DeleteButton } from "@components/buttons";
 
+type IdLike = string | number;
+
 interface FormActionButtonsProps {
-    editingIndex: number | null;
-    currentIndex: number;
+    editingId: IdLike | null;
+    currentId: IdLike;
     onEdit: () => void;
     onSave: () => void;
     onCancel: () => void;
@@ -14,8 +16,8 @@ interface FormActionButtonsProps {
 }
 
 export default function FormActionButtons({
-    editingIndex,
-    currentIndex,
+    editingId,
+    currentId,
     onEdit,
     onSave,
     onCancel,
@@ -24,7 +26,7 @@ export default function FormActionButtons({
     addButtonLabel = "Ajouter",
     className = "",
 }: FormActionButtonsProps): React.ReactElement {
-    if (isFormNew && editingIndex === null) {
+    if (isFormNew && editingId === null) {
         return (
             <button
                 type="button"
@@ -36,7 +38,7 @@ export default function FormActionButtons({
         );
     }
 
-    if (editingIndex === currentIndex) {
+    if (editingId === currentId) {
         return (
             <ActionButtons
                 isEditing={true}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -14,7 +14,7 @@ import { usePostForm } from "@entities/models/post/hooks";
 export default function PostManagerPage() {
     const [posts, setPosts] = useState<PostType[]>([]);
     const [editingPost, setEditingPost] = useState<PostType | null>(null);
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const [editingId, setEditingId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
 
     const manager = usePostForm(editingPost);
@@ -28,14 +28,15 @@ export default function PostManagerPage() {
         void fetchPosts();
     }, [fetchPosts]);
 
-    const handleEdit = (idx: number) => {
-        setEditingPost(posts[idx]);
-        setEditingIndex(idx);
+    const handleEditById = (id: string) => {
+        const post = posts.find((p) => p.id === id);
+        if (!post) return;
+        setEditingPost(post);
+        setEditingId(id);
     };
 
-    const handleDelete = async (idx: number) => {
+    const handleDeleteById = async (id: string) => {
         if (!confirm("Supprimer ce post ?")) return;
-        const id = posts[idx].id;
         await postService.delete({ id });
         await fetchPosts();
     };
@@ -43,12 +44,12 @@ export default function PostManagerPage() {
     const handleSave = async () => {
         await fetchPosts();
         setEditingPost(null);
-        setEditingIndex(null);
+        setEditingId(null);
     };
 
     const handleCancel = () => {
         setEditingPost(null);
-        setEditingIndex(null);
+        setEditingId(null);
     };
 
     return (
@@ -59,13 +60,13 @@ export default function PostManagerPage() {
                 <SectionHeader>Liste des articles</SectionHeader>
                 <PostList
                     posts={posts}
-                    editingIndex={editingIndex}
-                    onEdit={handleEdit}
+                    editingId={editingId}
+                    onEditById={handleEditById}
                     onSave={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}
-                    onDelete={handleDelete}
+                    onDeleteById={handleDeleteById}
                 />
             </BlogEditorLayout>
         </RequireAdmin>

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -6,20 +6,22 @@ import GenericList from "../GenericList";
 import { byOptionalOrder } from "../sorters";
 import { type PostType } from "@/src/entities/models/post";
 
+type IdLike = string | number;
+
 interface Props {
     posts: PostType[];
-    editingIndex: number | null;
-    onEdit: (idx: number) => void;
+    editingId: IdLike | null;
+    onEditById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
-    onDelete: (idx: number) => void;
+    onDeleteById: (id: IdLike) => void;
 }
 
 export default function PostList(props: Props) {
     return (
         <GenericList<PostType>
             items={props.posts}
-            editingIndex={props.editingIndex}
+            editingId={props.editingId}
             getKey={(p) => p.id}
             renderContent={(p) => (
                 <p className="self-center">
@@ -27,10 +29,10 @@ export default function PostList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEdit={props.onEdit}
+            onEdit={props.onEditById}
             onSave={props.onSave}
             onCancel={props.onCancel}
-            onDelete={props.onDelete}
+            onDelete={props.onDeleteById}
         />
     );
 }

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -10,7 +10,7 @@ import { type SectionTypes, initialSectionForm, useSectionForm } from "@entities
 
 export default function SectionManagerPage() {
     const [editingSection, setEditingSection] = useState<SectionTypes | null>(null);
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const [editingId, setEditingId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
     const manager = useSectionForm(editingSection);
     const {
@@ -25,24 +25,28 @@ export default function SectionManagerPage() {
         fetchList();
     }, [fetchList]);
 
-    const handleEdit = (idx: number) => {
+    const handleEditById = (id: string) => {
+        const idx = sections.findIndex((s) => s.id === id);
+        if (idx === -1) return;
         setEditingSection(sections[idx]);
-        setEditingIndex(idx);
+        setEditingId(id);
     };
 
-    const handleDelete = async (idx: number) => {
+    const handleDeleteById = async (id: string) => {
+        const idx = sections.findIndex((s) => s.id === id);
+        if (idx === -1) return;
         await remove(idx);
     };
 
     const handleSave = async () => {
         await fetchList();
         setEditingSection(null);
-        setEditingIndex(null);
+        setEditingId(null);
     };
 
     const handleCancel = () => {
         setEditingSection(null);
-        setEditingIndex(null);
+        setEditingId(null);
         setMode("create");
         setForm(initialSectionForm);
     };
@@ -54,19 +58,21 @@ export default function SectionManagerPage() {
                 <SectionForm
                     ref={formRef}
                     manager={manager}
-                    editingIndex={editingIndex}
+                    editingIndex={
+                        editingId !== null ? sections.findIndex((s) => s.id === editingId) : null
+                    }
                     onSave={handleSave}
                 />
                 <SectionHeader>Liste des sections</SectionHeader>
                 <SectionList
                     sections={sections}
-                    editingIndex={editingIndex}
-                    onEdit={handleEdit}
+                    editingId={editingId}
+                    onEditById={handleEditById}
                     onSave={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}
-                    onDelete={handleDelete}
+                    onDeleteById={handleDeleteById}
                 />
             </BlogEditorLayout>
         </RequireAdmin>

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -5,20 +5,22 @@ import GenericList from "@components/Blog/manage/GenericList";
 import { byOptionalOrder } from "@components/Blog/manage/sorters";
 import { type SectionTypes } from "@entities/models/section";
 
+type IdLike = string | number;
+
 interface Props {
     sections: SectionTypes[];
-    editingIndex: number | null;
-    onEdit: (idx: number) => void;
+    editingId: IdLike | null;
+    onEditById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
-    onDelete: (idx: number) => void;
+    onDeleteById: (id: IdLike) => void;
 }
 
 export default function SectionList(props: Props) {
     return (
         <GenericList<SectionTypes>
             items={props.sections}
-            editingIndex={props.editingIndex}
+            editingId={props.editingId}
             getKey={(s) => s.id}
             renderContent={(s) => (
                 <p className="self-center">
@@ -26,10 +28,10 @@ export default function SectionList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEdit={props.onEdit}
+            onEdit={props.onEditById}
             onSave={props.onSave}
             onCancel={props.onCancel}
-            onDelete={props.onDelete}
+            onDelete={props.onDeleteById}
         />
     );
 }

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -1,7 +1,7 @@
 // src/components/Blog/manage/tags/CreateTag.tsx
 "use client";
 
-import React, { useEffect, useRef, useCallback } from "react";
+import React, { useEffect, useRef, useCallback, useState } from "react";
 import RequireAdmin from "@components/RequireAdmin";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
@@ -16,9 +16,10 @@ import { useTagForm, type UseTagFormReturn } from "@entities/models/tag/hooks";
 export default function CreateTagPage() {
     const formRef = useRef<HTMLFormElement>(null);
     const manager: UseTagFormReturn = useTagForm();
+    const [editingId, setEditingId] = useState<string | null>(null);
 
     const {
-        extras: { tags, posts, index },
+        extras: { tags, posts },
         loading,
         fetchAll,
         edit,
@@ -38,7 +39,32 @@ export default function CreateTagPage() {
 
     const handleSaved = useCallback(async () => {
         await fetchAll?.();
+        setEditingId(null);
     }, [fetchAll]);
+
+    const handleEditById = useCallback(
+        (id: string) => {
+            const idx = tags.findIndex((t) => t.id === id);
+            if (idx === -1) return;
+            edit(idx);
+            setEditingId(id);
+        },
+        [tags, edit]
+    );
+
+    const handleDeleteById = useCallback(
+        async (id: string) => {
+            const idx = tags.findIndex((t) => t.id === id);
+            if (idx === -1) return;
+            await remove(idx);
+        },
+        [tags, remove]
+    );
+
+    const handleCancel = useCallback(() => {
+        cancel();
+        setEditingId(null);
+    }, [cancel]);
 
     return (
         <RequireAdmin>
@@ -53,11 +79,11 @@ export default function CreateTagPage() {
                 <SectionHeader>Liste des tags</SectionHeader>
                 <TagList
                     tags={tags}
-                    editingIndex={index ?? null}
-                    onEdit={edit}
+                    editingId={editingId}
+                    onEditById={handleEditById}
                     onSave={submitForm}
-                    onCancel={cancel}
-                    onDelete={remove}
+                    onCancel={handleCancel}
+                    onDeleteById={handleDeleteById}
                 />
 
                 <SectionHeader loading={loading}>Associer les tags aux articles</SectionHeader>

--- a/src/components/Blog/manage/tags/TagList.tsx
+++ b/src/components/Blog/manage/tags/TagList.tsx
@@ -5,20 +5,22 @@ import GenericList from "@components/Blog/manage/GenericList";
 import { byAlpha } from "@components/Blog/manage/sorters";
 import type { TagType } from "@entities/models/tag/types";
 
+type IdLike = string | number;
+
 interface Props {
     tags: TagType[];
-    editingIndex: number | null;
-    onEdit: (idx: number) => void;
+    editingId: IdLike | null;
+    onEditById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
-    onDelete: (idx: number) => void;
+    onDeleteById: (id: IdLike) => void;
 }
 
-function TagListInner({ tags, editingIndex, onEdit, onSave, onCancel, onDelete }: Props) {
+function TagListInner({ tags, editingId, onEditById, onSave, onCancel, onDeleteById }: Props) {
     return (
         <GenericList<TagType>
             items={tags}
-            editingIndex={editingIndex}
+            editingId={editingId}
             getKey={(t) => t.id}
             renderContent={(t) => (
                 <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-blue-100 text-blue-800 text-sm font-semibold">
@@ -39,10 +41,10 @@ function TagListInner({ tags, editingIndex, onEdit, onSave, onCancel, onDelete }
                 ].join(" ")
             }
             sortBy={byAlpha((t) => t.name)}
-            onEdit={onEdit}
+            onEdit={onEditById}
             onSave={onSave}
             onCancel={onCancel}
-            onDelete={onDelete}
+            onDelete={onDeleteById}
         />
     );
 }


### PR DESCRIPTION
## Description
- utiliser `editingId` dans `GenericList` et callbacks basés sur l'id
- adapter les listes (sections, tags, posts, auteurs) aux handlers `onEditById`/`onDeleteById`
- stocker `editingId` dans les pages de gestion et piloter les actions par identifiant

## Tests effectués
- `yarn prettier --write src/components/Blog/manage/components/FormActionButtons.tsx src/components/Blog/manage/GenericList.tsx src/components/Blog/manage/sections/SectionList.tsx src/components/Blog/manage/tags/TagList.tsx src/components/Blog/manage/posts/PostList.tsx src/components/Blog/manage/authors/AuthorList.tsx src/components/Blog/manage/sections/CreateSection.tsx src/components/Blog/manage/tags/CreateTag.tsx src/components/Blog/manage/posts/CreatePost.tsx src/components/Blog/manage/authors/CreateAuthor.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3cf80a27083249954bc0769b49923