### PR TITLE
[Feat] stabiliser le calcul de l'ordre

### DIFF
--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -56,7 +56,13 @@ export default function PostManagerPage() {
         <RequireAdmin>
             <BlogEditorLayout title="Gestion des Posts">
                 <SectionHeader className="mt-8">Nouvel article</SectionHeader>
-                <PostForm ref={formRef} manager={manager} posts={posts} onSave={handleSave} />
+                <PostForm
+                    ref={formRef}
+                    manager={manager}
+                    posts={posts}
+                    editingId={editingId}
+                    onSave={handleSave}
+                />
                 <SectionHeader>Liste des articles</SectionHeader>
                 <PostList
                     posts={posts}

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -20,10 +20,11 @@ interface Props {
     manager: ReturnType<typeof usePostForm>;
     onSave: () => void;
     posts: PostType[];
+    editingId: string | null;
 }
 
 const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
-    { manager, onSave, posts },
+    { manager, onSave, posts, editingId },
     ref
 ) {
     const {
@@ -154,8 +155,8 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 ]}
             />
             <OrderSelector
-                sections={posts}
-                currentIndex={-1}
+                items={posts}
+                editingId={editingId}
                 value={form.order ?? 1}
                 onReorder={(_, newOrder) => handleChange("order", newOrder)}
             />

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -58,9 +58,7 @@ export default function SectionManagerPage() {
                 <SectionForm
                     ref={formRef}
                     manager={manager}
-                    editingIndex={
-                        editingId !== null ? sections.findIndex((s) => s.id === editingId) : null
-                    }
+                    editingId={editingId}
                     onSave={handleSave}
                 />
                 <SectionHeader>Liste des sections</SectionHeader>

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -17,11 +17,11 @@ import {
 interface Props {
     manager: ReturnType<typeof useSectionForm>;
     onSave: () => void;
-    editingIndex: number | null;
+    editingId: string | null;
 }
 
 const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
-    { manager, onSave, editingIndex },
+    { manager, onSave, editingId },
     ref
 ) {
     const {
@@ -102,8 +102,8 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
                 readOnly={false}
             />
             <OrderSelector
-                sections={sections}
-                currentIndex={editingIndex ?? -1}
+                items={sections}
+                editingId={editingId}
                 value={form.order ?? 1}
                 onReorder={(_, newOrder) => handleChange("order", newOrder)}
             />

--- a/src/components/forms/OrderSelector.tsx
+++ b/src/components/forms/OrderSelector.tsx
@@ -2,15 +2,16 @@ import React from "react";
 import SelectField from "./SelectField";
 
 interface Props {
-    sections: { id: string }[];
-    currentIndex: number; // -1 si l'élément n'existe pas encore
+    items: { id: string }[];
+    editingId: string | null; // null si l'élément n'existe pas encore
     value: number; // valeur en base 1 (1,2,3,...)
-    onReorder: (currentIndex: number, newOrder: number) => void; // newOrder en base 1
+    onReorder: (editingId: string | null, newOrder: number) => void; // newOrder en base 1
 }
 
-export default function OrderSelector({ sections, currentIndex, value, onReorder }: Props) {
-    const isNew = currentIndex < 0 || currentIndex >= sections.length;
-    const max = isNew ? sections.length + 1 : sections.length;
+export default function OrderSelector({ items, editingId, value, onReorder }: Props) {
+    const currentIndex = editingId ? items.findIndex((s) => s.id === editingId) : -1;
+    const isNew = currentIndex < 0 || currentIndex >= items.length;
+    const max = isNew ? items.length + 1 : items.length;
 
     const options = Array.from({ length: max }, (_, i) => {
         const n = i + 1; // 1..max
@@ -22,7 +23,7 @@ export default function OrderSelector({ sections, currentIndex, value, onReorder
 
     const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const newPosition = parseInt(e.target.value, 10); // base 1
-        onReorder(currentIndex, newPosition);
+        onReorder(editingId, newPosition);
     };
 
     return (


### PR DESCRIPTION
## Résumé
- calcule la position actuelle via l'identifiant pour éviter les décalages
- propage `editingId` aux formulaires de posts et sections

## Tests effectués
- `yarn prettier --write src/components/forms/OrderSelector.tsx src/components/Blog/manage/posts/PostForm.tsx src/components/Blog/manage/sections/SectionsForm.tsx src/components/Blog/manage/posts/CreatePost.tsx src/components/Blog/manage/sections/CreateSection.tsx`
- `yarn test`
- `yarn lint` *(échoue : aucune sortie)*
- `yarn build` *(échoue : se bloque lors de la compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d66aafa48324b31bcbd7f25ad090