### PR TITLE
[Fix] assouplir la contrainte générique de useModelForm

### DIFF
--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 export type FormMode = "create" | "edit";
 export type FieldKey<T> = keyof T & string;
 
-export interface UseModelFormOptions<F, E = Record<string, unknown>> {
+export interface UseModelFormOptions<F extends object, E = Record<string, unknown>> {
     initialForm: F;
     initialExtras?: E;
     mode?: FormMode;
@@ -80,7 +80,7 @@ function deepEqual(a: unknown, b: unknown) {
 }
 
 export default function useModelForm<
-    F extends Record<string, unknown>,
+    F extends object,
     E extends Record<string, unknown> = Record<string, unknown>,
 >(options: UseModelFormOptions<F, E>): UseModelFormResult<F, E> {
     const {


### PR DESCRIPTION
## Résumé
- permettre l'utilisation de formulaires sans index signature

## Tests
- `yarn lint`
- `yarn build` *(échec : Type error in useTodosWithComments.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cfe6fb0483249d458a1b8be9ca64