### PR TITLE
[Feat] expose l'état du manager

### DIFF
--- a/src/entities/core/managerContract.ts
+++ b/src/entities/core/managerContract.ts
@@ -4,53 +4,52 @@ export type MaybePromise<T> = T | Promise<T>;
 export type ListParams = { limit?: number };
 export type ListResult<E> = { items: E[]; nextToken?: string };
 
-export interface ManagerState<E, F, Extras> {
-    entities: E[];
-    form: F;
-    extras: Extras;
-
-    // édition
-    editingId: string | null;
-    isEditing: boolean;
-
-    // chargement/erreurs
-    loadingList: boolean;
-    loadingEntity: boolean;
-    loadingExtras: boolean;
-    errorList: unknown;
-    errorEntity: unknown;
-    errorExtras: unknown;
-
-    // sauvegardes réseau
-    savingCreate: boolean;
-    savingUpdate: boolean;
-    savingDelete: boolean;
-
-    // pagination minimale (limit-only)
-    pageSize: number;
-    hasNext: boolean;
-    hasPrev: boolean;
-}
-
 export interface ManagerContract<E, F, Id = string, Extras = Record<string, unknown>> {
-    // ---- état (snapshot) ----
-    getState(): ManagerState<E, F, Extras>;
+    // --- états exposés ---
+    readonly entities: E[];
+    readonly form: F;
+    readonly extras: Extras;
 
-    // ---- data pur ----
+    readonly editingId: Id | null;
+    readonly isEditing: boolean;
+
+    // --- chargement / erreurs ---
+    readonly loadingList: boolean;
+    readonly loadingEntity: boolean;
+    readonly loadingExtras: boolean;
+    readonly errorList: Error | null;
+    readonly errorEntity: Error | null;
+    readonly errorExtras: Error | null;
+
+    // --- sauvegardes réseau ---
+    readonly savingCreate: boolean;
+    readonly savingUpdate: boolean;
+    readonly savingDelete: boolean;
+
+    // --- pagination ---
+    readonly pageSize: number;
+    readonly nextToken: string | null;
+    readonly prevTokens: string[];
+    readonly hasNext: boolean;
+    readonly hasPrev: boolean;
+    loadNextPage(): MaybePromise<void>;
+    loadPrevPage(): MaybePromise<void>;
+
+    // --- data pur ---
     listEntities(params?: ListParams): Promise<ListResult<E>>;
     getEntityById(id: Id): Promise<E | null>;
 
-    // ---- cycle de vie ----
+    // --- cycle de vie ---
     refresh(): Promise<void>;
     refreshExtras(): Promise<void>;
     loadEntityById(id: Id): Promise<void>;
 
-    // ---- CRUD (réseau) ----
+    // --- CRUD ---
     createEntity(data: F): Promise<Id>;
     updateEntity(id: Id, data: Partial<F>): Promise<void>;
     deleteById(id: Id): Promise<void>;
 
-    // ---- form local ----
+    // --- form local ---
     getInitialForm(): F;
     updateField<K extends keyof F>(name: K, value: F[K]): void;
     patchForm(partial: Partial<F>): void;
@@ -60,10 +59,6 @@ export interface ManagerContract<E, F, Id = string, Extras = Record<string, unkn
     cancelEdit(): void;
 
     // ---- relations ----
-    /**
-     * N:N générique (diff add/remove ou replace)
-     * `options.relation` est utile pour les modèles avec plusieurs N:N (ex: Post: 'tags' | 'sections').
-     */
     syncManyToMany?(
         id: Id,
         link: { add?: Id[]; remove?: Id[]; replace?: Id[] },

--- a/src/entities/models/post/manager.ts
+++ b/src/entities/models/post/manager.ts
@@ -1,10 +1,5 @@
 // src/entities/models/post/manager.ts
-import type {
-    ManagerContract,
-    ManagerState,
-    ListResult,
-    MaybePromise,
-} from "@entities/core/managerContract";
+import type { ManagerContract, ListResult, MaybePromise } from "@entities/core/managerContract";
 import { postService } from "@entities/models/post/service";
 import { postTagService } from "@entities/relations/postTag/service";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
@@ -38,9 +33,9 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
     let loadingList = false,
         loadingEntity = false,
         loadingExtras = false;
-    let errorList: unknown = null,
-        errorEntity: unknown = null,
-        errorExtras: unknown = null;
+    let errorList: Error | null = null,
+        errorEntity: Error | null = null,
+        errorExtras: Error | null = null;
 
     let savingCreate = false,
         savingUpdate = false,
@@ -99,7 +94,7 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
             const { items } = await listEntities({ limit: pageSize });
             entities = items;
         } catch (e) {
-            errorList = e;
+            errorList = e as Error;
         } finally {
             loadingList = false;
         }
@@ -120,7 +115,7 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
                 sections: s.data ?? [],
             };
         } catch (e) {
-            errorExtras = e;
+            errorExtras = e as Error;
         } finally {
             loadingExtras = false;
         }
@@ -139,7 +134,7 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
             form = toPostForm(p, tagIds, sectionIds);
             enterEdit(id);
         } catch (e) {
-            errorEntity = e;
+            errorEntity = e as Error;
         } finally {
             loadingEntity = false;
         }
@@ -235,7 +230,7 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
     }> => ({ valid: true, errors: {} });
 
     // ------- snapshot -------
-    const getState = (): ManagerState<PostType, PostFormType, Extras> => ({
+    const getState = () => ({
         entities,
         form,
         extras,

--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -1,10 +1,5 @@
 // src/entities/models/tag/manager.ts
-import type {
-    ManagerContract,
-    ManagerState,
-    ListResult,
-    MaybePromise,
-} from "@entities/core/managerContract";
+import type { ManagerContract, ListResult, MaybePromise } from "@entities/core/managerContract";
 import { tagService } from "@entities/models/tag/service";
 import { postService } from "@entities/models/post/service";
 import { postTagService } from "@entities/relations/postTag/service";
@@ -28,9 +23,9 @@ export function createTagManager(): ManagerContract<TagType, TagFormType, Id, Ex
     let loadingList = false,
         loadingEntity = false,
         loadingExtras = false;
-    let errorList: unknown = null,
-        errorEntity: unknown = null,
-        errorExtras: unknown = null;
+    let errorList: Error | null = null,
+        errorEntity: Error | null = null,
+        errorExtras: Error | null = null;
 
     let savingCreate = false,
         savingUpdate = false,
@@ -89,7 +84,7 @@ export function createTagManager(): ManagerContract<TagType, TagFormType, Id, Ex
             const { items } = await listEntities({ limit: pageSize });
             entities = items;
         } catch (e) {
-            errorList = e;
+            errorList = e as Error;
         } finally {
             loadingList = false;
         }
@@ -102,7 +97,7 @@ export function createTagManager(): ManagerContract<TagType, TagFormType, Id, Ex
             const { data } = await postService.list({ limit: 999 });
             extras = { posts: data ?? [] };
         } catch (e) {
-            errorExtras = e;
+            errorExtras = e as Error;
         } finally {
             loadingExtras = false;
         }
@@ -118,7 +113,7 @@ export function createTagManager(): ManagerContract<TagType, TagFormType, Id, Ex
             form = toTagForm(t, postIds);
             enterEdit(id);
         } catch (e) {
-            errorEntity = e;
+            errorEntity = e as Error;
         } finally {
             loadingEntity = false;
         }
@@ -192,7 +187,7 @@ export function createTagManager(): ManagerContract<TagType, TagFormType, Id, Ex
     }> => ({ valid: true, errors: {} });
 
     // ------- snapshot -------
-    const getState = (): ManagerState<TagType, TagFormType, Extras> => ({
+    const getState = () => ({
         entities,
         form,
         extras,


### PR DESCRIPTION
## Objectif
- exposer l'état du `ManagerContract` sous forme de propriétés
- ajouter les éléments de pagination et typer les erreurs en `Error | null`

## Tests effectués
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a631fa91e88324830f717fa8a2cfd5