### PR TITLE
[Fix] vérifie la forme des corps de requête dans les tests de relation

### DIFF
--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -28,8 +28,8 @@ describe("postTagService", () => {
     it("listByParent retourne les IDs tag", async () => {
         server.use(
             http.post("https://api.test/postTag/list", async ({ request }) => {
-                const body = await request.json();
-                if (body.args?.filter?.postId?.eq === "post1") {
+                const body = (await request.json()) as any;
+                if (typeof body === "object" && body?.args?.filter?.postId?.eq === "post1") {
                     return HttpResponse.json({
                         data: [
                             { postId: "post1", tagId: "tag1" },
@@ -46,8 +46,8 @@ describe("postTagService", () => {
     it("listByChild retourne les IDs post", async () => {
         server.use(
             http.post("https://api.test/postTag/list", async ({ request }) => {
-                const body = await request.json();
-                if (body.args?.filter?.tagId?.eq === "tag1") {
+                const body = (await request.json()) as any;
+                if (typeof body === "object" && body?.args?.filter?.tagId?.eq === "tag1") {
                     return HttpResponse.json({
                         data: [
                             { postId: "post1", tagId: "tag1" },
@@ -65,7 +65,7 @@ describe("postTagService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -77,7 +77,7 @@ describe("postTagService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -89,7 +89,7 @@ describe("postTagService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -103,7 +103,7 @@ describe("postTagService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -28,8 +28,8 @@ describe("sectionPostService", () => {
     it("listByParent retourne les IDs post", async () => {
         server.use(
             http.post("https://api.test/sectionPost/list", async ({ request }) => {
-                const body = await request.json();
-                if (body.args?.filter?.sectionId?.eq === "section1") {
+                const body = (await request.json()) as any;
+                if (typeof body === "object" && body?.args?.filter?.sectionId?.eq === "section1") {
                     return HttpResponse.json({
                         data: [
                             { sectionId: "section1", postId: "post1" },
@@ -49,8 +49,8 @@ describe("sectionPostService", () => {
     it("listByChild retourne les IDs section", async () => {
         server.use(
             http.post("https://api.test/sectionPost/list", async ({ request }) => {
-                const body = await request.json();
-                if (body.args?.filter?.postId?.eq === "post1") {
+                const body = (await request.json()) as any;
+                if (typeof body === "object" && body?.args?.filter?.postId?.eq === "post1") {
                     return HttpResponse.json({
                         data: [
                             { sectionId: "section1", postId: "post1" },
@@ -71,7 +71,7 @@ describe("sectionPostService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -83,7 +83,7 @@ describe("sectionPostService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -95,7 +95,7 @@ describe("sectionPostService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -109,7 +109,7 @@ describe("sectionPostService", () => {
         let received: any;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = await request.json();
+                received = (await request.json()) as any;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );


### PR DESCRIPTION
## Description
- sécurise l'accès aux filtres des requêtes `postTag` et `sectionPost`

## Tests effectués
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cffed91c832489af28cf746988cc