### PR TITLE
[Feat] création de section sans id

### DIFF
--- a/src/entities/models/section/__tests__/form.test.ts
+++ b/src/entities/models/section/__tests__/form.test.ts
@@ -31,8 +31,9 @@ describe("toSectionForm", () => {
 });
 
 describe("toSectionCreate / toSectionUpdate", () => {
-    it("supprime postIds", () => {
+    it("supprime id et postIds", () => {
         const form: SectionFormTypes = {
+            id: faker.string.uuid(),
             slug: faker.lorem.slug(),
             title: faker.lorem.words(3),
             description: faker.lorem.sentence(),

--- a/src/entities/models/section/form.ts
+++ b/src/entities/models/section/form.ts
@@ -2,6 +2,7 @@ import { z, type ZodType } from "zod";
 import {
     type SectionType,
     type SectionFormTypes,
+    type SectionTypeCreateInput,
     type SectionTypeUpdateInput,
 } from "@entities/models/section/types";
 import { toSeoForm, initialSeoForm, seoSchema } from "@entities/customTypes/seo";
@@ -17,7 +18,7 @@ export const {
 } = createModelForm<
     SectionType,
     SectionFormTypes,
-    SectionTypeUpdateInput,
+    SectionTypeCreateInput,
     SectionTypeUpdateInput,
     [string[]]
 >({
@@ -48,9 +49,10 @@ export const {
         seo: toSeoForm((section.seo ?? {}) as SeoType),
         postIds,
     }),
-    toCreate: (form: SectionFormTypes): SectionTypeUpdateInput => {
-        const { postIds, ...values } = form;
+    toCreate: (form: SectionFormTypes): SectionTypeCreateInput => {
+        const { id: _id, postIds, ...values } = form;
         void postIds;
+        void _id;
         return values;
     },
     toUpdate: (form: SectionFormTypes): SectionTypeUpdateInput => {

--- a/src/entities/models/section/service.ts
+++ b/src/entities/models/section/service.ts
@@ -1,10 +1,13 @@
 import { crudService, deleteEdges } from "@entities/core";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
-import type { SectionTypeOmit, SectionTypeUpdateInput } from "@entities/models/section/types";
+import type {
+    SectionTypeCreateInput,
+    SectionTypeUpdateInput,
+} from "@entities/models/section/types";
 
 const base = crudService<
     "Section",
-    Omit<SectionTypeOmit, "posts">,
+    SectionTypeCreateInput,
     SectionTypeUpdateInput & { id: string },
     { id: string },
     { id: string }

--- a/src/entities/models/section/types.ts
+++ b/src/entities/models/section/types.ts
@@ -3,6 +3,7 @@ import { type SeoTypeOmit } from "@entities/customTypes/seo/types";
 
 export type SectionType = BaseModel<"Section">;
 export type SectionTypeOmit = CreateOmit<"Section">;
+export type SectionTypeCreateInput = Omit<SectionTypeOmit, "id" | "posts"> & { id?: string };
 export type SectionTypeUpdateInput = UpdateInput<"Section">;
 
 type PostCustomTypes = { seo: SeoTypeOmit };


### PR DESCRIPTION
## Description
- permettre la création d'une section sans fournir d'identifiant

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : erreurs de typage existantes)*
- `yarn build` *(échoue : erreurs de compilation)*
- `yarn test` *(échoue : suites de tests invalides)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b4197308324be0d659f651a1487