### PR TITLE
[Fix] remplace les casts any dans les tests

### DIFF
--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 import { postTagService } from "@entities/relations/postTag/service";
+import type { ListRequest, CreateRequest, DeleteRequest } from "@test/fixtures/relations";
+
+interface PostTagIds {
+    postId: string;
+    tagId: string;
+}
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const mockModel = {
@@ -28,7 +34,10 @@ describe("postTagService", () => {
     it("listByParent retourne les IDs tag", async () => {
         server.use(
             http.post("https://api.test/postTag/list", async ({ request }) => {
-                const body = (await request.json()) as any;
+                const body = (await request.json()) as ListRequest<{
+                    postId?: { eq?: string };
+                    tagId?: { eq?: string };
+                }>;
                 if (typeof body === "object" && body?.args?.filter?.postId?.eq === "post1") {
                     return HttpResponse.json({
                         data: [
@@ -46,7 +55,10 @@ describe("postTagService", () => {
     it("listByChild retourne les IDs post", async () => {
         server.use(
             http.post("https://api.test/postTag/list", async ({ request }) => {
-                const body = (await request.json()) as any;
+                const body = (await request.json()) as ListRequest<{
+                    postId?: { eq?: string };
+                    tagId?: { eq?: string };
+                }>;
                 if (typeof body === "object" && body?.args?.filter?.tagId?.eq === "tag1") {
                     return HttpResponse.json({
                         data: [
@@ -62,10 +74,10 @@ describe("postTagService", () => {
     });
 
     it("create envoie les IDs corrects", async () => {
-        let received: any;
+        let received: CreateRequest<PostTagIds>;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as CreateRequest<PostTagIds>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -74,10 +86,10 @@ describe("postTagService", () => {
     });
 
     it("delete envoie les IDs corrects", async () => {
-        let received: any;
+        let received: DeleteRequest<PostTagIds>;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as DeleteRequest<PostTagIds>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -86,10 +98,10 @@ describe("postTagService", () => {
     });
 
     it("échoue avec authMode apiKey", async () => {
-        let received: any;
+        let received: CreateRequest<PostTagIds>;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as CreateRequest<PostTagIds>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -100,10 +112,10 @@ describe("postTagService", () => {
     });
 
     it("échoue avec authMode userPool", async () => {
-        let received: any;
+        let received: DeleteRequest<PostTagIds>;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as DeleteRequest<PostTagIds>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
+import type { ListRequest, CreateRequest, DeleteRequest } from "@test/fixtures/relations";
+
+interface SectionPostIds {
+    sectionId: string;
+    postId: string;
+}
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const mockModel = {
@@ -28,7 +34,10 @@ describe("sectionPostService", () => {
     it("listByParent retourne les IDs post", async () => {
         server.use(
             http.post("https://api.test/sectionPost/list", async ({ request }) => {
-                const body = (await request.json()) as any;
+                const body = (await request.json()) as ListRequest<{
+                    sectionId?: { eq?: string };
+                    postId?: { eq?: string };
+                }>;
                 if (typeof body === "object" && body?.args?.filter?.sectionId?.eq === "section1") {
                     return HttpResponse.json({
                         data: [
@@ -49,7 +58,10 @@ describe("sectionPostService", () => {
     it("listByChild retourne les IDs section", async () => {
         server.use(
             http.post("https://api.test/sectionPost/list", async ({ request }) => {
-                const body = (await request.json()) as any;
+                const body = (await request.json()) as ListRequest<{
+                    sectionId?: { eq?: string };
+                    postId?: { eq?: string };
+                }>;
                 if (typeof body === "object" && body?.args?.filter?.postId?.eq === "post1") {
                     return HttpResponse.json({
                         data: [
@@ -68,10 +80,10 @@ describe("sectionPostService", () => {
     });
 
     it("create envoie les IDs corrects", async () => {
-        let received: any;
+        let received: CreateRequest<SectionPostIds>;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as CreateRequest<SectionPostIds>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -80,10 +92,10 @@ describe("sectionPostService", () => {
     });
 
     it("delete envoie les IDs corrects", async () => {
-        let received: any;
+        let received: DeleteRequest<SectionPostIds>;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as DeleteRequest<SectionPostIds>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -92,10 +104,10 @@ describe("sectionPostService", () => {
     });
 
     it("échoue avec authMode apiKey", async () => {
-        let received: any;
+        let received: CreateRequest<SectionPostIds>;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as CreateRequest<SectionPostIds>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -106,10 +118,10 @@ describe("sectionPostService", () => {
     });
 
     it("échoue avec authMode userPool", async () => {
-        let received: any;
+        let received: DeleteRequest<SectionPostIds>;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = (await request.json()) as any;
+                received = (await request.json()) as DeleteRequest<SectionPostIds>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );

--- a/test/fixtures/relations.ts
+++ b/test/fixtures/relations.ts
@@ -1,0 +1,14 @@
+export interface ListRequest<TFilter> {
+    args?: { filter?: TFilter };
+    opts?: { authMode?: string };
+}
+
+export interface CreateRequest<TData> {
+    data: TData;
+    opts?: { authMode?: string };
+}
+
+export interface DeleteRequest<TWhere> {
+    where: TWhere;
+    opts?: { authMode?: string };
+}


### PR DESCRIPTION
## Objectif
- supprimer les casts `as any` dans les tests
- mutualiser les types de requête pour les relations

## Tests effectués
- `yarn prettier --write test/fixtures/relations.ts src/entities/relations/postTag/__tests__/service.test.ts src/entities/relations/sectionPost/__tests__/service.test.ts src/entities/models/comment/__tests__/service.test.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a472d125f48324a1785ca00040d6bd