### PR TITLE
[Fix] supprimer l'id requis pour créer un profil utilisateur

### DIFF
--- a/src/entities/models/userProfile/__tests__/form.test.ts
+++ b/src/entities/models/userProfile/__tests__/form.test.ts
@@ -35,6 +35,7 @@ describe("toUserProfileForm", () => {
 describe("toUserProfileCreate / toUserProfileUpdate", () => {
     it("retourne l'objet tel quel", () => {
         const form: UserProfileFormType = {
+            id: faker.string.uuid(),
             firstName: faker.person.firstName(),
             familyName: faker.person.lastName(),
             address: faker.location.streetAddress(),
@@ -44,7 +45,10 @@ describe("toUserProfileCreate / toUserProfileUpdate", () => {
             phoneNumber: faker.phone.number(),
         };
 
-        expect(toUserProfileCreate(form)).toEqual(form);
-        expect(toUserProfileUpdate(form)).toEqual(form);
+        const expected = { ...form };
+        delete expected.id;
+
+        expect(toUserProfileCreate(form)).toEqual(expected);
+        expect(toUserProfileUpdate(form)).toEqual(expected);
     });
 });

--- a/src/entities/models/userProfile/form.ts
+++ b/src/entities/models/userProfile/form.ts
@@ -1,6 +1,11 @@
 import { z, type ZodType } from "zod";
 import { createModelForm } from "@entities/core";
-import type { UserProfileType, UserProfileFormType, UserProfileTypeUpdateInput } from "./types";
+import type {
+    UserProfileType,
+    UserProfileFormType,
+    UserProfileTypeUpdateInput,
+    UserProfileTypeOmit,
+} from "./types";
 
 export const {
     zodSchema: userProfileSchema,
@@ -11,7 +16,7 @@ export const {
 } = createModelForm<
     UserProfileType,
     UserProfileFormType,
-    UserProfileTypeUpdateInput,
+    Omit<UserProfileTypeOmit, "id">,
     UserProfileTypeUpdateInput
 >({
     zodSchema: z.object({
@@ -44,7 +49,7 @@ export const {
         country: profile.country ?? "",
         phoneNumber: profile.phoneNumber ?? "",
     }),
-    toCreate: (form: UserProfileFormType): UserProfileTypeUpdateInput => {
+    toCreate: (form: UserProfileFormType): Omit<UserProfileTypeOmit, "id"> => {
         const { id, ...values } = form;
         void id;
         return { ...values };

--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -7,7 +7,7 @@ import type {
 
 export const userProfileService = crudService<
     "UserProfile",
-    UserProfileTypeOmit & { id: string },
+    Omit<UserProfileTypeOmit, "id">,
     UserProfileTypeUpdateInput & { id: string },
     { id: string },
     { id: string }


### PR DESCRIPTION
## Résumé
- Retire l'exigence d'`id` lors de `userProfileService.create`
- Rend `toUserProfileCreate` strict sur les champs requis et met à jour les tests

## Tests effectués
- `yarn lint`
- `yarn tsc` (échec)
- `yarn test` (échec)
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a66b49d01483248a0ecdc3a1ec5224