### PR TITLE
[Feat] Simplifie les posts pour le TagManager

### DIFF
--- a/src/components/Blog/manage/tags/PostTagsRelationManager.tsx
+++ b/src/components/Blog/manage/tags/PostTagsRelationManager.tsx
@@ -5,8 +5,10 @@ import ButtonBase from "@components/buttons/ButtonBase";
 import type { TagType } from "@entities/models/tag/types";
 import type { PostType } from "@entities/models/post/types";
 
+type PostSummary = Pick<PostType, "id" | "title">;
+
 interface Props {
-    posts: PostType[];
+    posts: PostSummary[];
     tags: TagType[];
     tagsForPost: (postId: string) => TagType[];
     isTagLinked: (postId: string, tagId: string) => boolean;
@@ -40,7 +42,6 @@ function PostTagsRelationManagerInner({
                         <li key={post.id} className="py-6">
                             <div className="mb-1 flex items-center gap-2">
                                 <span className="font-semibold text-lg">{post.title}</span>
-                                <span className="text-gray-400 text-xs">({post.slug})</span>
                             </div>
 
                             <div className="mb-2 text-sm text-gray-600 flex flex-wrap gap-1 items-center">

--- a/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { TagType } from "@entities/models/tag/types";
 import type { PostType } from "@entities/models/post/types";
 
+type PostSummary = Pick<PostType, "id" | "title">;
+
 vi.mock("@entities/models/tag/service", () => ({
     tagService: {
         list: vi.fn(),
@@ -36,7 +38,7 @@ const tags: TagType[] = [
     { id: "t1", name: "Tag1" } as TagType,
     { id: "t2", name: "Tag2" } as TagType,
 ];
-const posts: PostType[] = [{ id: "p1", title: "Post1" } as PostType];
+const posts: PostSummary[] = [{ id: "p1", title: "Post1" }];
 const postTags = [{ postId: "p1", tagId: "t1" }];
 
 beforeEach(() => {

--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -5,10 +5,12 @@ import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
 import { tagService } from "./service";
 import { tagSchema, initialTagForm, toTagForm, toTagCreate, toTagUpdate } from "./form";
 import type { TagType, TagFormType } from "./types";
+import type { PostType } from "@entities/models/post/types";
 import type { ZodObject, ZodRawShape } from "zod";
 
 type Id = string;
-type Extras = { posts: { id: string; title?: string }[] };
+type PostSummary = Pick<PostType, "id" | "title">;
+type Extras = { posts: PostSummary[] };
 
 export function createTagManager() {
     async function validateName(
@@ -79,7 +81,8 @@ export function createTagManager() {
         },
         loadExtras: async () => {
             const { data } = await postService.list({ limit: 999 });
-            return { posts: data ?? [] };
+            const posts: PostSummary[] = (data ?? []).map(({ id, title }) => ({ id, title }));
+            return { posts };
         },
         loadEntityForm: async (id) => {
             const { data } = await tagService.get({ id });


### PR DESCRIPTION
## Résumé
- introduit le type `PostSummary` limité à `id` et `title`
- ajuste le gestionnaire de tags pour renvoyer ce format
- nettoie l’affichage des relations article/tag

## Tests
- `yarn lint` *(blocage du processus, aucune sortie)*
- `yarn tsc` *(erreurs de compilation)*
- `yarn build` *(interrompu après le démarrage)*
- `yarn test src/entities/models/tag/__tests__/hooks.test.tsx` *(import introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a66e63606c8324b26008f712916960