### PR TITLE
[Fix] remplace les imports du PostList par des alias

### DIFF
--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -2,9 +2,9 @@
 "use client";
 
 import React from "react";
-import GenericList from "../GenericList";
-import { byOptionalOrder } from "../sorters";
-import { type PostType } from "@/src/entities/models/post";
+import GenericList from "@components/Blog/manage/GenericList";
+import { byOptionalOrder } from "@components/Blog/manage/sorters";
+import { type PostType } from "@entities/models/post";
 
 type IdLike = string | number;
 


### PR DESCRIPTION
## Description
- remplace les chemins relatifs par des alias dans `PostList`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Type error dans `CreateAuthor.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dc16c44083248fee9bbd6a07b4fd