### PR TITLE
[Fix] simplifier types d'arguments CRUD

### DIFF
--- a/src/entities/core/services/crudService.ts
+++ b/src/entities/core/services/crudService.ts
@@ -8,14 +8,10 @@ type ClientModels = typeof client.models;
 type ClientModelKey = keyof ClientModels;
 
 type BaseModel<K extends ClientModelKey> = Schema[K]["type"];
-type OperationArg<T, M extends keyof T> = T[M] extends { (...args: infer P): unknown }
-    ? P[0]
-    : never;
-
-type CreateArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "create">;
-type UpdateArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "update">;
-type GetArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "get">;
-type DeleteArg<K extends ClientModelKey> = OperationArg<ClientModels[K], "delete">;
+type CreateArg<K extends ClientModelKey> = Parameters<ClientModels[K]["create"]>[0];
+type UpdateArg<K extends ClientModelKey> = Parameters<ClientModels[K]["update"]>[0];
+type GetArg<K extends ClientModelKey> = Parameters<ClientModels[K]["get"]>[0];
+type DeleteArg<K extends ClientModelKey> = Parameters<ClientModels[K]["delete"]>[0];
 
 export type AuthMode = "apiKey" | "userPool" | "identityPool" | "iam" | "lambda";
 type CrudAuth = { read?: AuthMode | AuthMode[]; write?: AuthMode | AuthMode[] };


### PR DESCRIPTION
## Résumé
- remplacer les alias d'opérations par l'utilisation directe de `Parameters`

## Tests
- `yarn lint`
- `yarn build` *(échec: Argument of type '{ [x: string]: string | null; id: string; }' is not assignable to parameter of type '{ id: string; } & Partial<Record<K, unknown>>')*

------
https://chatgpt.com/codex/tasks/task_e_68a4a1092d808324acb0868fa8436aaa