### PR TITLE
[Fix] enforce consistent file name casing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
         "strict": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,


### PR DESCRIPTION
## Summary
- enable TypeScript's `forceConsistentCasingInFileNames` option
- verify module imports use correct file-name casing

## Testing
- `yarn prettier --write tsconfig.json`
- `node check-import-case.js` (script inline)
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3d6e02a38832492bf494f057591a0