### PR TITLE
[Fix] typage des champs du profil utilisateur

### DIFF
--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -76,8 +76,10 @@ export default function UserProfileManager() {
         );
     };
 
-    const handleChange = (field: keyof UserProfileFormType, value: unknown) => {
-        manager.updateField(field, value as any);
+    type UserProfileFieldValue = UserProfileFormType[keyof UserProfileFormType];
+
+    const handleChange = (field: keyof UserProfileFormType, value: UserProfileFieldValue) => {
+        manager.updateField(field, value);
     };
 
     const submit = async () => {
@@ -98,8 +100,8 @@ export default function UserProfileManager() {
         manager.patchForm(next);
     };
 
-    const saveField = async (field: keyof UserProfileFormType, value: string) => {
-        manager.updateField(field, value as any);
+    const saveField = async (field: keyof UserProfileFormType, value: UserProfileFieldValue) => {
+        manager.updateField(field, value);
         await submit();
     };
 
@@ -130,7 +132,7 @@ export default function UserProfileManager() {
                 reset={reset}
                 setForm={setForm}
                 fields={fields}
-                labels={(f) => fieldLabel(f as any)}
+                labels={fieldLabel}
                 saveField={saveField}
                 clearField={clearField}
                 // Wrapper “à la AuthorList.onDeleteById”

--- a/src/components/Profile/utilsUserProfile.tsx
+++ b/src/components/Profile/utilsUserProfile.tsx
@@ -1,5 +1,6 @@
-import { type UserProfileTypeUpdateInput } from "@entities/models/userProfile/types";
-export const label = (field: keyof UserProfileTypeUpdateInput): string => {
+import { type UserProfileFormType } from "@entities/models/userProfile";
+
+export const label = (field: keyof UserProfileFormType): string => {
     switch (field) {
         case "firstName":
             return "Prénom";


### PR DESCRIPTION
## Description
- typage strict des valeurs pour `handleChange` et `saveField`
- simplification de `fieldLabel` avec utilisation directe dans `labels`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue: erreurs de typage existantes dans le projet)*

------
https://chatgpt.com/codex/tasks/task_e_68a65f0ae7ac8324a6bd7b4ff3351f3f