### PR TITLE
[Fix] typage du body dans syncManyToMany

### DIFF
--- a/src/entities/core/utils/__tests__/syncManyToMany.test.ts
+++ b/src/entities/core/utils/__tests__/syncManyToMany.test.ts
@@ -30,7 +30,7 @@ describe("syncManyToMany", () => {
         it("listByParent retourne les IDs enfant", async () => {
             server.use(
                 http.post("https://api.test/relation", async ({ request }) => {
-                    const body = await request.json();
+                    const body = (await request.json()) as { filter?: Record<string, any> };
                     if (body.filter?.parentId?.eq === "p1") {
                         return HttpResponse.json({
                             data: [
@@ -53,7 +53,7 @@ describe("syncManyToMany", () => {
         it("listByChild retourne les IDs parent", async () => {
             server.use(
                 http.post("https://api.test/relation", async ({ request }) => {
-                    const body = await request.json();
+                    const body = (await request.json()) as { filter?: Record<string, any> };
                     if (body.filter?.childId?.eq === "c1") {
                         return HttpResponse.json({
                             data: [


### PR DESCRIPTION
## Description
- typage explicite du corps de requête dans les tests `syncManyToMany`

## Tests effectués
- `yarn prettier --write src/entities/core/utils/__tests__/syncManyToMany.test.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4842e02508324862a8d60ccc10046