### PR TITLE
[Fix] retire submit du hook tag

### DIFF
--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -59,7 +59,7 @@ export function useTagForm() {
         },
     });
 
-    const { extras, setExtras, setForm, setMode, submit, reset: formReset } = modelForm;
+    const { extras, setExtras, setForm, setMode, reset: formReset } = modelForm;
 
     const fetchAll = useCallback(async () => {
         setLoading(true);


### PR DESCRIPTION
## Objectif
- éviter de récupérer `submit` inutilement dans `useTagForm`

## Tests effectués
- `yarn lint` (⚠️ 2 warnings)
- `yarn test` (❌ erreurs de `postService.list` non défini)


------
https://chatgpt.com/codex/tasks/task_e_68a4849947a88324b794eb2c88fb212c