### PR TITLE
[Feat] tests de pagination et validation pour Tag

### DIFF
--- a/src/entities/models/tag/__tests__/manager.test.ts
+++ b/src/entities/models/tag/__tests__/manager.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import type { TagType, TagFormType } from "@entities/models/tag/types";
+import { createTagManager } from "@entities/models/tag/manager";
+
+vi.mock("@entities/models/tag/service", () => ({
+    tagService: {
+        list: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        deleteCascade: vi.fn(),
+        get: vi.fn(),
+    },
+}));
+
+vi.mock("@entities/models/post/service", () => ({
+    postService: {
+        list: vi.fn(),
+    },
+}));
+
+vi.mock("@entities/relations/postTag/service", () => ({
+    postTagService: {
+        listByChild: vi.fn(),
+        list: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+import { tagService } from "@entities/models/tag/service";
+
+describe("tag manager", () => {
+    it("loadNextPage et loadPrevPage modifient loadingList", async () => {
+        const listMock = tagService.list as ReturnType<typeof vi.fn>;
+        listMock
+            .mockResolvedValueOnce({
+                data: [{ id: "t1", name: "Tag1" } as TagType],
+                nextToken: "token2",
+            })
+            .mockResolvedValueOnce({
+                data: [{ id: "t2", name: "Tag2" } as TagType],
+                nextToken: null,
+            })
+            .mockResolvedValueOnce({
+                data: [{ id: "t1", name: "Tag1" } as TagType],
+                nextToken: "token2",
+            });
+
+        const manager = createTagManager();
+        await manager.refresh();
+
+        const nextPromise = manager.loadNextPage();
+        expect(manager.loadingList).toBe(true);
+        await nextPromise;
+        expect(manager.loadingList).toBe(false);
+        expect(manager.entities[0].id).toBe("t2");
+        expect(manager.hasPrev).toBe(true);
+
+        const prevPromise = manager.loadPrevPage();
+        expect(manager.loadingList).toBe(true);
+        await prevPromise;
+        expect(manager.loadingList).toBe(false);
+        expect(manager.entities[0].id).toBe("t1");
+        expect(manager.hasPrev).toBe(false);
+    });
+
+    it("validateForm détecte les erreurs et savingCreate reste inchangé", async () => {
+        const listMock = tagService.list as ReturnType<typeof vi.fn>;
+        listMock.mockResolvedValue({ data: [{ id: "t1", name: "Tag1" } as TagType] });
+
+        const manager = createTagManager();
+        expect(manager.savingCreate).toBe(false);
+
+        const result = await manager.validateForm({
+            form: { id: "", name: "", postIds: [] } as TagFormType,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.name).toBe("Nom requis");
+        expect(manager.savingCreate).toBe(false);
+    });
+
+    it("createEntity active puis désactive savingCreate", async () => {
+        const listMock = tagService.list as ReturnType<typeof vi.fn>;
+        listMock.mockResolvedValue({ data: [] });
+        (tagService.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+            data: { id: "t3" },
+        });
+
+        const manager = createTagManager();
+
+        const promise = manager.createEntity({ id: "", name: "Tag3", postIds: [] });
+        expect(manager.savingCreate).toBe(true);
+        await promise;
+        expect(manager.savingCreate).toBe(false);
+    });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -6,7 +6,7 @@ declare global {
 }
 
 globalThis.expect = expect;
-import "@testing-library/jest-dom";
+await import("@testing-library/jest-dom");
 
 export const server = setupServer();
 


### PR DESCRIPTION
## Description
- ajoute des tests pour `loadNextPage`, `loadPrevPage` et `validateForm` du manager Tag
- corrige la configuration de test pour charger `jest-dom` après l'initialisation de `expect`

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : types manquants dans plusieurs managers)*
- `yarn test src/entities/models/tag/__tests__/manager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a65eeb7d5883249128e5204a14f133