### PR TITLE
[Fix] garantir un tableau vide pour les posts

### DIFF
--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -22,7 +22,7 @@ export default function CreateTagPage() {
     const { state, refresh, refreshExtras, loadEntityById, cancelEdit, deleteById } = manager;
     const {
         entities: tags,
-        extras: { posts },
+        extras: { posts = [] },
         editingId,
         loadingList,
         loadingExtras,


### PR DESCRIPTION
## Description
- assure que `CreateTag` fournit un tableau vide par défaut pour les articles
- évite les plantages de `PostTagsRelationManager` lorsque les articles sont absents

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : erreurs de typage existantes)*
- `yarn build` *(échoue : erreurs de typage existantes)*


------
https://chatgpt.com/codex/tasks/task_e_68a66e6013b083249a7a917ec3edd6b0