### PR TITLE
[Feat] utiliser PostSummary dans la gestion des tags

### DIFF
--- a/src/components/Blog/manage/tags/PostTagsRelationManager.tsx
+++ b/src/components/Blog/manage/tags/PostTagsRelationManager.tsx
@@ -3,10 +3,10 @@
 import React, { useMemo } from "react";
 import ButtonBase from "@components/buttons/ButtonBase";
 import type { TagType } from "@entities/models/tag/types";
-import type { PostType } from "@entities/models/post/types";
+import type { PostSummary } from "@entities/models/post/types";
 
 interface Props {
-    posts: PostType[];
+    posts: PostSummary[];
     tags: TagType[];
     tagsForPost: (postId: string) => TagType[];
     isTagLinked: (postId: string, tagId: string) => boolean;
@@ -40,7 +40,6 @@ function PostTagsRelationManagerInner({
                         <li key={post.id} className="py-6">
                             <div className="mb-1 flex items-center gap-2">
                                 <span className="font-semibold text-lg">{post.title}</span>
-                                <span className="text-gray-400 text-xs">({post.slug})</span>
                             </div>
 
                             <div className="mb-2 text-sm text-gray-600 flex flex-wrap gap-1 items-center">

--- a/src/entities/models/post/types.ts
+++ b/src/entities/models/post/types.ts
@@ -2,6 +2,7 @@ import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/co
 import { type SeoTypeOmit } from "@entities/customTypes/seo/types";
 
 export type PostType = BaseModel<"Post">;
+export type PostSummary = Pick<PostType, "id" | "title">;
 export type PostTypeOmit = CreateOmit<"Post">;
 export type PostTypeUpdateInput = UpdateInput<"Post">;
 

--- a/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { TagType } from "@entities/models/tag/types";
-import type { PostType } from "@entities/models/post/types";
+import type { PostSummary } from "@entities/models/post/types";
 
 vi.mock("@entities/models/tag/service", () => ({
     tagService: {
@@ -36,7 +36,7 @@ const tags: TagType[] = [
     { id: "t1", name: "Tag1" } as TagType,
     { id: "t2", name: "Tag2" } as TagType,
 ];
-const posts: PostType[] = [{ id: "p1", title: "Post1" } as PostType];
+const posts: PostSummary[] = [{ id: "p1", title: "Post1" }];
 const postTags = [{ postId: "p1", tagId: "t1" }];
 
 beforeEach(() => {

--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -1,5 +1,6 @@
 import { createManager } from "@entities/core";
 import { postService } from "@entities/models/post/service";
+import type { PostSummary } from "@entities/models/post/types";
 import { postTagService } from "@entities/relations/postTag/service";
 import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
 import { tagService } from "./service";
@@ -8,7 +9,7 @@ import type { TagType, TagFormType } from "./types";
 import type { ZodObject, ZodRawShape } from "zod";
 
 type Id = string;
-type Extras = { posts: { id: string; title?: string }[] };
+type Extras = { posts: PostSummary[] };
 
 export function createTagManager() {
     async function validateName(
@@ -79,7 +80,7 @@ export function createTagManager() {
         },
         loadExtras: async () => {
             const { data } = await postService.list({ limit: 999 });
-            return { posts: data ?? [] };
+            return { posts: (data ?? []).map(({ id, title }) => ({ id, title })) };
         },
         loadEntityForm: async (id) => {
             const { data } = await tagService.get({ id });


### PR DESCRIPTION
## Résumé
- introduit le type `PostSummary` limité à `id` et `title`
- simplifie `PostTagsRelationManager` pour n'utiliser que `PostSummary`
- adapte le gestionnaire de tags et les tests associés

## Test
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue: The return type of an async function or method must be the global Promise<T> type; Argument of type 'Partial<CreateOmit<"Section">>' is not assignable to parameter of type 'Omit<SectionTypeOmit, "posts">'; Argument of type 'Partial<CreateOmit<"Tag">>' is not assignable to parameter of type 'Omit<TagTypeOmit, "posts">'; Type '{ content: string; }' is not assignable to type 'TodoFormType'; Type '{ content: string; }' is not assignable to type 'TodoFormType'; Argument of type 'UserNameTypeCreateInput' is not assignable to parameter of type 'UserNameTypeCreateInput & { id: string; }'; Argument of type 'Partial<CreateOmit<"UserProfile">>' is not assignable to parameter of type 'UserProfileTypeOmit & { id: string; }')
- `yarn test` *(échoue: Failed to resolve import "@entities/models/author/hooks" from "src/entities/models/author/__tests__/useAuthorForm.test.ts"; Failed to resolve import "@entities/models/post/hooks" from "src/entities/models/post/__tests__/usePostForm.test.ts"; Failed to resolve import "@entities/models/tag/hooks" from "src/entities/models/tag/__tests__/hooks.test.tsx"; expected { id: '', …(5) } to deeply equal { Object (authorName, avatar, ...) }; expected { id: '', …(12) } to deeply equal { …(12) }; expected { id: '', …(6) } to deeply equal { Object (slug, title, ...) }; expected { id: '', name: 'gallery', …(1) } to deeply equal { name: 'gallery', postIds: [ …(2) ] }; expected { id: '', …(3) } to deeply equal { userName: 'Robert.Kiehn86', …(2) }; expected { Object (id, firstName, ...) } to deeply equal { firstName: 'Bernadine', …(6) })

------
https://chatgpt.com/codex/tasks/task_e_68a66b3707dc8324b184dc40ded4319c