### PR TITLE
[Fix] userNameService.create sans id

### DIFF
--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -18,7 +18,6 @@ export default function Authentication() {
             if (!userId) throw new Error("userId manquant");
             try {
                 await userNameService.create({
-                    id: userId,
                     userName: formData.username,
                 });
             } catch (err) {

--- a/src/entities/models/userName/service.ts
+++ b/src/entities/models/userName/service.ts
@@ -1,11 +1,14 @@
 // src/entities/models/userName/service.ts
 import { crudService } from "@entities/core";
-import type { UserNameTypeCreateInput, UserNameTypeUpdateInput } from "@entities/models/userName/types";
+import type {
+    UserNameTypeCreateInput,
+    UserNameTypeUpdateInput,
+} from "@entities/models/userName/types";
 
 // ✅ Lecture en public (API key), écritures avec User Pool
 export const userNameService = crudService<
     "UserName",
-    UserNameTypeCreateInput & { id: string },
+    UserNameTypeCreateInput,
     UserNameTypeUpdateInput & { id: string },
     { id: string },
     { id: string }


### PR DESCRIPTION
## Objectif
- Autoriser `userNameService.create` à accepter `UserNameTypeCreateInput` sans champ `id`
- Adapter l'appel dans `Authentication` en conséquence

## Tests effectués
- `yarn install`
- `yarn prettier src/components/Authentication/Authentication.tsx src/entities/models/userName/service.ts --write`
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : plusieurs erreurs TypeScript existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b48b07c8324a4d83e1c1313fd17