### PR TITLE
[Feat] alias @test pour les tests

### DIFF
--- a/src/entities/core/utils/__tests__/syncManyToMany.test.ts
+++ b/src/entities/core/utils/__tests__/syncManyToMany.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
 import { relationService } from "@entities/core/services";
 import { http, HttpResponse } from "msw";
-import { server } from "@/test/setup";
+import { server } from "@test/setup";
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const mockModel = {

--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "@/test/setup";
+import { server } from "@test/setup";
 import { postTagService } from "@entities/relations/postTag/service";
 
 vi.mock("@entities/core/services/amplifyClient", () => {

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "@/test/setup";
+import { server } from "@test/setup";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
 
 vi.mock("@entities/core/services/amplifyClient", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
             "@services/*": ["src/services/*"],
             "@myTypes/*": ["src/types/*"],
             "@entities/*": ["src/entities/*"],
-            "@public/*": ["public/*"]
+            "@public/*": ["public/*"],
+            "@test/*": ["test/*"]
         },
         "plugins": [{ "name": "next" }]
     },


### PR DESCRIPTION
## Summary
- ajoute l'alias `@test` dans `tsconfig.json`
- remplace les imports `@/test` par `@test`

## Testing
- `yarn prettier --write tsconfig.json src/entities/core/utils/__tests__/syncManyToMany.test.ts src/entities/relations/postTag/__tests__/service.test.ts src/entities/relations/sectionPost/__tests__/service.test.ts`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cfeb0ca883248142ceec4c578f5c