### PR TITLE
[Feat] utilise les méthodes du manager par id

### DIFF
--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -1,17 +1,12 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import RequireAdmin from "@components/RequireAdmin";
 import AuthorForm from "@components/Blog/manage/authors/AuthorForm";
 import AuthorList from "@components/Blog/manage/authors/AuthorList";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
-import {
-    type AuthorType,
-    initialAuthorForm,
-    useAuthorForm,
-    authorService,
-} from "@entities/models/author";
+import { type AuthorType, initialAuthorForm, useAuthorForm } from "@entities/models/author";
 
 export default function AuthorManagerPage() {
     const [editingAuthor, setEditingAuthor] = useState<AuthorType | null>(null);
@@ -21,6 +16,8 @@ export default function AuthorManagerPage() {
     const {
         extras: { authors, loading },
         fetchAuthors,
+        selectById,
+        removeById,
         setForm,
         setMode,
     } = manager;
@@ -29,31 +26,35 @@ export default function AuthorManagerPage() {
         fetchAuthors();
     }, [fetchAuthors]);
 
-    const handleEditById = (id: string) => {
-        const author = authors.find((a) => a.id === id);
-        if (!author) return;
-        setEditingAuthor(author);
-        setEditingId(id);
-    };
+    const handleEditById = useCallback(
+        (id: string) => {
+            const author = selectById(id);
+            if (!author) return;
+            setEditingAuthor(author);
+            setEditingId(id);
+        },
+        [selectById]
+    );
 
-    const handleDeleteById = async (id: string) => {
-        if (!confirm("Supprimer cet auteur ?")) return;
-        await authorService.deleteCascade({ id });
-        await fetchAuthors();
-    };
+    const handleDeleteById = useCallback(
+        async (id: string) => {
+            await removeById(id);
+        },
+        [removeById]
+    );
 
-    const handleSave = async () => {
+    const handleSave = useCallback(async () => {
         await fetchAuthors();
         setEditingAuthor(null);
         setEditingId(null);
-    };
+    }, [fetchAuthors]);
 
-    const handleCancel = () => {
+    const handleCancel = useCallback(() => {
         setEditingAuthor(null);
         setEditingId(null);
         setMode("create");
         setForm(initialAuthorForm);
-    };
+    }, [setMode, setForm]);
 
     return (
         <RequireAdmin>

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import RequireAdmin from "@components/RequireAdmin";
 import SectionForm from "./SectionsForm";
 import SectionList from "./SectionList";
@@ -16,7 +16,8 @@ export default function SectionManagerPage() {
     const {
         extras: { sections },
         fetchList,
-        remove,
+        selectById,
+        removeById,
         setForm,
         setMode,
     } = manager;
@@ -25,31 +26,35 @@ export default function SectionManagerPage() {
         fetchList();
     }, [fetchList]);
 
-    const handleEditById = (id: string) => {
-        const idx = sections.findIndex((s) => s.id === id);
-        if (idx === -1) return;
-        setEditingSection(sections[idx]);
-        setEditingId(id);
-    };
+    const handleEditById = useCallback(
+        (id: string) => {
+            const section = selectById(id);
+            if (!section) return;
+            setEditingSection(section);
+            setEditingId(id);
+        },
+        [selectById]
+    );
 
-    const handleDeleteById = async (id: string) => {
-        const idx = sections.findIndex((s) => s.id === id);
-        if (idx === -1) return;
-        await remove(idx);
-    };
+    const handleDeleteById = useCallback(
+        async (id: string) => {
+            await removeById(id);
+        },
+        [removeById]
+    );
 
-    const handleSave = async () => {
+    const handleSave = useCallback(async () => {
         await fetchList();
         setEditingSection(null);
         setEditingId(null);
-    };
+    }, [fetchList]);
 
-    const handleCancel = () => {
+    const handleCancel = useCallback(() => {
         setEditingSection(null);
         setEditingId(null);
         setMode("create");
         setForm(initialSectionForm);
-    };
+    }, [setMode, setForm]);
 
     return (
         <RequireAdmin>

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -22,9 +22,9 @@ export default function CreateTagPage() {
         extras: { tags, posts },
         loading,
         fetchAll,
-        edit,
+        selectById,
         cancel,
-        remove,
+        removeById,
         tagsForPost,
         isTagLinked,
         toggle,
@@ -44,21 +44,17 @@ export default function CreateTagPage() {
 
     const handleEditById = useCallback(
         (id: string) => {
-            const idx = tags.findIndex((t) => t.id === id);
-            if (idx === -1) return;
-            edit(idx);
+            void selectById(id);
             setEditingId(id);
         },
-        [tags, edit]
+        [selectById]
     );
 
     const handleDeleteById = useCallback(
         async (id: string) => {
-            const idx = tags.findIndex((t) => t.id === id);
-            if (idx === -1) return;
-            await remove(idx);
+            await removeById(id);
         },
-        [tags, remove]
+        [removeById]
     );
 
     const handleCancel = useCallback(() => {

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -33,7 +33,7 @@ export function useAuthorForm(author: AuthorType | null) {
         },
     });
 
-    const { setExtras, setForm, setMode } = modelForm;
+    const { setExtras, setForm, setMode, extras } = modelForm;
 
     const fetchAuthors = useCallback(async () => {
         setExtras((prev) => ({ ...prev, loading: true }));
@@ -49,6 +49,20 @@ export function useAuthorForm(author: AuthorType | null) {
         }
     }, [setExtras]);
 
+    const selectById = useCallback(
+        (id: string) => extras.authors.find((a) => a.id === id) ?? null,
+        [extras.authors]
+    );
+
+    const removeById = useCallback(
+        async (id: string) => {
+            if (!window.confirm("Supprimer cet auteur ?")) return;
+            await authorService.deleteCascade({ id });
+            await fetchAuthors();
+        },
+        [fetchAuthors]
+    );
+
     useEffect(() => {
         void fetchAuthors();
     }, [fetchAuthors]);
@@ -63,5 +77,5 @@ export function useAuthorForm(author: AuthorType | null) {
         }
     }, [author, setForm, setMode]);
 
-    return { ...modelForm, fetchAuthors };
+    return { ...modelForm, fetchAuthors, selectById, removeById };
 }

--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -52,15 +52,20 @@ export function useSectionForm(section: SectionTypes | null) {
         setExtras((e) => ({ ...e, sections: data ?? [] }));
     }, [setExtras]);
 
-    const remove = useCallback(
-        async (idx: number) => {
-            const sectionItem = extras.sections[idx];
+    const selectById = useCallback(
+        (id: string) => extras.sections.find((s) => s.id === id) ?? null,
+        [extras.sections]
+    );
+
+    const removeById = useCallback(
+        async (id: string) => {
+            const sectionItem = selectById(id);
             if (!sectionItem) return;
             if (!window.confirm("Supprimer cette section ?")) return;
             await sectionService.deleteCascade({ id: sectionItem.id });
             await fetchList();
         },
-        [extras.sections, fetchList]
+        [selectById, fetchList]
     );
 
     useEffect(() => {
@@ -84,5 +89,5 @@ export function useSectionForm(section: SectionTypes | null) {
         })();
     }, [section, setForm, setMode]);
 
-    return { ...modelForm, fetchList, remove };
+    return { ...modelForm, fetchList, selectById, removeById };
 }

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -86,12 +86,12 @@ export function useTagForm() {
         void fetchAll();
     }, [fetchAll]);
 
-    const edit = useCallback(
-        async (idx: number) => {
+    const selectById = useCallback(
+        async (id: string) => {
+            const idx = extras.tags.findIndex((t) => t.id === id);
+            if (idx === -1) return;
             const tag = extras.tags[idx];
-            if (!tag) return;
-            const postIds = await postTagService.listByChild(tag.id); // idéal: string[]
-            // Si objets -> normalise : const postIds = (await postTagService.listByChild(tag.id)).map(x => x.postId);
+            const postIds = await postTagService.listByChild(tag.id);
             currentId.current = tag.id;
             setForm(toTagForm(tag, postIds));
             setMode("edit");
@@ -107,10 +107,11 @@ export function useTagForm() {
         setExtras((prev) => ({ ...prev, index: null }));
     }, [setForm, setMode, setExtras]);
 
-    const remove = useCallback(
-        async (idx: number) => {
+    const removeById = useCallback(
+        async (id: string) => {
+            const idx = extras.tags.findIndex((t) => t.id === id);
+            if (idx === -1) return;
             const tag = extras.tags[idx];
-            if (!tag) return;
             if (!window.confirm("Supprimer ce tag ?")) return;
             await tagService.deleteCascade({ id: tag.id });
             await fetchAll();
@@ -170,10 +171,10 @@ export function useTagForm() {
         ...modelForm,
         loading,
         fetchAll,
-        edit,
+        selectById,
         cancel,
         save,
-        remove,
+        removeById,
         toggle,
         tagsForPost,
         isTagLinked,


### PR DESCRIPTION
## Summary
- utilise `selectById` et `removeById` dans les pages de gestion du blog
- mémorise les callbacks d’édition, suppression, sauvegarde et annulation
- expose les méthodes `selectById`/`removeById` dans les hooks des entités

## Testing
- `yarn prettier --write .`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ed4e074883249ac92b7794bb0f6e