### PR TITLE
[Fix] gestion des surcharges dans OperationArg

### DIFF
--- a/src/entities/core/services/crudService.ts
+++ b/src/entities/core/services/crudService.ts
@@ -8,8 +8,9 @@ type ClientModels = typeof client.models;
 type ClientModelKey = keyof ClientModels;
 
 type BaseModel<K extends ClientModelKey> = Schema[K]["type"];
-type OperationArg<T, M extends PropertyKey> =
-    T extends Record<M, (arg: infer A, ...rest: unknown[]) => unknown> ? A : never;
+type OperationArg<T, M extends keyof T> = T[M] extends { (...args: infer P): unknown }
+    ? P[0]
+    : never;
 
 type CreateArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "create">;
 type UpdateArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "update">;


### PR DESCRIPTION
## Description
- Tolère les surcharges de fonctions dans `OperationArg`
- Garantit que `CreateArg`, `UpdateArg`, `GetArg` et `DeleteArg` infèrent les bons types d'entrée des modèles

## Tests effectués
- `yarn lint`
- `yarn tsc --noEmit` *(échoue sur des fichiers de test non liés)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cfd97b2c832491517f1aa5edef8d