### PR TITLE
[Feat] fabrique générique de manager

### DIFF
--- a/src/entities/core/createManager.ts
+++ b/src/entities/core/createManager.ts
@@ -1,0 +1,215 @@
+// src/entities/core/createManager.ts
+import type { ManagerContract, ManagerState, ListParams, ListResult } from "./managerContract";
+
+export interface ManagerFactoryOptions<E, F, Id = string, Extras = Record<string, unknown>> {
+    getInitialForm: () => F;
+    listEntities: (params: ListParams) => Promise<ListResult<E>>;
+    getEntityById: (id: Id) => Promise<E | null>;
+    createEntity: (data: F) => Promise<Id>;
+    updateEntity: (id: Id, data: Partial<F>, ctx: { form: F }) => Promise<void>;
+    deleteById: (id: Id) => Promise<void>;
+    loadExtras?: () => Promise<Extras>;
+    loadEntityForm?: (id: Id) => Promise<F>;
+    toForm?: (entity: E) => F | Promise<F>;
+    pageSize?: number;
+    syncManyToMany?: ManagerContract<E, F, Id, Extras>["syncManyToMany"];
+    validateField?: ManagerContract<E, F, Id, Extras>["validateField"];
+    validateForm?: ManagerContract<E, F, Id, Extras>["validateForm"];
+}
+
+export function createManager<E, F, Id = string, Extras = Record<string, unknown>>(
+    options: ManagerFactoryOptions<E, F, Id, Extras>
+): ManagerContract<E, F, Id, Extras> {
+    const {
+        getInitialForm,
+        listEntities,
+        getEntityById,
+        createEntity: createNet,
+        updateEntity: updateNet,
+        deleteById: deleteNet,
+        loadExtras,
+        loadEntityForm,
+        toForm,
+        pageSize: initialPageSize = 20,
+        syncManyToMany,
+        validateField,
+        validateForm,
+    } = options;
+
+    // ---- état interne ----
+    let entities: E[] = [];
+    let form: F = getInitialForm();
+    let extras: Extras = {} as Extras;
+
+    let editingId: Id | null = null;
+    let isEditing = false;
+
+    let loadingList = false,
+        loadingEntity = false,
+        loadingExtras = false;
+    let errorList: unknown = null,
+        errorEntity: unknown = null,
+        errorExtras: unknown = null;
+
+    let savingCreate = false,
+        savingUpdate = false,
+        savingDelete = false;
+
+    let pageSize = initialPageSize;
+    let hasNext = false;
+    const hasPrev = false; // limit-only pagination
+
+    // ---- helpers ----
+    const updateField = <K extends keyof F>(name: K, value: F[K]) => {
+        form = { ...form, [name]: value };
+    };
+
+    const patchForm = (partial: Partial<F>) => {
+        form = { ...form, ...partial };
+    };
+
+    const clearField = <K extends keyof F>(name: K) => {
+        const init = getInitialForm();
+        form = { ...form, [name]: init[name] };
+    };
+
+    const clearForm = () => {
+        form = getInitialForm();
+    };
+
+    const enterEdit = (id: Id | null) => {
+        editingId = id;
+        isEditing = id !== null;
+    };
+
+    const cancelEdit = () => {
+        clearForm();
+        enterEdit(null);
+    };
+
+    // ---- cycle de vie ----
+    const refresh = async () => {
+        loadingList = true;
+        errorList = null;
+        try {
+            const { items, nextToken } = await listEntities({ limit: pageSize });
+            entities = items;
+            hasNext = Boolean(nextToken);
+        } catch (e) {
+            errorList = e;
+        } finally {
+            loadingList = false;
+        }
+    };
+
+    const refreshExtras = async () => {
+        if (!loadExtras) return;
+        loadingExtras = true;
+        errorExtras = null;
+        try {
+            extras = await loadExtras();
+        } catch (e) {
+            errorExtras = e;
+        } finally {
+            loadingExtras = false;
+        }
+    };
+
+    const loadEntityById = async (id: Id) => {
+        loadingEntity = true;
+        errorEntity = null;
+        try {
+            let f: F;
+            if (loadEntityForm) {
+                f = await loadEntityForm(id);
+            } else {
+                const entity = await getEntityById(id);
+                if (!entity) throw new Error("Entity not found");
+                f = toForm ? await toForm(entity) : (entity as unknown as F);
+            }
+            form = f;
+            enterEdit(id);
+        } catch (e) {
+            errorEntity = e;
+        } finally {
+            loadingEntity = false;
+        }
+    };
+
+    // ---- CRUD ----
+    const createEntity = async (data: F) => {
+        savingCreate = true;
+        try {
+            const id = await createNet(data);
+            await refresh();
+            enterEdit(id);
+            return id;
+        } finally {
+            savingCreate = false;
+        }
+    };
+
+    const updateEntity = async (id: Id, data: Partial<F>) => {
+        savingUpdate = true;
+        try {
+            await updateNet(id, data, { form });
+            await refresh();
+        } finally {
+            savingUpdate = false;
+        }
+    };
+
+    const deleteById = async (id: Id) => {
+        savingDelete = true;
+        try {
+            await deleteNet(id);
+            if (editingId === id) cancelEdit();
+            await refresh();
+        } finally {
+            savingDelete = false;
+        }
+    };
+
+    // ---- snapshot ----
+    const getState = (): ManagerState<E, F, Extras> => ({
+        entities,
+        form,
+        extras,
+        editingId,
+        isEditing,
+        loadingList,
+        loadingEntity,
+        loadingExtras,
+        errorList,
+        errorEntity,
+        errorExtras,
+        savingCreate,
+        savingUpdate,
+        savingDelete,
+        pageSize,
+        hasNext,
+        hasPrev,
+    });
+
+    return {
+        getState,
+        listEntities,
+        getEntityById,
+        refresh,
+        refreshExtras,
+        loadEntityById,
+        createEntity,
+        updateEntity,
+        deleteById,
+        getInitialForm,
+        updateField,
+        patchForm,
+        clearField,
+        clearForm,
+        enterEdit,
+        cancelEdit,
+        syncManyToMany,
+        validateField,
+        validateForm,
+    };
+}

--- a/src/entities/core/index.ts
+++ b/src/entities/core/index.ts
@@ -4,3 +4,4 @@ export * from "./utils";
 export * from "./types";
 export * from "./auth";
 export * from "./managerContract";
+export * from "./createManager";

--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -1,14 +1,8 @@
 // src/entities/models/tag/manager.ts
-import type {
-    ManagerContract,
-    ManagerState,
-    ListResult,
-    MaybePromise,
-} from "@entities/core/managerContract";
+import { createManager, syncManyToMany as syncNN, type ManagerContract } from "@entities/core";
 import { tagService } from "@entities/models/tag/service";
 import { postService } from "@entities/models/post/service";
 import { postTagService } from "@entities/relations/postTag/service";
-import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
 import { initialTagForm, toTagForm, toTagCreate, toTagUpdate } from "@entities/models/tag/form";
 import type { TagType, TagFormType } from "@entities/models/tag/types";
 import type { PostType } from "@entities/models/post/types";
@@ -17,231 +11,57 @@ type Id = string;
 type Extras = { posts: PostType[] };
 
 export function createTagManager(): ManagerContract<TagType, TagFormType, Id, Extras> {
-    // ------- état interne -------
-    let entities: TagType[] = [];
-    let form: TagFormType = { ...initialTagForm };
-    let extras: Extras = { posts: [] };
-
-    let editingId: Id | null = null;
-    let isEditing = false;
-
-    let loadingList = false,
-        loadingEntity = false,
-        loadingExtras = false;
-    let errorList: unknown = null,
-        errorEntity: unknown = null,
-        errorExtras: unknown = null;
-
-    let savingCreate = false,
-        savingUpdate = false,
-        savingDelete = false;
-
-    let pageSize = 20;
-    const hasNext = false,
-        hasPrev = false; // limit-only
-
-    // ------- helpers -------
-    const getInitialForm = () => ({ ...initialTagForm });
-
-    const updateField = <K extends keyof TagFormType>(name: K, value: TagFormType[K]) => {
-        form = { ...form, [name]: value };
-    };
-
-    const patchForm = (partial: Partial<TagFormType>) => {
-        form = { ...form, ...partial };
-    };
-
-    const clearField = <K extends keyof TagFormType>(name: K) => {
-        const init = getInitialForm();
-        form = { ...form, [name]: init[name] };
-    };
-
-    const clearForm = () => {
-        form = getInitialForm();
-    };
-
-    const enterEdit = (id: Id | null) => {
-        editingId = id;
-        isEditing = id !== null;
-    };
-
-    const cancelEdit = () => {
-        clearForm();
-        enterEdit(null);
-    };
-
-    // ------- data pur -------
-    const listEntities = async (_?: { limit?: number }): Promise<ListResult<TagType>> => {
-        const { data } = await tagService.list({ limit: pageSize });
-        return { items: data ?? [] };
-    };
-
-    const getEntityById = async (id: Id) => {
-        const { data } = await tagService.get({ id });
-        return data ?? null;
-    };
-
-    // ------- cycle de vie -------
-    const refresh = async () => {
-        loadingList = true;
-        errorList = null;
-        try {
-            const { items } = await listEntities({ limit: pageSize });
-            entities = items;
-        } catch (e) {
-            errorList = e;
-        } finally {
-            loadingList = false;
-        }
-    };
-
-    const refreshExtras = async () => {
-        loadingExtras = true;
-        errorExtras = null;
-        try {
-            const { data } = await postService.list({ limit: 999 });
-            extras = { posts: data ?? [] };
-        } catch (e) {
-            errorExtras = e;
-        } finally {
-            loadingExtras = false;
-        }
-    };
-
-    const loadEntityById = async (id: Id) => {
-        loadingEntity = true;
-        errorEntity = null;
-        try {
-            const t = await getEntityById(id);
-            if (!t) throw new Error("Tag introuvable");
-            const postIds = await postTagService.listByChild(id);
-            form = toTagForm(t, postIds);
-            enterEdit(id);
-        } catch (e) {
-            errorEntity = e;
-        } finally {
-            loadingEntity = false;
-        }
-    };
-
-    // ------- CRUD (réseau) -------
-    const createEntity = async (data: TagFormType) => {
-        savingCreate = true;
-        try {
+    return createManager<TagType, TagFormType, Id, Extras>({
+        getInitialForm: () => ({ ...initialTagForm }),
+        listEntities: async ({ limit }) => {
+            const { data, nextToken } = await tagService.list({ limit });
+            return { items: data ?? [], nextToken };
+        },
+        getEntityById: async (id) => {
+            const { data } = await tagService.get({ id });
+            return data ?? null;
+        },
+        createEntity: async (data) => {
             const { data: created, errors } = await tagService.create(toTagCreate(data));
             if (!created) throw new Error(errors?.[0]?.message ?? "Création tag échouée");
-            await refresh();
-            enterEdit(created.id);
             return created.id;
-        } finally {
-            savingCreate = false;
-        }
-    };
-
-    const updateEntity = async (id: Id, data: Partial<TagFormType>) => {
-        savingUpdate = true;
-        try {
+        },
+        updateEntity: async (id, data, { form }) => {
             const { errors } = await tagService.update({
                 id,
                 ...toTagUpdate({ ...form, ...data }),
             });
             if (errors?.length) throw new Error(errors[0].message);
-            await refresh();
-        } finally {
-            savingUpdate = false;
-        }
-    };
-
-    const deleteById = async (id: Id) => {
-        savingDelete = true;
-        try {
+        },
+        deleteById: async (id) => {
             await tagService.deleteCascade({ id });
-            if (editingId === id) cancelEdit();
-            await refresh();
-        } finally {
-            savingDelete = false;
-        }
-    };
-
-    // ------- relations N:N -------
-    const syncManyToMany = async (id: Id, link: { add?: Id[]; remove?: Id[]; replace?: Id[] }) => {
-        const current = await postTagService.listByChild(id);
-        const target = link.replace ?? [
-            ...new Set([
-                ...current.filter((x) => !(link.remove ?? []).includes(x)),
-                ...(link.add ?? []),
-            ]),
-        ];
-        await syncNN(
-            current,
-            target,
-            (postId) => postTagService.create(postId, id),
-            (postId) => postTagService.delete(postId, id)
-        );
-    };
-
-    // ------- validation (stubs) -------
-    const validateField = async <K extends keyof TagFormType>(
-        _name: K,
-        _value: TagFormType[K]
-    ): MaybePromise<string | null> => null;
-
-    const validateForm = async (): MaybePromise<{
-        valid: boolean;
-        errors: Partial<Record<keyof TagFormType, string>>;
-    }> => ({ valid: true, errors: {} });
-
-    // ------- snapshot -------
-    const getState = (): ManagerState<TagType, TagFormType, Extras> => ({
-        entities,
-        form,
-        extras,
-        editingId,
-        isEditing,
-        loadingList,
-        loadingEntity,
-        loadingExtras,
-        errorList,
-        errorEntity,
-        errorExtras,
-        savingCreate,
-        savingUpdate,
-        savingDelete,
-        pageSize,
-        hasNext,
-        hasPrev,
+        },
+        loadExtras: async () => {
+            const { data } = await postService.list({ limit: 999 });
+            return { posts: data ?? [] };
+        },
+        loadEntityForm: async (id) => {
+            const tag = await tagService.get({ id }).then((r) => r.data ?? null);
+            if (!tag) throw new Error("Tag introuvable");
+            const postIds = await postTagService.listByChild(id);
+            return toTagForm(tag, postIds);
+        },
+        syncManyToMany: async (id, link) => {
+            const current = await postTagService.listByChild(id);
+            const target = link.replace ?? [
+                ...new Set([
+                    ...current.filter((x) => !(link.remove ?? []).includes(x)),
+                    ...(link.add ?? []),
+                ]),
+            ];
+            await syncNN(
+                current,
+                target,
+                (postId) => postTagService.create(postId, id),
+                (postId) => postTagService.delete(postId, id)
+            );
+        },
+        validateField: async () => null,
+        validateForm: async () => ({ valid: true, errors: {} }),
     });
-
-    return {
-        // état
-        getState,
-
-        // data pur
-        listEntities,
-        getEntityById,
-
-        // cycle de vie
-        refresh,
-        refreshExtras,
-        loadEntityById,
-
-        // CRUD
-        createEntity,
-        updateEntity,
-        deleteById,
-
-        // form local
-        getInitialForm,
-        updateField,
-        patchForm,
-        clearField,
-        clearForm,
-        enterEdit,
-        cancelEdit,
-
-        // relations & validation
-        syncManyToMany,
-        validateField,
-        validateForm,
-    };
 }


### PR DESCRIPTION
## Description
- ajoute `createManager` pour fournir les implémentations standard des managers
- refactorise le manager `Tag` pour utiliser cette fabrique

## Tests effectués
- `yarn prettier --write src/entities/core/createManager.ts src/entities/core/index.ts src/entities/models/tag/manager.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a632ed79a48324b0903ba5478f83ed