### PR TITLE
[Fix] mémorise l'état initial du UserNameManager

### DIFF
--- a/src/entities/models/userName/useUserNameManager.ts
+++ b/src/entities/models/userName/useUserNameManager.ts
@@ -6,10 +6,12 @@ import { createUserNameManager } from "./manager";
  */
 export function useUserNameManager() {
     const mgr = useMemo(() => createUserNameManager(), []);
+    const initialState = useMemo(() => mgr.getState(), [mgr]);
+    // prettier-ignore
     const state = useSyncExternalStore(
         mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
+        mgr.getState,
+        () => initialState
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Description
- optimise l'appel à `useSyncExternalStore` en mémorisant l'état initial
- préserve la logique de rafraîchissement existante

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : modules manquants)*

------
https://chatgpt.com/codex/tasks/task_e_68a6660d42fc8324804aaacad91b1c39