### PR TITLE
[Fix] état unique pour createManager

### DIFF
--- a/ContratManager.md
+++ b/ContratManager.md
@@ -13,6 +13,7 @@ De nouvelles étapes nécessaires peuvent être ajoutées au fur et à mesure.
 ## 2. Fabrique générique
 
 - [x] Créer `src/entities/core/createManager.ts` (gestion état local + services + flags)
+- [x] Conserver un objet `state` unique et notifications immutables
 
 ---
 


### PR DESCRIPTION
## Description
- centralise l'état dans un objet unique pour `createManager`
- mise à jour du suivi ContratManager

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue: types manquants dans certains managers)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b2d599483248284a6b97292d0da