### PR TITLE
[Fix] désactive allowJs et skipLibCheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
         "target": "ES2017",
         "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
+        "allowJs": false,
+        "skipLibCheck": false,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
## Résumé
- restreint la compilation aux fichiers TypeScript
- force la vérification des types des dépendances

## Tests
- `yarn lint`
- `npx tsc` *(échoué : erreurs de typage dans plusieurs gestionnaires et dépendances)*

------
https://chatgpt.com/codex/tasks/task_e_68a65f23e3a08324a5946edd0a2c54a4