### PR TITLE
[Feat] migration vers hooks managers pour profils

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { PowerButton } from "@src/components/buttons";
-import { useUserNameForm } from "@entities/models/userName/hooks";
+import { useUserNameManager } from "@entities/models/userName";
 import UserNameModal from "@src/components/Profile/UserNameModal";
 import { useUserNameRefresh } from "@entities/models/userName/useUserNameRefresh";
 
@@ -15,10 +15,8 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ className }) => {
     const { user, signOut } = useAuthenticator();
-    const {
-        form: { userName },
-        refresh,
-    } = useUserNameForm(null);
+    const { form, refresh } = useUserNameManager();
+    const { userName } = form;
 
     const [showModal, setShowModal] = useState(false);
 

--- a/src/components/Profile/UserNameModal.tsx
+++ b/src/components/Profile/UserNameModal.tsx
@@ -1,12 +1,9 @@
 // src/components/Profile/UserNameModal.tsx
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import Modal from "react-modal-component-by-jeremy";
 import UserNameManager from "./UserNameManager";
-import { useUserNameForm } from "@entities/models/userName/hooks";
-import { useUserNameRefresh } from "@entities/models/userName/useUserNameRefresh";
-import type { UserNameType } from "@entities/models/userName";
 
 interface UserNameModalProps {
     isOpen: boolean;
@@ -14,16 +11,6 @@ interface UserNameModalProps {
 }
 
 export default function UserNameModal({ isOpen, onClose }: UserNameModalProps) {
-    const [editingProfile] = useState<UserNameType | null>(null);
-    const manager = useUserNameForm(editingProfile);
-
-    // ⚡ écoute l’event bus seulement quand le modal est visible
-    useUserNameRefresh({
-        refresh: manager.refresh,
-        enabled: isOpen,
-        onAuthChange: false, // inutile ici
-    });
-
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Mon pseudo public" type="info">
             <UserNameManager />

--- a/src/entities/models/userName/form.ts
+++ b/src/entities/models/userName/form.ts
@@ -21,28 +21,33 @@ export const {
     [string[], string[]]
 >({
     zodSchema: z.object({
+        id: z.string(),
         userName: z.string(),
         commentsIds: z.array(z.string()),
         postCommentsIds: z.array(z.string()),
     }) as ZodType<UserNameFormType>,
     initialForm: {
+        id: "",
         userName: "",
         commentsIds: [],
         postCommentsIds: [],
     },
     toForm: (userName, commentsIds: string[] = [], postCommentsIds: string[] = []) => ({
+        id: userName.id,
         userName: userName.userName ?? "",
         commentsIds,
         postCommentsIds,
     }),
     toCreate: (form: UserNameFormType): UserNameTypeCreateInput => {
-        const { commentsIds, postCommentsIds, ...values } = form;
+        const { id, commentsIds, postCommentsIds, ...values } = form;
+        void id;
         void commentsIds;
         void postCommentsIds;
         return values;
     },
     toUpdate: (form: UserNameFormType): UserNameTypeUpdateInput => {
-        const { commentsIds, postCommentsIds, ...values } = form;
+        const { id, commentsIds, postCommentsIds, ...values } = form;
+        void id;
         void commentsIds;
         void postCommentsIds;
         return values;

--- a/src/entities/models/userProfile/form.ts
+++ b/src/entities/models/userProfile/form.ts
@@ -15,6 +15,7 @@ export const {
     UserProfileTypeUpdateInput
 >({
     zodSchema: z.object({
+        id: z.string(),
         firstName: z.string(),
         familyName: z.string(),
         address: z.string(),
@@ -24,6 +25,7 @@ export const {
         phoneNumber: z.string(),
     }) as ZodType<UserProfileFormType>,
     initialForm: {
+        id: "",
         firstName: "",
         familyName: "",
         address: "",
@@ -33,6 +35,7 @@ export const {
         phoneNumber: "",
     },
     toForm: (profile) => ({
+        id: profile.id,
         firstName: profile.firstName ?? "",
         familyName: profile.familyName ?? "",
         address: profile.address ?? "",
@@ -41,10 +44,14 @@ export const {
         country: profile.country ?? "",
         phoneNumber: profile.phoneNumber ?? "",
     }),
-    toCreate: (form: UserProfileFormType): UserProfileTypeUpdateInput => ({
-        ...form,
-    }),
-    toUpdate: (form: UserProfileFormType): UserProfileTypeUpdateInput => ({
-        ...form,
-    }),
+    toCreate: (form: UserProfileFormType): UserProfileTypeUpdateInput => {
+        const { id, ...values } = form;
+        void id;
+        return { ...values };
+    },
+    toUpdate: (form: UserProfileFormType): UserProfileTypeUpdateInput => {
+        const { id, ...values } = form;
+        void id;
+        return { ...values };
+    },
 });


### PR DESCRIPTION
## Description
- remplace useUserNameForm par useUserNameManager dans le header
- adopte les managers pour UserNameManager et UserProfileManager
- ajoute l'identifiant aux formulaires UserName et UserProfile

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : types manquants sur d'autres modèles)*
- `yarn build` *(interrompu après tentative)*

------
https://chatgpt.com/codex/tasks/task_e_68a658a2cb008324a13636e6fc28a57e