### PR TITLE
[Feat] Optimise les listes du blog

### DIFF
--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -17,7 +17,7 @@ interface Props {
     onDeleteById: (id: IdLike) => void;
 }
 
-export default function AuthorList(props: Props) {
+function AuthorListInner(props: Props) {
     return (
         <GenericList<AuthorType>
             items={props.authors}
@@ -36,3 +36,5 @@ export default function AuthorList(props: Props) {
         />
     );
 }
+
+export default React.memo(AuthorListInner);

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -41,6 +41,15 @@ export default function AuthorManagerPage() {
         // la liste est rafraîchie automatiquement par le manager
     }, []);
 
+    const handleRequestSubmit = useCallback(() => {
+        formRef.current?.requestSubmit();
+    }, []);
+
+    const handleCancel = useCallback(() => {
+        cancelEdit();
+        patchForm(initialAuthorForm);
+    }, [cancelEdit, patchForm]);
+
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
@@ -51,13 +60,8 @@ export default function AuthorManagerPage() {
                     authors={authors}
                     editingId={editingId}
                     onEditById={handleEditById}
-                    onSave={() => {
-                        formRef.current?.requestSubmit();
-                    }}
-                    onCancel={() => {
-                        cancelEdit();
-                        patchForm(initialAuthorForm);
-                    }}
+                    onSave={handleRequestSubmit}
+                    onCancel={handleCancel}
                     onDeleteById={handleDeleteById}
                 />
             </BlogEditorLayout>

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -38,6 +38,10 @@ export default function PostManagerPage() {
         cancelEdit();
     }, [cancelEdit]);
 
+    const handleRequestSubmit = useCallback(() => {
+        formRef.current?.requestSubmit();
+    }, []);
+
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Gestion des Posts">
@@ -54,9 +58,7 @@ export default function PostManagerPage() {
                     posts={posts}
                     editingId={editingId}
                     onEditById={handleEditById}
-                    onSave={() => {
-                        formRef.current?.requestSubmit();
-                    }}
+                    onSave={handleRequestSubmit}
                     onCancel={handleCancel}
                     onDeleteById={handleDeleteById}
                 />

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -17,7 +17,7 @@ interface Props {
     onDeleteById: (id: IdLike) => void;
 }
 
-export default function PostList(props: Props) {
+function PostListInner(props: Props) {
     return (
         <GenericList<PostType>
             items={props.posts}
@@ -36,3 +36,5 @@ export default function PostList(props: Props) {
         />
     );
 }
+
+export default React.memo(PostListInner);

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -48,6 +48,10 @@ export default function SectionManagerPage() {
         cancelEdit();
     }, [cancelEdit]);
 
+    const handleRequestSubmit = useCallback(() => {
+        formRef.current?.requestSubmit();
+    }, []);
+
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Gestion des Sections">
@@ -63,9 +67,7 @@ export default function SectionManagerPage() {
                     sections={sections}
                     editingId={editingId}
                     onEditById={handleEditById}
-                    onSave={() => {
-                        formRef.current?.requestSubmit();
-                    }}
+                    onSave={handleRequestSubmit}
                     onCancel={handleCancel}
                     onDeleteById={handleDeleteById}
                 />

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -16,7 +16,7 @@ interface Props {
     onDeleteById: (id: IdLike) => void;
 }
 
-export default function SectionList(props: Props) {
+function SectionListInner(props: Props) {
     return (
         <GenericList<SectionType>
             items={props.sections}
@@ -35,3 +35,5 @@ export default function SectionList(props: Props) {
         />
     );
 }
+
+export default React.memo(SectionListInner);


### PR DESCRIPTION
## Description
- envelopper les listes du blog avec `React.memo`
- stabiliser les callbacks transmis grâce à `useCallback`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : types manquants dans plusieurs managers)*


------
https://chatgpt.com/codex/tasks/task_e_68a6643bc05c83249d2d642ae3d695e0