### PR TITLE
[Fix] prise en charge de userNameId nul dans commentService.update

### DIFF
--- a/src/entities/models/userName/manager.ts
+++ b/src/entities/models/userName/manager.ts
@@ -77,7 +77,7 @@ export function createUserNameManager() {
                 current,
                 target,
                 (commentId) => commentService.update({ id: commentId, userNameId: id }),
-                (commentId) => commentService.update({ id: commentId, userNameId: null as any })
+                (commentId) => commentService.update({ id: commentId, userNameId: null })
             );
         },
     });

--- a/src/types/models/comment.ts
+++ b/src/types/models/comment.ts
@@ -7,5 +7,7 @@ export type CommentCreateInput = {
     postId?: string;
     userNameId: string;
 };
-export type CommentUpdateInput = UpdateInput<"Comment">;
+export type CommentUpdateInput = Omit<UpdateInput<"Comment">, "userNameId"> & {
+    userNameId?: string | null;
+};
 export type CommentFormType = ModelForm<"Comment">;


### PR DESCRIPTION
## Résumé
- autorise la mise à jour d'un commentaire avec `userNameId` nul
- supprime l'usage de `any` lors de la dissociation des commentaires

## Tests
- `yarn install`
- `yarn prettier --write src/entities/models/userName/manager.ts src/types/models/comment.ts`
- `yarn lint`
- `yarn tsc` *(échoue: TS1064, TS2345, TS2322)*

------
https://chatgpt.com/codex/tasks/task_e_68a65f0fa6f08324b5f59ed68324a20b