### PR TITLE
[Fix] Utilisation de Error dans ManagerState

### DIFF
--- a/src/entities/core/createManager.ts
+++ b/src/entities/core/createManager.ts
@@ -309,13 +309,13 @@ export function createManager<E, F, Id = string, Extras = Record<string, unknown
             return loadingExtras;
         },
         get errorList() {
-            return errorList as Error | null;
+            return errorList;
         },
         get errorEntity() {
-            return errorEntity as Error | null;
+            return errorEntity;
         },
         get errorExtras() {
-            return errorExtras as Error | null;
+            return errorExtras;
         },
         get savingCreate() {
             return savingCreate;

--- a/src/entities/core/managerContract.ts
+++ b/src/entities/core/managerContract.ts
@@ -13,9 +13,9 @@ export type ManagerState<E, F, Extras = Record<string, unknown>, Id = string> = 
     loadingList: boolean;
     loadingEntity: boolean;
     loadingExtras: boolean;
-    errorList: unknown;
-    errorEntity: unknown;
-    errorExtras: unknown;
+    errorList: Error | null;
+    errorEntity: Error | null;
+    errorExtras: Error | null;
     savingCreate: boolean;
     savingUpdate: boolean;
     savingDelete: boolean;


### PR DESCRIPTION
## Description
- typed les champs d'erreurs de `ManagerState` en `Error | null`
- supprime les conversions inutiles dans `createManager`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : erreurs TS existantes)*
- `yarn build` *(échoue : erreurs TS existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ee7dbb08324ae6e0ebe14833a7b