### PR TITLE
[Fix] typage explicite de crudService

### DIFF
--- a/src/entities/core/services/__tests__/crudService.test.ts
+++ b/src/entities/core/services/__tests__/crudService.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 describe("crudService", () => {
     const svc = crudService("Test", {
         auth: { read: ["apiKey", "userPool"], write: ["apiKey", "userPool"] },
-    });
+    }) as ReturnType<typeof crudService<"Test">>;
 
     it("list utilise le fallback et filtre selon canAccess", async () => {
         const fetchSpy = vi.spyOn(global, "fetch");


### PR DESCRIPTION
## Description
- typer explicitement l'appel à `crudService` dans les tests

## Tests effectués
- `yarn install`
- `yarn prettier --write src/entities/core/services/__tests__/crudService.test.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3d02c3f9c8324abbac293c2222803