### PR TITLE
[Fix] Typage UserNameManager

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -25,8 +25,8 @@ export default function UserNameManager() {
         onAuthChange: true,
     });
 
-    const handleChange = (field: keyof UserNameFormType, value: unknown) => {
-        manager.updateField(field, value as any);
+    const handleChange = <K extends keyof UserNameFormType>(field: K, value: UserNameFormType[K]) => {
+        manager.updateField(field, value);
     };
 
     const submit = async () => {
@@ -47,8 +47,8 @@ export default function UserNameManager() {
         manager.patchForm(next);
     };
 
-    const saveField = async (field: keyof UserNameFormType, value: string) => {
-        manager.updateField(field, value as any);
+    const saveField = async <K extends keyof UserNameFormType>(field: K, value: UserNameFormType[K]) => {
+        manager.updateField(field, value);
         await submit();
     };
 
@@ -80,13 +80,13 @@ export default function UserNameManager() {
             form={form}
             mode={isEditing ? "edit" : "create"}
             dirty={JSON.stringify(form) !== JSON.stringify(initialUserNameForm)}
-            handleChange={handleChange}
+            handleChange={handleChange as (field: keyof UserNameFormType, value: unknown) => void}
             submit={submit}
             reset={reset}
             setForm={setForm}
             fields={fields}
-            labels={fieldLabel as (field: keyof UserNameFormType) => string}
-            saveField={saveField}
+            labels={fieldLabel}
+            saveField={saveField as (field: keyof UserNameFormType, value: string) => Promise<void>}
             clearField={clearField}
             deleteEntity={async (id?: string) => {
                 const target = id ?? editingId ?? user?.userId ?? user?.username ?? undefined;

--- a/src/components/Profile/utilsUserName.tsx
+++ b/src/components/Profile/utilsUserName.tsx
@@ -1,6 +1,6 @@
-import { type UserNameTypeUpdateInput } from "@entities/models/userName/types";
+import { type UserNameFormType } from "@entities/models/userName";
 
-export const label = (field: keyof UserNameTypeUpdateInput): string => {
+export const label = (field: keyof UserNameFormType): string => {
     switch (field) {
         case "userName":
             return "Pseudo public";


### PR DESCRIPTION
## Objet
- Harmoniser les types de `handleChange` et `saveField`
- Typer correctement `fieldLabel` afin d'éviter les casts

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : erreurs de typage existantes)*
- `yarn build` *(échoue : `CreateTag.tsx` ne compile pas)*

------
https://chatgpt.com/codex/tasks/task_e_68a65f0e034883248991a8162e736945