### PR TITLE
[Fix] replace dynamic jest-dom import

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -6,7 +6,7 @@ declare global {
 }
 
 globalThis.expect = expect;
-await import("@testing-library/jest-dom");
+import "@testing-library/jest-dom";
 
 export const server = setupServer();
 


### PR DESCRIPTION
## Summary
- replace dynamic jest-dom import with static import

## Testing
- `yarn install`
- `yarn prettier --write test/setup.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a484a01d148324bfc9d558bed09c28