### PR TITLE
[Feat] gestion de la pagination et listeners

### DIFF
--- a/src/entities/core/createManager.ts
+++ b/src/entities/core/createManager.ts
@@ -1,5 +1,5 @@
 // src/entities/core/createManager.ts
-import type { ManagerContract, ListParams, ListResult } from "./managerContract";
+import type { ManagerContract, ListParams, ListResult, ManagerState } from "./managerContract";
 
 export interface ManagerFactoryOptions<E, F, Id = string, Extras = Record<string, unknown>> {
     getInitialForm: () => F;
@@ -113,9 +113,60 @@ export function createManager<E, F, Id = string, Extras = Record<string, unknown
             const { items, nextToken: token } = await listEntities({ limit: pageSize });
             entities = items;
             nextToken = token ?? null;
-            prevTokens = [];
+            prevTokens = [null];
             hasNext = nextToken !== null;
-            hasPrev = prevTokens.length > 0;
+            hasPrev = prevTokens.length > 1;
+            notify();
+        } catch (e) {
+            errorList = e as Error;
+            notify();
+        } finally {
+            loadingList = false;
+            notify();
+        }
+    };
+
+    const loadNextPage = async () => {
+        if (!nextToken) return;
+        loadingList = true;
+        errorList = null;
+        notify();
+        try {
+            prevTokens.push(nextToken);
+            const { items, nextToken: token } = await listEntities({
+                limit: pageSize,
+                nextToken,
+            });
+            entities = items;
+            nextToken = token ?? null;
+            hasNext = nextToken !== null;
+            hasPrev = prevTokens.length > 1;
+            notify();
+        } catch (e) {
+            errorList = e as Error;
+            notify();
+        } finally {
+            loadingList = false;
+            notify();
+        }
+    };
+
+    const loadPrevPage = async () => {
+        if (prevTokens.length <= 1) return;
+        loadingList = true;
+        errorList = null;
+        notify();
+        try {
+            prevTokens.pop();
+            const token = prevTokens[prevTokens.length - 1] ?? null;
+            const { items, nextToken: tokenNext } = await listEntities({
+                limit: pageSize,
+                nextToken: token ?? undefined,
+            });
+            entities = items;
+            nextToken = tokenNext ?? null;
+            hasNext = nextToken !== null;
+            hasPrev = prevTokens.length > 1;
             notify();
         } catch (e) {
             errorList = e as Error;
@@ -225,6 +276,8 @@ export function createManager<E, F, Id = string, Extras = Record<string, unknown
         savingUpdate,
         savingDelete,
         pageSize,
+        nextToken,
+        prevTokens,
         hasNext,
         hasPrev,
     });
@@ -289,6 +342,8 @@ export function createManager<E, F, Id = string, Extras = Record<string, unknown
         get hasPrev() {
             return hasPrev;
         },
+        loadNextPage,
+        loadPrevPage,
         listEntities,
         getEntityById,
         refresh,

--- a/src/entities/core/managerContract.ts
+++ b/src/entities/core/managerContract.ts
@@ -20,6 +20,8 @@ export type ManagerState<E, F, Extras = Record<string, unknown>, Id = string> = 
     savingUpdate: boolean;
     savingDelete: boolean;
     pageSize: number;
+    nextToken: string | null;
+    prevTokens: (string | null)[];
     hasNext: boolean;
     hasPrev: boolean;
 };


### PR DESCRIPTION
## Description
- mise en place d'un système interne de listeners pour suivre les mutations d'état
- ajout de la logique de pagination avec gestion des tokens et navigation avant/arrière
- exposition des nouvelles API de pagination via l'objet manager

## Tests effectués
- `yarn install`
- `yarn lint`
- `yarn build` *(échoue : Type error dans `src/entities/models/author/form.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68a648ba18348324bda7a8861fca59ae