### PR TITLE
[Feat] gère les listes par id

### DIFF
--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -22,17 +22,17 @@ export default function AuthorList(props: Props) {
         <GenericList<AuthorType>
             items={props.authors}
             editingId={props.editingId}
-            getKey={(a) => a.id}
+            getId={(a) => a.id}
             renderContent={(a) => (
                 <p className="self-center">
                     <strong>{a.authorName}</strong> — {a.email}
                 </p>
             )}
             sortBy={byAlpha((a) => a.authorName)}
-            onEdit={props.onEditById}
+            onEditById={props.onEditById}
             onSave={props.onSave}
             onCancel={props.onCancel}
-            onDelete={props.onDeleteById}
+            onDeleteById={props.onDeleteById}
         />
     );
 }

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -22,17 +22,17 @@ export default function PostList(props: Props) {
         <GenericList<PostType>
             items={props.posts}
             editingId={props.editingId}
-            getKey={(p) => p.id}
+            getId={(p) => p.id}
             renderContent={(p) => (
                 <p className="self-center">
                     <strong>{p.title}</strong> (ordre : {p.order})
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEdit={props.onEditById}
+            onEditById={props.onEditById}
             onSave={props.onSave}
             onCancel={props.onCancel}
-            onDelete={props.onDeleteById}
+            onDeleteById={props.onDeleteById}
         />
     );
 }

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -21,17 +21,17 @@ export default function SectionList(props: Props) {
         <GenericList<SectionTypes>
             items={props.sections}
             editingId={props.editingId}
-            getKey={(s) => s.id}
+            getId={(s) => s.id}
             renderContent={(s) => (
                 <p className="self-center">
                     <strong>{s.title}</strong> (ordre : {s.order})
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEdit={props.onEditById}
+            onEditById={props.onEditById}
             onSave={props.onSave}
             onCancel={props.onCancel}
-            onDelete={props.onDeleteById}
+            onDeleteById={props.onDeleteById}
         />
     );
 }

--- a/src/components/Blog/manage/tags/TagList.tsx
+++ b/src/components/Blog/manage/tags/TagList.tsx
@@ -21,7 +21,7 @@ function TagListInner({ tags, editingId, onEditById, onSave, onCancel, onDeleteB
         <GenericList<TagType>
             items={tags}
             editingId={editingId}
-            getKey={(t) => t.id}
+            getId={(t) => t.id}
             renderContent={(t) => (
                 <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-blue-100 text-blue-800 text-sm font-semibold">
                     {t.name}
@@ -41,10 +41,10 @@ function TagListInner({ tags, editingId, onEditById, onSave, onCancel, onDeleteB
                 ].join(" ")
             }
             sortBy={byAlpha((t) => t.name)}
-            onEdit={onEditById}
+            onEditById={onEditById}
             onSave={onSave}
             onCancel={onCancel}
-            onDelete={onDeleteById}
+            onDeleteById={onDeleteById}
         />
     );
 }


### PR DESCRIPTION
## Description
- remplace getKey par getId dans GenericList
- renomme les callbacks en onEditById/onDeleteById
- adapte SectionList, TagList, AuthorList et PostList

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue: Type 'string' does not satisfy the constraint 'keyof ModelTypes<...>')*


------
https://chatgpt.com/codex/tasks/task_e_68a45bd8b79c8324bba83d5973948c2e