### PR TITLE
[Feat] unifie la gestion d'édition des hooks

### DIFF
--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -8,6 +8,8 @@ import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
 import { type AuthorType, initialAuthorForm, useAuthorForm } from "@entities/models/author";
 
+type IdLike = string | number;
+
 export default function AuthorManagerPage() {
     const [editingAuthor, setEditingAuthor] = useState<AuthorType | null>(null);
     const [editingId, setEditingId] = useState<string | null>(null);
@@ -27,18 +29,18 @@ export default function AuthorManagerPage() {
     }, [fetchAuthors]);
 
     const handleEditById = useCallback(
-        (id: string) => {
-            const author = selectById(id);
+        (id: IdLike) => {
+            const author = selectById(String(id));
             if (!author) return;
             setEditingAuthor(author);
-            setEditingId(id);
+            setEditingId(String(id));
         },
         [selectById]
     );
 
     const handleDeleteById = useCallback(
-        async (id: string) => {
-            await removeById(id);
+        async (id: IdLike) => {
+            await removeById(String(id));
         },
         [removeById]
     );

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -10,6 +10,8 @@ import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
 import { usePostForm } from "@entities/models/post/hooks";
 
+type IdLike = string | number;
+
 export default function PostManagerPage() {
     const [editingPost, setEditingPost] = useState<PostType | null>(null);
     const [editingId, setEditingId] = useState<string | null>(null);
@@ -28,18 +30,18 @@ export default function PostManagerPage() {
     }, [fetchPosts]);
 
     const handleEditById = useCallback(
-        (id: string) => {
-            const post = selectById(id);
+        (id: IdLike) => {
+            const post = selectById(String(id));
             if (!post) return;
             setEditingPost(post);
-            setEditingId(id);
+            setEditingId(String(id));
         },
         [selectById]
     );
 
     const handleDeleteById = useCallback(
-        async (id: string) => {
-            await removeById(id);
+        async (id: IdLike) => {
+            await removeById(String(id));
         },
         [removeById]
     );

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -8,6 +8,8 @@ import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
 import { type SectionTypes, initialSectionForm, useSectionForm } from "@entities/models/section";
 
+type IdLike = string | number;
+
 export default function SectionManagerPage() {
     const [editingSection, setEditingSection] = useState<SectionTypes | null>(null);
     const [editingId, setEditingId] = useState<string | null>(null);
@@ -27,18 +29,18 @@ export default function SectionManagerPage() {
     }, [fetchList]);
 
     const handleEditById = useCallback(
-        (id: string) => {
-            const section = selectById(id);
+        (id: IdLike) => {
+            const section = selectById(String(id));
             if (!section) return;
             setEditingSection(section);
-            setEditingId(id);
+            setEditingId(String(id));
         },
         [selectById]
     );
 
     const handleDeleteById = useCallback(
-        async (id: string) => {
-            await removeById(id);
+        async (id: IdLike) => {
+            await removeById(String(id));
         },
         [removeById]
     );

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -13,6 +13,8 @@ import PostTagsRelationManager from "@components/Blog/manage/tags/PostTagsRelati
 
 import { useTagForm, type UseTagFormReturn } from "@entities/models/tag/hooks";
 
+type IdLike = string | number;
+
 export default function CreateTagPage() {
     const formRef = useRef<HTMLFormElement>(null);
     const manager: UseTagFormReturn = useTagForm();
@@ -43,16 +45,16 @@ export default function CreateTagPage() {
     }, [fetchAll]);
 
     const handleEditById = useCallback(
-        (id: string) => {
-            void selectById(id);
-            setEditingId(id);
+        (id: IdLike) => {
+            void selectById(String(id));
+            setEditingId(String(id));
         },
         [selectById]
     );
 
     const handleDeleteById = useCallback(
-        async (id: string) => {
-            await removeById(id);
+        async (id: IdLike) => {
+            await removeById(String(id));
         },
         [removeById]
     );

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -15,12 +15,7 @@ interface Props {
 
 const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, onSave }, ref) {
     const { form, setForm } = manager;
-
-    // Normalise: certains hooks ont `save` au lieu de `submit`
-    const normalizedManager: EntityFormManager<TagFormType> = {
-        ...manager,
-        submit: manager.submit ?? manager.save,
-    };
+    const normalizedManager = manager as EntityFormManager<TagFormType>;
 
     return (
         <EntityFormShell

--- a/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -81,34 +81,34 @@ describe("useTagForm", () => {
         expect(result.current.extras.postTags).not.toContainEqual({ postId: "p1", tagId: "t2" });
     });
 
-    it("edit préremplit le formulaire et fixe l'index", async () => {
+    it("selectById préremplit le formulaire et fixe editingId", async () => {
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
             await result.current.fetchAll();
         });
         await act(async () => {
-            await result.current.edit(0);
+            await result.current.selectById("t1");
         });
         expect(result.current.form).toEqual({ name: "Tag1", postIds: ["p1"] });
-        expect(result.current.extras.index).toBe(0);
+        expect(result.current.editingId).toBe("t1");
     });
 
-    it("cancel réinitialise le formulaire et l'index", async () => {
+    it("reset réinitialise le formulaire et l'id", async () => {
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
             await result.current.fetchAll();
         });
         await act(async () => {
-            await result.current.edit(0);
+            await result.current.selectById("t1");
         });
         act(() => {
-            result.current.cancel();
+            result.current.reset();
         });
         expect(result.current.form).toEqual({ name: "", postIds: [] });
-        expect(result.current.extras.index).toBeNull();
+        expect(result.current.editingId).toBeNull();
     });
 
-    it("remove supprime le tag et réinitialise l'index", async () => {
+    it("removeById supprime le tag et réinitialise editingId", async () => {
         const deleteTagMock = tagService.deleteCascade as ReturnType<typeof vi.fn>;
         deleteTagMock.mockResolvedValue({});
         vi.spyOn(window, "confirm").mockReturnValue(true);
@@ -117,12 +117,12 @@ describe("useTagForm", () => {
             await result.current.fetchAll();
         });
         await act(async () => {
-            await result.current.edit(0);
+            await result.current.selectById("t1");
         });
         await act(async () => {
-            await result.current.remove(0);
+            await result.current.removeById("t1");
         });
         expect(deleteTagMock).toHaveBeenCalledWith({ id: "t1" });
-        expect(result.current.extras.index).toBeNull();
+        expect(result.current.editingId).toBeNull();
     });
 });


### PR DESCRIPTION
## Description
- ajout d'un `editingId` commun aux hooks d'entités
- standardisation de l'API des hooks autour de `selectById`/`removeById`
- alignement des composants et des tests sur la nouvelle API

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue : Type error in crudService)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f25ea5b483248910234ccae5f94d