### PR TITLE
[Fix] typage du service Tag

### DIFF
--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,7 +1,7 @@
 import { crudService, deleteEdges } from "@entities/core";
 import { postTagService } from "@entities/relations/postTag/service";
 
-const base = crudService("Tag", {
+const base = crudService<"Tag">("Tag", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
 


### PR DESCRIPTION
## Description
- ajoute le paramètre générique `<"Tag">` au service Tag

## Tests
- `yarn install`
- `yarn prettier --write src/entities/models/tag/service.ts`
- `yarn lint`
- `yarn build` *(échoue: Argument of type `{ [x: string]: string | null; id: string; }` ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a484875e888324b69b9933afe30c5f