### PR TITLE
[Fix] délai de génération des champs

### DIFF
--- a/src/hooks/useAutoGenFields.ts
+++ b/src/hooks/useAutoGenFields.ts
@@ -24,16 +24,22 @@ export function useAutoGenFields({ configs }: UseAutoGenFieldsProps) {
     // édition indépendante de chaque champ source
     const [isEditing, setIsEditing] = useState<Record<string, boolean>>({});
 
-    // Génération automatique
+    // Génération automatique (avec délai)
     useEffect(() => {
-        configs.forEach((cfg) => {
-            if (isEditing[cfg.editingKey] && autoFlags[cfg.target]) {
-                const value = cfg.transform ? cfg.transform(cfg.source) : cfg.source;
-                if (value !== cfg.current) {
-                    cfg.setter(value ?? "");
+        const timer = setTimeout(() => {
+            configs.forEach((cfg) => {
+                if (isEditing[cfg.editingKey] && autoFlags[cfg.target]) {
+                    const value = cfg.transform ? cfg.transform(cfg.source) : cfg.source;
+                    if (value !== cfg.current) {
+                        cfg.setter(value ?? "");
+                    }
                 }
-            }
-        });
+            });
+        }, 200);
+
+        return () => {
+            clearTimeout(timer);
+        };
     }, [configs, autoFlags, isEditing]);
 
     function handleSourceFocus(key: string) {


### PR DESCRIPTION
## Description
- retarde la génération automatique des champs de 200ms

## Tests
- `yarn install`
- `yarn prettier --write src/hooks/useAutoGenFields.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3d57674188324bc7f1bd325df02e7