### PR TITLE
[Fix] exclusion des fichiers de test dans TypeScript

### DIFF
--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -12,6 +12,9 @@
         "node_modules",
         "amplify",
         ".Help",
-        ".next" // ← on force l’exclusion ici
+        ".next", // ← on force l’exclusion ici
+        "__tests__",
+        "**/*.test.ts",
+        "**/*.test.tsx"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,5 +42,14 @@
         "public/**/*.json",
         ".next/types/**/*.ts"
     ],
-    "exclude": ["node_modules", "amplify", ".Help/examples", ".next", "dist"]
+    "exclude": [
+        "node_modules",
+        "amplify",
+        ".Help/examples",
+        ".next",
+        "dist",
+        "__tests__",
+        "**/*.test.ts",
+        "**/*.test.tsx"
+    ]
 }


### PR DESCRIPTION
## Objectif
- empêcher l'analyse des fichiers de test par TypeScript

## Changements
- ajout des motifs `__tests__`, `**/*.test.ts`, `**/*.test.tsx` dans `exclude`

## Tests effectués
- `yarn lint`
- `yarn tsc --noEmit` *(échoue : erreurs de typage existantes, hors fichiers de test)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a11a57a88324912c1cc4e46730c0