### PR TITLE
[Fix] expose les jetons de pagination dans l'état du manager

### DIFF
--- a/src/entities/core/createManager.ts
+++ b/src/entities/core/createManager.ts
@@ -279,6 +279,8 @@ export function createManager<E, F, Id = string, Extras = Record<string, unknown
         pageSize,
         hasNext,
         hasPrev,
+        nextToken,
+        prevTokens,
     });
 
     return {


### PR DESCRIPTION
## Description
- expose `nextToken` et `prevTokens` dans `getState`

## Tests effectués
- `yarn install`
- `yarn prettier --write src/entities/core/createManager.ts`
- `yarn lint`
- `yarn tsc -p tsconfig.json --noEmit` *(échoue: plusieurs erreurs de typage existantes)*
- `yarn build` *(échoue: erreurs de typage)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ee6a6108324b462b8bc5ec668f2