### PR TITLE
[Feat] utilise TagManager pour gestion des tags

### DIFF
--- a/src/entities/models/tag/useTagManager.ts
+++ b/src/entities/models/tag/useTagManager.ts
@@ -17,5 +17,5 @@ export function useTagManager() {
         void mgr.refreshExtras();
     }, [mgr]);
 
-    return { ...state, ...mgr };
+    return { state, ...mgr };
 }


### PR DESCRIPTION
## Description
- migration des composants de tags vers `useTagManager`
- remplacement des actions de formulaire par `SaveButton` et `CancelButton`

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échecs dans des fichiers non liés)*


------
https://chatgpt.com/codex/tasks/task_e_68a65867ca448324ac5f451295cd5966