### PR TITLE
[Feat] expose subscribe in manager contract

### DIFF
--- a/src/entities/core/managerContract.ts
+++ b/src/entities/core/managerContract.ts
@@ -26,6 +26,7 @@ export type ManagerState<E, F, Extras = Record<string, unknown>, Id = string> = 
 
 export interface ManagerContract<E, F, Id = string, Extras = Record<string, unknown>> {
     getState(): ManagerState<E, F, Extras, Id>;
+    subscribe(listener: () => void): () => void;
 
     // --- états exposés ---
     readonly entities: E[];

--- a/src/entities/models/author/useAuthorManager.ts
+++ b/src/entities/models/author/useAuthorManager.ts
@@ -7,7 +7,7 @@ import { createAuthorManager } from "./manager";
 export function useAuthorManager() {
     const mgr = useMemo(() => createAuthorManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );

--- a/src/entities/models/comment/useCommentManager.ts
+++ b/src/entities/models/comment/useCommentManager.ts
@@ -7,7 +7,7 @@ import { createCommentManager } from "./manager";
 export function useCommentManager() {
     const mgr = useMemo(() => createCommentManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );

--- a/src/entities/models/post/usePostManager.ts
+++ b/src/entities/models/post/usePostManager.ts
@@ -7,7 +7,7 @@ import { createPostManager } from "./manager";
 export function usePostManager() {
     const mgr = useMemo(() => createPostManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );

--- a/src/entities/models/section/useSectionManager.ts
+++ b/src/entities/models/section/useSectionManager.ts
@@ -7,7 +7,7 @@ import { createSectionManager } from "./manager";
 export function useSectionManager() {
     const mgr = useMemo(() => createSectionManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );

--- a/src/entities/models/tag/useTagManager.ts
+++ b/src/entities/models/tag/useTagManager.ts
@@ -7,7 +7,7 @@ import { createTagManager } from "./manager";
 export function useTagManager() {
     const mgr = useMemo(() => createTagManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );

--- a/src/entities/models/todo/useTodoManager.ts
+++ b/src/entities/models/todo/useTodoManager.ts
@@ -7,7 +7,7 @@ import { createTodoManager } from "./manager";
 export function useTodoManager() {
     const mgr = useMemo(() => createTodoManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );

--- a/src/entities/models/userName/useUserNameManager.ts
+++ b/src/entities/models/userName/useUserNameManager.ts
@@ -7,7 +7,7 @@ import { createUserNameManager } from "./manager";
 export function useUserNameManager() {
     const mgr = useMemo(() => createUserNameManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );

--- a/src/entities/models/userProfile/useUserProfileManager.ts
+++ b/src/entities/models/userProfile/useUserProfileManager.ts
@@ -7,7 +7,7 @@ import { createUserProfileManager } from "./manager";
 export function useUserProfileManager() {
     const mgr = useMemo(() => createUserProfileManager(), []);
     const state = useSyncExternalStore(
-        mgr.subscribe?.bind(mgr) ?? (() => () => {}),
+        mgr.subscribe,
         () => mgr.getState(),
         () => mgr.getState()
     );


### PR DESCRIPTION
## Summary
- expose a subscribe API in manager contracts
- implement listener management and notifications in manager factory
- update hooks to use the new subscribe signature

## Testing
- `yarn lint`
- `yarn test` *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a645a5a528832484417199521aa6b4