### PR TITLE
[Feat] migration des posts vers usePostManager

### DIFF
--- a/src/components/Blog/manage/EntityFormShell.tsx
+++ b/src/components/Blog/manage/EntityFormShell.tsx
@@ -3,6 +3,7 @@
 
 import React, { forwardRef, type FormEvent, type Ref } from "react";
 import type { JSX } from "react";
+import { AddButton, SaveButton } from "@components/buttons";
 
 export interface EntityFormManager<F> {
     form: F;
@@ -36,8 +37,8 @@ const EntityFormShellInner = <F,>(
 ) => {
     const { submit, setForm, setMode, mode, saving, message } = manager;
 
-    async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-        e.preventDefault();
+    async function handleSubmit(e?: FormEvent<HTMLFormElement>) {
+        e?.preventDefault();
         await submit();
         setMode("create");
         setForm(initialForm);
@@ -49,13 +50,25 @@ const EntityFormShellInner = <F,>(
             <form ref={ref} onSubmit={handleSubmit} className={`grid gap-2 ${className ?? ""}`}>
                 {children}
                 <div className="flex space-x-2">
-                    <button
-                        type="submit"
-                        disabled={!!saving}
-                        className="bg-blue-500 text-white px-4 py-2 rounded"
-                    >
-                        {mode === "edit" ? submitLabel.edit : submitLabel.create}
-                    </button>
+                    {mode === "edit" ? (
+                        <SaveButton
+                            onClick={() => {
+                                void handleSubmit();
+                            }}
+                            label={submitLabel.edit}
+                            className="min-w-[120px]"
+                            disabled={!!saving}
+                        />
+                    ) : (
+                        <AddButton
+                            onClick={() => {
+                                void handleSubmit();
+                            }}
+                            label={submitLabel.create}
+                            className="min-w-[120px]"
+                            disabled={!!saving}
+                        />
+                    )}
                 </div>
             </form>
             {message && (

--- a/src/components/Blog/manage/components/FormActionButtons.tsx
+++ b/src/components/Blog/manage/components/FormActionButtons.tsx
@@ -1,5 +1,5 @@
 import ActionButtons from "./buttons/ActionButtons";
-import { EditButton, DeleteButton } from "@components/buttons";
+import { EditButton, DeleteButton, AddButton } from "@components/buttons";
 
 type IdLike = string | number;
 
@@ -27,15 +27,7 @@ export default function FormActionButtons({
     className = "",
 }: FormActionButtonsProps): React.ReactElement {
     if (isFormNew && editingId === null) {
-        return (
-            <button
-                type="button"
-                onClick={onSave}
-                className="bg-green-500 text-white py-2 rounded-lg hover:bg-green-600 transition"
-            >
-                {addButtonLabel}
-            </button>
-        );
+        return <AddButton onClick={onSave} label={addButtonLabel} className="!p-2 !h-8" />;
     }
 
     if (editingId === currentId) {

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -1,61 +1,42 @@
 // src/components/Blog/manage/posts/CreatePost.tsx (refactored)
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useRef, useCallback } from "react";
 import PostList from "./PostList";
 import PostForm from "./PostForm";
-import { type PostType } from "@entities/models/post/types";
 import RequireAdmin from "@components/RequireAdmin";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
-import { usePostForm } from "@entities/models/post/hooks";
+import { usePostManager } from "@entities/models/post";
 
 type IdLike = string | number;
 
 export default function PostManagerPage() {
-    const [editingPost, setEditingPost] = useState<PostType | null>(null);
-    const [editingId, setEditingId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
-
-    const manager = usePostForm(editingPost);
-    const {
-        extras: { posts },
-        fetchPosts,
-        selectById,
-        removeById,
-    } = manager;
-
-    useEffect(() => {
-        void fetchPosts();
-    }, [fetchPosts]);
+    const manager = usePostManager();
+    const { entities: posts, editingId, loadEntityById, deleteById, refresh, cancelEdit } = manager;
 
     const handleEditById = useCallback(
         (id: IdLike) => {
-            const post = selectById(String(id));
-            if (!post) return;
-            setEditingPost(post);
-            setEditingId(String(id));
+            void loadEntityById(String(id));
         },
-        [selectById]
+        [loadEntityById]
     );
 
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
-            await removeById(String(id));
+            await deleteById(String(id));
         },
-        [removeById]
+        [deleteById]
     );
 
     const handleSave = useCallback(async () => {
-        await fetchPosts();
-        setEditingPost(null);
-        setEditingId(null);
-    }, [fetchPosts]);
+        await refresh();
+    }, [refresh]);
 
     const handleCancel = useCallback(() => {
-        setEditingPost(null);
-        setEditingId(null);
-    }, []);
+        cancelEdit();
+    }, [cancelEdit]);
 
     return (
         <RequireAdmin>

--- a/src/components/buttons/Buttons.tsx
+++ b/src/components/buttons/Buttons.tsx
@@ -24,9 +24,10 @@ type ButtonProps = {
     className?: string;
     sx?: SxProps<Theme>;
     color?: string;
+    disabled?: boolean;
 };
 
-export function EditButton({ onClick, label, className, color }: ButtonProps) {
+export function EditButton({ onClick, label, className, color, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -34,13 +35,14 @@ export function EditButton({ onClick, label, className, color }: ButtonProps) {
             onClick={onClick}
             icon={<EditIcon fontSize="small" />}
             className={className}
+            disabled={disabled}
             variant="outlined"
             sx={getEditButtonStyles(color)}
         />
     );
 }
 
-export function DeleteButton({ onClick, label, className }: ButtonProps) {
+export function DeleteButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -49,6 +51,7 @@ export function DeleteButton({ onClick, label, className }: ButtonProps) {
             icon={<DeleteIcon fontSize="small" />}
             color="error"
             className={className}
+            disabled={disabled}
             variant="outlined"
             sx={deleteButtonStyles}
         />
@@ -70,7 +73,7 @@ export function BackButton({ href, onClick, label = "Retour", className, sx }: B
         />
     );
 }
-export function SaveButton({ onClick, label, className }: ButtonProps) {
+export function SaveButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -79,12 +82,13 @@ export function SaveButton({ onClick, label, className }: ButtonProps) {
             icon={<SaveIcon />}
             color="primary"
             className={className}
+            disabled={disabled}
             variant="contained"
         />
     );
 }
 
-export function CancelButton({ onClick, label, className }: ButtonProps) {
+export function CancelButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -93,12 +97,13 @@ export function CancelButton({ onClick, label, className }: ButtonProps) {
             icon={<CancelIcon />}
             color="inherit"
             className={className}
+            disabled={disabled}
             variant="outlined"
         />
     );
 }
 
-export function AddButton({ onClick, label, className }: ButtonProps) {
+export function AddButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -107,12 +112,13 @@ export function AddButton({ onClick, label, className }: ButtonProps) {
             icon={<AddIcon />}
             color="success"
             className={className}
+            disabled={disabled}
             variant="contained"
         />
     );
 }
 
-export function SubmitButton({ onClick, label, className }: ButtonProps) {
+export function SubmitButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -121,12 +127,13 @@ export function SubmitButton({ onClick, label, className }: ButtonProps) {
             icon={<SendIcon />}
             color="primary"
             className={className}
+            disabled={disabled}
             variant="contained"
         />
     );
 }
 
-export function ClearFieldButton({ onClick, label, className }: ButtonProps) {
+export function ClearFieldButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -135,11 +142,12 @@ export function ClearFieldButton({ onClick, label, className }: ButtonProps) {
             icon={<BackspaceIcon />}
             color="warning"
             className={className}
+            disabled={disabled}
             variant="outlined"
         />
     );
 }
-export function PowerButton({ onClick, label, className }: ButtonProps) {
+export function PowerButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -148,12 +156,13 @@ export function PowerButton({ onClick, label, className }: ButtonProps) {
             icon={<PowerIcon />}
             color="error" // rouge pour indiquer la déconnexion
             className={className}
+            disabled={disabled}
             variant="outlined"
             sx={{ ...(deleteButtonStyles || {}) }}
         />
     );
 }
-export function RefreshButton({ onClick, label, className }: ButtonProps) {
+export function RefreshButton({ onClick, label, className, disabled }: ButtonProps) {
     return (
         <ButtonBase
             label={label}
@@ -162,6 +171,7 @@ export function RefreshButton({ onClick, label, className }: ButtonProps) {
             icon={<RefreshIcon />}
             color="primary"
             className={className}
+            disabled={disabled}
             variant="contained"
         />
     );


### PR DESCRIPTION
## Résumé
- remplace le hook de formulaire des posts par usePostManager
- bascule la gestion des champs et des tags/sections sur les fonctions du manager
- utilise AddButton, SaveButton et DeleteButton avec les icônes MUI

## Tests
- `yarn install`
- `yarn prettier --write src/components/buttons/Buttons.tsx src/components/Blog/manage/components/FormActionButtons.tsx src/components/Blog/manage/EntityFormShell.tsx src/components/Blog/manage/posts/PostForm.tsx src/components/Blog/manage/posts/CreatePost.tsx`
- `yarn lint` *(sans sortie)*
- `yarn tsc` *(sans sortie)*

------
https://chatgpt.com/codex/tasks/task_e_68a6588304bc83249426377fd4e043b1