### PR TITLE
[Feat] gestion des suppressions en cascade

### DIFF
--- a/src/entities/models/author/service.ts
+++ b/src/entities/models/author/service.ts
@@ -15,12 +15,7 @@ const base = crudService<
 export const authorService = {
     ...base,
     async deleteCascade({ id }: { id: string }) {
-        const { data: posts } = await postService.list({
-            filter: { authorId: { eq: id } },
-        });
-        await setNullBatch(posts ?? [], ["authorId"], (p) =>
-            postService.update({ id: p.id, authorId: p.authorId })
-        );
+        await setNullBatch(postService.list, (p) => postService.update(p), "authorId", id);
         return base.delete({ id });
     },
 };

--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -17,21 +17,25 @@ const base = crudService<
 export const postService = {
     ...base,
     async deleteCascade({ id }: { id: string }) {
-        const { data: comments } = await commentService.list({
-            filter: { postId: { eq: id } },
-        });
-        await deleteEdges(comments ?? [], (c) => commentService.delete({ id: c.id }));
+        await deleteEdges(
+            commentService.list,
+            (c) => commentService.delete({ id: c.id }),
+            "postId",
+            id
+        );
 
-        const { data: tagEdges } = await postTagService.list({
-            filter: { postId: { eq: id } },
-        });
-        await deleteEdges(tagEdges ?? [], (edge) => postTagService.delete(edge.postId, edge.tagId));
+        await deleteEdges(
+            postTagService.list,
+            (edge) => postTagService.delete(edge.postId, edge.tagId),
+            "postId",
+            id
+        );
 
-        const { data: sectionEdges } = await sectionPostService.list({
-            filter: { postId: { eq: id } },
-        });
-        await deleteEdges(sectionEdges ?? [], (edge) =>
-            sectionPostService.delete(edge.sectionId, edge.postId)
+        await deleteEdges(
+            sectionPostService.list,
+            (edge) => sectionPostService.delete(edge.sectionId, edge.postId),
+            "postId",
+            id
         );
 
         return base.delete({ id });

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -8,11 +8,11 @@ const base = crudService("Section", {
 export const sectionService = {
     ...base,
     async deleteCascade({ id }: { id: string }) {
-        const { data: edges } = await sectionPostService.list({
-            filter: { sectionId: { eq: id } },
-        });
-        await deleteEdges(edges ?? [], (edge) =>
-            sectionPostService.delete(edge.sectionId, edge.postId)
+        await deleteEdges(
+            sectionPostService.list,
+            (edge) => sectionPostService.delete(edge.sectionId, edge.postId),
+            "sectionId",
+            id
         );
         return base.delete({ id });
     },

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -8,10 +8,12 @@ const base = crudService("Tag", {
 export const tagService = {
     ...base,
     async deleteCascade({ id }: { id: string }) {
-        const { data: edges } = await postTagService.list({
-            filter: { tagId: { eq: id } },
-        });
-        await deleteEdges(edges ?? [], (edge) => postTagService.delete(edge.postId, edge.tagId));
+        await deleteEdges(
+            postTagService.list,
+            (edge) => postTagService.delete(edge.postId, edge.tagId),
+            "tagId",
+            id
+        );
         return base.delete({ id });
     },
 };


### PR DESCRIPTION
## Objectif
- factoriser la logique de suppression en cascade via des helpers génériques
- appliquer cette politique dans les services Post, Tag, Section et Author

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Type error dans CreateAuthor.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ed86a758832495bc41c9010cc0f3