### PR TITLE
[Feat] migration du gestionnaire d'auteurs

### DIFF
--- a/ContratManager.md
+++ b/ContratManager.md
@@ -83,6 +83,7 @@ De nouvelles étapes nécessaires peuvent être ajoutées au fur et à mesure.
 ## 5. Migration UI
 
 - [ ] Remplacer anciens hooks (`useTagForm`, `usePostForm`, …) par `useXxxManager`
+- [x] `useAuthorForm` → `useAuthorManager`
 - [ ] Mappage fonctions :
     - `setForm → patchForm`
     - `handleChange → updateField`


### PR DESCRIPTION
## Description
- remplace `useAuthorForm` par `useAuthorManager`
- adapte les callbacks du gestionnaire
- ajoute les boutons de sauvegarde, annulation et suppression
- met à jour l'avancement dans `ContratManager`

## Tests effectués
- `yarn install`
- `yarn prettier --write .`
- `yarn lint`
- `yarn tsc` *(échoue: UserNameFormType requiert `id`, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a65885b590832486b74a0157b4e2c2