### PR TITLE
[Fix] simplifie la gestion d'annulation des auteurs

### DIFF
--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -51,13 +51,6 @@ export default function AuthorManagerPage() {
         setEditingId(null);
     }, [fetchAuthors]);
 
-    const handleCancel = useCallback(() => {
-        setEditingAuthor(null);
-        setEditingId(null);
-        setMode("create");
-        setForm(initialAuthorForm);
-    }, [setMode, setForm]);
-
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
@@ -71,7 +64,12 @@ export default function AuthorManagerPage() {
                     onSave={() => {
                         formRef.current?.requestSubmit();
                     }}
-                    onCancel={handleCancel}
+                    onCancel={() => {
+                        setEditingAuthor(null);
+                        setEditingId(null);
+                        setMode("create");
+                        setForm(initialAuthorForm);
+                    }}
                     onDeleteById={handleDeleteById}
                 />
             </BlogEditorLayout>


### PR DESCRIPTION
## Description
- intègre directement la logique d'annulation dans `CreateAuthor`

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Blog/manage/authors/CreateAuthor.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a483fec6a0832486f7763bada27120