### PR TITLE
[Fix] cast update input in author service

### DIFF
--- a/src/entities/models/author/service.ts
+++ b/src/entities/models/author/service.ts
@@ -18,7 +18,7 @@ export const authorService = {
         await setNullBatch(
             postService.list,
             async (p) => {
-                await postService.update(p);
+                await postService.update(p as AuthorTypeUpdateInput & { id: string });
             },
             "authorId",
             id


### PR DESCRIPTION
## Summary
- cast update argument in author service

## Testing
- `yarn lint`
- `yarn build` *(fails: src/entities/core/services/cascade.ts:56:26 Type error: Argument of type '{ [x: string]: string | null; id: string; }' is not assignable to parameter of type '{ id: string; } & Partial<Record<K, unknown>>.')*


------
https://chatgpt.com/codex/tasks/task_e_68a4a0eb71308324ab772d55ae4fb073