### PR TITLE
[Feat] suppression en cascade des entités du blog

### DIFF
--- a/e2e/section-management.spec.ts
+++ b/e2e/section-management.spec.ts
@@ -22,7 +22,7 @@ test.describe("Section", () => {
         const updated = await sectionService.update({ id, title: updatedTitle });
         expect(updated.data.title).toBe(updatedTitle);
 
-        await sectionService.delete({ id });
+        await sectionService.deleteCascade({ id });
         await signOutUser();
     });
 });

--- a/e2e/tag-post.spec.ts
+++ b/e2e/tag-post.spec.ts
@@ -41,9 +41,8 @@ test.describe("Tag & Post", () => {
         expect(postIdsForTag).toContain(postId);
 
         // Nettoyage
-        await postTagService.delete(postId, tagId);
-        await postService.delete({ id: postId });
-        await tagService.delete({ id: tagId });
+        await postService.deleteCascade({ id: postId });
+        await tagService.deleteCascade({ id: tagId });
         await signOutUser();
     });
 });

--- a/e2e/user-login.spec.ts
+++ b/e2e/user-login.spec.ts
@@ -14,7 +14,7 @@ test.describe("Authentification", () => {
             const tagName = `e2e-auth-${Date.now()}`;
             const created = await tagService.create({ name: tagName });
             expect(created.data.name).toBe(tagName);
-            await tagService.delete({ id: created.data.id });
+            await tagService.deleteCascade({ id: created.data.id });
             await signOutUser();
         }
     });

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -38,7 +38,7 @@ export default function AuthorManagerPage() {
 
     const handleDeleteById = async (id: string) => {
         if (!confirm("Supprimer cet auteur ?")) return;
-        await authorService.delete({ id });
+        await authorService.deleteCascade({ id });
         await fetchAuthors();
     };
 

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -37,7 +37,7 @@ export default function PostManagerPage() {
 
     const handleDeleteById = async (id: string) => {
         if (!confirm("Supprimer ce post ?")) return;
-        await postService.delete({ id });
+        await postService.deleteCascade({ id });
         await fetchPosts();
     };
 

--- a/src/entities/models/author/service.ts
+++ b/src/entities/models/author/service.ts
@@ -1,7 +1,8 @@
-import { crudService } from "@entities/core";
+import { crudService, setNullBatch } from "@entities/core";
+import { postService } from "@entities/models/post/service";
 import type { AuthorTypeOmit, AuthorTypeUpdateInput } from "@entities/models/author/types";
 
-export const authorService = crudService<
+const base = crudService<
     "Author",
     Omit<AuthorTypeOmit, "posts">,
     AuthorTypeUpdateInput & { id: string },
@@ -10,3 +11,16 @@ export const authorService = crudService<
 >("Author", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
+
+export const authorService = {
+    ...base,
+    async deleteCascade({ id }: { id: string }) {
+        const { data: posts } = await postService.list({
+            filter: { authorId: { eq: id } },
+        });
+        await setNullBatch(posts ?? [], ["authorId"], (p) =>
+            postService.update({ id: p.id, authorId: p.authorId })
+        );
+        return base.delete({ id });
+    },
+};

--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -1,7 +1,10 @@
-import { crudService } from "@entities/core";
+import { crudService, deleteEdges } from "@entities/core";
+import { commentService } from "@entities/models/comment/service";
+import { postTagService } from "@entities/relations/postTag/service";
+import { sectionPostService } from "@entities/relations/sectionPost/service";
 import type { PostTypeOmit, PostTypeUpdateInput } from "@entities/models/post/types";
 
-export const postService = crudService<
+const base = crudService<
     "Post",
     Omit<PostTypeOmit, "comments" | "author" | "sections" | "tags">,
     PostTypeUpdateInput & { id: string },
@@ -10,3 +13,27 @@ export const postService = crudService<
 >("Post", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
+
+export const postService = {
+    ...base,
+    async deleteCascade({ id }: { id: string }) {
+        const { data: comments } = await commentService.list({
+            filter: { postId: { eq: id } },
+        });
+        await deleteEdges(comments ?? [], (c) => commentService.delete({ id: c.id }));
+
+        const { data: tagEdges } = await postTagService.list({
+            filter: { postId: { eq: id } },
+        });
+        await deleteEdges(tagEdges ?? [], (edge) => postTagService.delete(edge.postId, edge.tagId));
+
+        const { data: sectionEdges } = await sectionPostService.list({
+            filter: { postId: { eq: id } },
+        });
+        await deleteEdges(sectionEdges ?? [], (edge) =>
+            sectionPostService.delete(edge.sectionId, edge.postId)
+        );
+
+        return base.delete({ id });
+    },
+};

--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -57,7 +57,7 @@ export function useSectionForm(section: SectionTypes | null) {
             const sectionItem = extras.sections[idx];
             if (!sectionItem) return;
             if (!window.confirm("Supprimer cette section ?")) return;
-            await sectionService.delete({ id: sectionItem.id });
+            await sectionService.deleteCascade({ id: sectionItem.id });
             await fetchList();
         },
         [extras.sections, fetchList]

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -1,5 +1,19 @@
-import { crudService } from "@entities/core";
+import { crudService, deleteEdges } from "@entities/core";
+import { sectionPostService } from "@entities/relations/sectionPost/service";
 
-export const sectionService = crudService("Section", {
+const base = crudService("Section", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
+
+export const sectionService = {
+    ...base,
+    async deleteCascade({ id }: { id: string }) {
+        const { data: edges } = await sectionPostService.list({
+            filter: { sectionId: { eq: id } },
+        });
+        await deleteEdges(edges ?? [], (edge) =>
+            sectionPostService.delete(edge.sectionId, edge.postId)
+        );
+        return base.delete({ id });
+    },
+};

--- a/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@entities/models/tag/service", () => ({
         list: vi.fn(),
         create: vi.fn(),
         update: vi.fn(),
-        delete: vi.fn(),
+        deleteCascade: vi.fn(),
     },
 }));
 
@@ -109,10 +109,8 @@ describe("useTagForm", () => {
     });
 
     it("remove supprime le tag et réinitialise l'index", async () => {
-        const deleteTagMock = tagService.delete as ReturnType<typeof vi.fn>;
-        const deleteRelationMock = postTagService.delete as ReturnType<typeof vi.fn>;
+        const deleteTagMock = tagService.deleteCascade as ReturnType<typeof vi.fn>;
         deleteTagMock.mockResolvedValue({});
-        deleteRelationMock.mockResolvedValue({});
         vi.spyOn(window, "confirm").mockReturnValue(true);
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
@@ -124,7 +122,6 @@ describe("useTagForm", () => {
         await act(async () => {
             await result.current.remove(0);
         });
-        expect(deleteRelationMock).toHaveBeenCalledWith("p1", "t1");
         expect(deleteTagMock).toHaveBeenCalledWith({ id: "t1" });
         expect(result.current.extras.index).toBeNull();
     });

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -112,10 +112,7 @@ export function useTagForm() {
             const tag = extras.tags[idx];
             if (!tag) return;
             if (!window.confirm("Supprimer ce tag ?")) return;
-            const linkedPostIds = await postTagService.listByChild(tag.id);
-            // Si objets -> normalise : const linkedPostIds = (await postTagService.listByChild(tag.id)).map(x => x.postId);
-            await Promise.all(linkedPostIds.map((postId) => postTagService.delete(postId, tag.id)));
-            await tagService.delete({ id: tag.id });
+            await tagService.deleteCascade({ id: tag.id });
             await fetchAll();
             if (extras.index === idx) {
                 cancel();

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,5 +1,17 @@
-import { crudService } from "@entities/core";
+import { crudService, deleteEdges } from "@entities/core";
+import { postTagService } from "@entities/relations/postTag/service";
 
-export const tagService = crudService("Tag", {
+const base = crudService("Tag", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
+
+export const tagService = {
+    ...base,
+    async deleteCascade({ id }: { id: string }) {
+        const { data: edges } = await postTagService.list({
+            filter: { tagId: { eq: id } },
+        });
+        await deleteEdges(edges ?? [], (edge) => postTagService.delete(edge.postId, edge.tagId));
+        return base.delete({ id });
+    },
+};


### PR DESCRIPTION
## Description
- ajoute `deleteCascade` aux services Post, Tag, Section et Author
- met à jour les pages et hooks pour utiliser la suppression en cascade

## Tests effectués
- `yarn install`
- `yarn prettier --write e2e/section-management.spec.ts e2e/tag-post.spec.ts e2e/user-login.spec.ts src/components/Blog/manage/authors/CreateAuthor.tsx src/components/Blog/manage/posts/CreatePost.tsx src/entities/models/author/service.ts src/entities/models/post/service.ts src/entities/models/section/hooks.tsx src/entities/models/section/service.ts src/entities/models/tag/__tests__/hooks.test.tsx src/entities/models/tag/hooks.tsx src/entities/models/tag/service.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3dc06201c8324bc17bd3c75a20b22