### PR TITLE
[Fix] envelopper les appels delete dans deleteEdges

### DIFF
--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -19,21 +19,27 @@ export const postService = {
     async deleteCascade({ id }: { id: string }) {
         await deleteEdges(
             commentService.list,
-            (c) => commentService.delete({ id: c.id }),
+            async (c) => {
+                await commentService.delete({ id: c.id });
+            },
             "postId",
             id
         );
 
         await deleteEdges(
             postTagService.list,
-            (edge) => postTagService.delete(edge.postId, edge.tagId),
+            async (edge) => {
+                await postTagService.delete(edge.postId, edge.tagId);
+            },
             "postId",
             id
         );
 
         await deleteEdges(
             sectionPostService.list,
-            (edge) => sectionPostService.delete(edge.sectionId, edge.postId),
+            async (edge) => {
+                await sectionPostService.delete(edge.sectionId, edge.postId);
+            },
             "postId",
             id
         );

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -10,7 +10,9 @@ export const sectionService = {
     async deleteCascade({ id }: { id: string }) {
         await deleteEdges(
             sectionPostService.list,
-            (edge) => sectionPostService.delete(edge.sectionId, edge.postId),
+            async (edge) => {
+                await sectionPostService.delete(edge.sectionId, edge.postId);
+            },
             "sectionId",
             id
         );

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -10,7 +10,9 @@ export const tagService = {
     async deleteCascade({ id }: { id: string }) {
         await deleteEdges(
             postTagService.list,
-            (edge) => postTagService.delete(edge.postId, edge.tagId),
+            async (edge) => {
+                await postTagService.delete(edge.postId, edge.tagId);
+            },
             "tagId",
             id
         );


### PR DESCRIPTION
## Summary
- rendre explicites les callbacks asynchrones pour les suppressions lors des deleteEdges

## Testing
- `yarn lint`
- `yarn build`
- `yarn test` *(échoue : postService.list is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a484b401e48324936e84331f89c862