### PR TITLE
Feat: cascade helpers

### DIFF
--- a/src/entities/core/services/__tests__/cascade.test.ts
+++ b/src/entities/core/services/__tests__/cascade.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { withConcurrency, deleteEdges, setNullBatch } from "@entities/core/services";
+
+function sleep(ms: number) {
+    return new Promise((res) => setTimeout(res, ms));
+}
+
+describe("cascade helpers", () => {
+    it("withConcurrency limite le nombre de tâches simultanées", async () => {
+        let active = 0;
+        let max = 0;
+        const res = await withConcurrency([1, 2, 3, 4], 2, async (n) => {
+            active++;
+            max = Math.max(max, active);
+            await sleep(10);
+            active--;
+            return n * 2;
+        });
+        expect(res).toEqual([2, 4, 6, 8]);
+        expect(max).toBeLessThanOrEqual(2);
+    });
+
+    it("deleteEdges utilise withConcurrency", async () => {
+        const edges = [1, 2, 3];
+        const calls: number[] = [];
+        await deleteEdges(
+            edges,
+            async (e) => {
+                calls.push(e);
+            },
+            2
+        );
+        expect(calls.sort()).toEqual(edges);
+    });
+
+    it("setNullBatch met les clés à null et appelle l'updater", async () => {
+        const items = [
+            { id: 1, ref: 10 },
+            { id: 2, ref: 20 },
+        ];
+        const updated: typeof items = [] as any;
+        await setNullBatch(items, ["ref"], async (item) => {
+            updated.push({ ...item });
+        });
+        expect(updated).toEqual([
+            { id: 1, ref: null },
+            { id: 2, ref: null },
+        ]);
+    });
+});

--- a/src/entities/core/services/cascade.ts
+++ b/src/entities/core/services/cascade.ts
@@ -1,0 +1,54 @@
+// src/entities/core/services/cascade.ts
+
+/**
+ * Exécute une fonction asynchrone sur une liste d'éléments avec une limite de concurrence.
+ */
+export async function withConcurrency<T, R>(
+    items: T[],
+    concurrency: number,
+    worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let nextIndex = 0;
+
+    async function run(): Promise<void> {
+        const current = nextIndex++;
+        if (current >= items.length) return;
+        results[current] = await worker(items[current], current);
+        await run();
+    }
+
+    const runners = Array.from({ length: Math.min(concurrency, items.length) }, () => run());
+    await Promise.all(runners);
+    return results;
+}
+
+/**
+ * Supprime des "edges" en utilisant une fonction fournie et une concurrence optionnelle.
+ */
+export async function deleteEdges<T>(
+    edges: T[],
+    deleter: (edge: T) => Promise<void>,
+    concurrency = 10
+): Promise<void> {
+    await withConcurrency(edges, concurrency, async (edge, _i) => {
+        await deleter(edge);
+    });
+}
+
+/**
+ * Met certaines clés à `null` pour chaque élément et exécute une fonction d'update.
+ */
+export async function setNullBatch<T extends Record<string, any>>(
+    items: T[],
+    keys: (keyof T)[],
+    updater: (item: T) => Promise<void>,
+    concurrency = 10
+): Promise<void> {
+    await withConcurrency(items, concurrency, async (item) => {
+        for (const key of keys) {
+            (item as any)[key] = null;
+        }
+        await updater(item);
+    });
+}

--- a/src/entities/core/services/index.ts
+++ b/src/entities/core/services/index.ts
@@ -1,3 +1,4 @@
 export { client, type Schema } from "./amplifyClient";
 export { crudService } from "./crudService";
 export { relationService } from "./relationService";
+export { withConcurrency, deleteEdges, setNullBatch } from "./cascade";


### PR DESCRIPTION
## Résumé
- ajouter les helpers `withConcurrency`, `deleteEdges` et `setNullBatch`
- exposer les helpers de cascade via le service core
- couvrir les helpers par des tests unitaires

## Tests
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d77845008324a766839680cd3a8b