### PR TITLE
[Fix] mémorise le snapshot serveur des managers

### DIFF
--- a/src/entities/models/author/useAuthorManager.ts
+++ b/src/entities/models/author/useAuthorManager.ts
@@ -6,11 +6,8 @@ import { createAuthorManager } from "./manager";
  */
 export function useAuthorManager() {
     const mgr = useMemo(() => createAuthorManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();

--- a/src/entities/models/comment/useCommentManager.ts
+++ b/src/entities/models/comment/useCommentManager.ts
@@ -6,11 +6,8 @@ import { createCommentManager } from "./manager";
  */
 export function useCommentManager() {
     const mgr = useMemo(() => createCommentManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();

--- a/src/entities/models/post/usePostManager.ts
+++ b/src/entities/models/post/usePostManager.ts
@@ -6,11 +6,8 @@ import { createPostManager } from "./manager";
  */
 export function usePostManager() {
     const mgr = useMemo(() => createPostManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();

--- a/src/entities/models/section/useSectionManager.ts
+++ b/src/entities/models/section/useSectionManager.ts
@@ -6,11 +6,8 @@ import { createSectionManager } from "./manager";
  */
 export function useSectionManager() {
     const mgr = useMemo(() => createSectionManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();

--- a/src/entities/models/tag/useTagManager.ts
+++ b/src/entities/models/tag/useTagManager.ts
@@ -6,11 +6,8 @@ import { createTagManager } from "./manager";
  */
 export function useTagManager() {
     const mgr = useMemo(() => createTagManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();

--- a/src/entities/models/todo/useTodoManager.ts
+++ b/src/entities/models/todo/useTodoManager.ts
@@ -6,11 +6,8 @@ import { createTodoManager } from "./manager";
  */
 export function useTodoManager() {
     const mgr = useMemo(() => createTodoManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();

--- a/src/entities/models/userName/useUserNameManager.ts
+++ b/src/entities/models/userName/useUserNameManager.ts
@@ -6,11 +6,8 @@ import { createUserNameManager } from "./manager";
  */
 export function useUserNameManager() {
     const mgr = useMemo(() => createUserNameManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();

--- a/src/entities/models/userProfile/useUserProfileManager.ts
+++ b/src/entities/models/userProfile/useUserProfileManager.ts
@@ -6,11 +6,8 @@ import { createUserProfileManager } from "./manager";
  */
 export function useUserProfileManager() {
     const mgr = useMemo(() => createUserProfileManager(), []);
-    const state = useSyncExternalStore(
-        mgr.subscribe,
-        () => mgr.getState(),
-        () => mgr.getState()
-    );
+    const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
+    const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
         void mgr.refresh();


### PR DESCRIPTION
## Résumé
- mémorise une fois le snapshot serveur pour chaque `use*Manager`
- utilise `mgr.getState` directement avec `useSyncExternalStore`

## Tests
- `yarn lint`
- `yarn tsc` *(échoue: existing type errors)*
- `yarn test` *(échoue: import et assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68a6661c40548324842da57e746aae56