### PR TITLE
[Fix] retirer le paramètre inutile dans UserNameManager

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -25,13 +25,16 @@ export default function UserNameManager() {
         onAuthChange: true,
     });
 
-    const handleChange = <K extends keyof UserNameFormType>(field: K, value: UserNameFormType[K]) => {
+    const handleChange = <K extends keyof UserNameFormType>(
+        field: K,
+        value: UserNameFormType[K]
+    ) => {
         manager.updateField(field, value);
     };
 
     const submit = async () => {
         if (isEditing && editingId) {
-            await manager.updateEntity(editingId, form, { form });
+            await manager.updateEntity(editingId, form);
         } else {
             const id = await manager.createEntity(form);
             manager.enterEdit(id);
@@ -47,7 +50,10 @@ export default function UserNameManager() {
         manager.patchForm(next);
     };
 
-    const saveField = async <K extends keyof UserNameFormType>(field: K, value: UserNameFormType[K]) => {
+    const saveField = async <K extends keyof UserNameFormType>(
+        field: K,
+        value: UserNameFormType[K]
+    ) => {
         manager.updateField(field, value);
         await submit();
     };


### PR DESCRIPTION
## Description
- retirer le troisième argument inutile lors de l'appel à `updateEntity` dans `UserNameManager`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échec : erreurs de typage existantes)*
- `yarn build` *(échec : erreurs de typage existantes)*
- `yarn test` *(échec : imports non résolus et assertions)*


------
https://chatgpt.com/codex/tasks/task_e_68a66b394c948324808c789d0ab2a32f