### PR TITLE
[Fix] remplacer authMode public par apiKey

### DIFF
--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -85,7 +85,7 @@ describe("postTagService", () => {
         expect(received.where).toEqual({ postId: "post1", tagId: "tag2" });
     });
 
-    it("échoue avec authMode public", async () => {
+    it("échoue avec authMode apiKey", async () => {
         let received: any;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
@@ -94,9 +94,9 @@ describe("postTagService", () => {
             })
         );
         await expect(
-            postTagService.create("post1", "tag1", { authMode: "public" })
+            postTagService.create("post1", "tag1", { authMode: "apiKey" })
         ).rejects.toThrow();
-        expect(received.opts.authMode).toBe("public");
+        expect(received.opts.authMode).toBe("apiKey");
     });
 
     it("échoue avec authMode userPool", async () => {

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -91,7 +91,7 @@ describe("sectionPostService", () => {
         expect(received.where).toEqual({ sectionId: "section1", postId: "post2" });
     });
 
-    it("échoue avec authMode public", async () => {
+    it("échoue avec authMode apiKey", async () => {
         let received: any;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
@@ -100,9 +100,9 @@ describe("sectionPostService", () => {
             })
         );
         await expect(
-            sectionPostService.create("section1", "post1", { authMode: "public" })
+            sectionPostService.create("section1", "post1", { authMode: "apiKey" })
         ).rejects.toThrow();
-        expect(received.opts.authMode).toBe("public");
+        expect(received.opts.authMode).toBe("apiKey");
     });
 
     it("échoue avec authMode userPool", async () => {


### PR DESCRIPTION
## Objet
- corriger l'utilisation de `authMode: "public"` dans les tests de relations

## Tests effectués
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3d04e42288324ac6581004ac0b0fb