### PR TITLE
[Fix] utilise byOptionalOrder pour trier les sections du blog

### DIFF
--- a/src/components/Blog/Blog.tsx
+++ b/src/components/Blog/Blog.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from "react";
 import { Section, Post, Author } from "@src/types/blog";
 import BlogSectionCard from "./BlogSectionCard";
 import PostContent from "./PostContent";
+import { byOptionalOrder } from "@components/Blog/manage/sorters";
 
 type BlogProps = {
     data: {
@@ -23,7 +24,7 @@ const Blog: React.FC<BlogProps> = ({ data, singlePost, noWrapper }) => {
         () =>
             sections
                 .slice()
-                .sort((a, b) => a.order - b.order)
+                .sort(byOptionalOrder)
                 .map((section) => {
                     const postsInSection = publishedPosts.filter((p) =>
                         p.sectionJsonIds.includes(section.sectionJsonId)


### PR DESCRIPTION
## Résumé
- importe `byOptionalOrder` pour gérer les ordres optionnels des sections
- remplace la fonction de tri directe par `byOptionalOrder`

## Tests effectués
- `yarn prettier src/components/Blog/Blog.tsx -w`
- `yarn lint`
- `yarn test`
- `yarn build` *(échoue : Type error in CreateAuthor.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dc1faad48324a6e3dc0069c85599