### PR TITLE
[Feat] passage à useSectionManager pour les sections

### DIFF
--- a/src/components/Blog/manage/components/FormActionButtons.tsx
+++ b/src/components/Blog/manage/components/FormActionButtons.tsx
@@ -1,5 +1,5 @@
 import ActionButtons from "./buttons/ActionButtons";
-import { EditButton, DeleteButton } from "@components/buttons";
+import { EditButton, DeleteButton, AddButton } from "@components/buttons";
 
 type IdLike = string | number;
 
@@ -27,15 +27,7 @@ export default function FormActionButtons({
     className = "",
 }: FormActionButtonsProps): React.ReactElement {
     if (isFormNew && editingId === null) {
-        return (
-            <button
-                type="button"
-                onClick={onSave}
-                className="bg-green-500 text-white py-2 rounded-lg hover:bg-green-600 transition"
-            >
-                {addButtonLabel}
-            </button>
-        );
+        return <AddButton onClick={onSave} label={addButtonLabel} className="!p-2 !h-8" />;
     }
 
     if (editingId === currentId) {

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -1,62 +1,52 @@
 "use client";
 
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useEffect, useRef, useCallback } from "react";
 import RequireAdmin from "@components/RequireAdmin";
 import SectionForm from "./SectionsForm";
 import SectionList from "./SectionList";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
-import { type SectionType, initialSectionForm, useSectionForm } from "@entities/models/section";
+import { useSectionManager } from "@entities/models/section";
 
 type IdLike = string | number;
 
 export default function SectionManagerPage() {
-    const [editingSection, setEditingSection] = useState<SectionType | null>(null);
-    const [editingId, setEditingId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
-    const manager = useSectionForm(editingSection);
+    const manager = useSectionManager();
     const {
-        extras: { sections },
-        fetchList,
-        selectById,
-        removeById,
-        setForm,
-        setMode,
+        entities: sections,
+        refresh,
+        loadEntityById,
+        deleteById,
+        editingId,
+        cancelEdit,
     } = manager;
 
     useEffect(() => {
-        fetchList();
-    }, [fetchList]);
+        void refresh();
+    }, [refresh]);
 
     const handleEditById = useCallback(
         (id: IdLike) => {
-            const section = selectById(String(id));
-            if (!section) return;
-            setEditingSection(section);
-            setEditingId(String(id));
+            void loadEntityById(String(id));
         },
-        [selectById]
+        [loadEntityById]
     );
 
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
-            await removeById(String(id));
+            await deleteById(String(id));
         },
-        [removeById]
+        [deleteById]
     );
 
     const handleSave = useCallback(async () => {
-        await fetchList();
-        setEditingSection(null);
-        setEditingId(null);
-    }, [fetchList]);
+        await refresh();
+    }, [refresh]);
 
     const handleCancel = useCallback(() => {
-        setEditingSection(null);
-        setEditingId(null);
-        setMode("create");
-        setForm(initialSectionForm);
-    }, [setMode, setForm]);
+        cancelEdit();
+    }, [cancelEdit]);
 
     return (
         <RequireAdmin>


### PR DESCRIPTION
## Description
- remplace `useSectionForm` par `useSectionManager`
- utilise `updateField`/`patchForm` à la place de `handleChange`/`setForm`
- intègre les boutons réutilisables pour ajouter et enregistrer

## Tests
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue: Property 'id' is missing...)*
- `yarn build` *(interrompu: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a6588bfc788324981eb081ee0f1545