### PR TITLE
[Fix] retire les génériques explicites des services

### DIFF
--- a/src/entities/core/services/cascade.ts
+++ b/src/entities/core/services/cascade.ts
@@ -53,6 +53,8 @@ export async function setNullBatch<T extends { id: string }, K extends keyof T &
     const { data } = await listFn({ filter: { [field]: { eq: id } } });
     const items = data ?? [];
     await withConcurrency(items, concurrency, async (item) => {
-        await updateFn({ id: item.id, [field]: null });
+        await updateFn({ id: item.id, [field]: null } as {
+            id: string;
+        } & Partial<Record<K, unknown>>);
     });
 }

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -1,7 +1,7 @@
 import { crudService, deleteEdges } from "@entities/core";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
 
-const base = crudService<"Section">("Section", {
+const base: ReturnType<typeof crudService<"Section">> = crudService("Section", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
 

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,7 +1,7 @@
 import { crudService, deleteEdges } from "@entities/core";
 import { postTagService } from "@entities/relations/postTag/service";
 
-const base = crudService<"Tag">("Tag", {
+const base: ReturnType<typeof crudService<"Tag">> = crudService("Tag", {
     auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });
 


### PR DESCRIPTION
## Description
- simplifie les services section et tag en retirant le paramètre générique explicite
- ajuste le service de cascade pour corriger le typage de `setNullBatch`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue: Type error in src/entities/core/services/crudService.ts:15:74)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a10764f0832493cb6d73b963c6e7