### PR TITLE
[Feat] assouplir création d'auteur et mise à jour de post

### DIFF
--- a/src/entities/models/author/form.ts
+++ b/src/entities/models/author/form.ts
@@ -1,5 +1,10 @@
 import { z, type ZodType } from "zod";
-import type { AuthorType, AuthorFormType, AuthorTypeUpdateInput } from "./types";
+import type {
+    AuthorType,
+    AuthorFormType,
+    AuthorTypeCreateInput,
+    AuthorTypeUpdateInput,
+} from "./types";
 import { createModelForm } from "@entities/core";
 
 export const {
@@ -11,7 +16,7 @@ export const {
 } = createModelForm<
     AuthorType,
     AuthorFormType,
-    AuthorTypeUpdateInput,
+    AuthorTypeCreateInput,
     AuthorTypeUpdateInput,
     [string[]]
 >({
@@ -39,13 +44,13 @@ export const {
         email: author.email ?? "",
         postIds,
     }),
-    toCreate: (form: AuthorFormType): AuthorTypeUpdateInput => {
-        const { postIds, ...values } = form;
+    toCreate: (form: AuthorFormType): AuthorTypeCreateInput => {
+        const { postIds, id: _id, ...values } = form;
         void postIds;
         return values;
     },
     toUpdate: (form: AuthorFormType): AuthorTypeUpdateInput => {
-        const { postIds, ...values } = form;
+        const { postIds, id: _id, ...values } = form;
         void postIds;
         return values;
     },

--- a/src/entities/models/author/manager.ts
+++ b/src/entities/models/author/manager.ts
@@ -9,7 +9,7 @@ import {
     toAuthorUpdate,
 } from "@entities/models/author/form";
 import type { AuthorType, AuthorFormType } from "@entities/models/author/types";
-import type { PostType, PostTypeUpdateInput } from "@entities/models/post/types";
+import type { PostType } from "@entities/models/post/types";
 
 type Id = string;
 type Extras = { posts: PostType[] };
@@ -67,12 +67,12 @@ export function createAuthorManager() {
                     postService.update({
                         id: postId,
                         authorId: id,
-                    } as PostTypeUpdateInput & { id: string }),
+                    }),
                 (postId) =>
                     postService.update({
                         id: postId,
                         authorId: null,
-                    } as PostTypeUpdateInput & { id: string })
+                    })
             );
         },
     });

--- a/src/entities/models/author/service.ts
+++ b/src/entities/models/author/service.ts
@@ -1,10 +1,10 @@
 import { crudService, setNullBatch } from "@entities/core";
 import { postService } from "@entities/models/post/service";
-import type { AuthorTypeOmit, AuthorTypeUpdateInput } from "@entities/models/author/types";
+import type { AuthorTypeCreateInput, AuthorTypeUpdateInput } from "@entities/models/author/types";
 
 const base = crudService<
     "Author",
-    Omit<AuthorTypeOmit, "posts">,
+    AuthorTypeCreateInput,
     AuthorTypeUpdateInput & { id: string },
     { id: string },
     { id: string }
@@ -18,7 +18,7 @@ export const authorService = {
         await setNullBatch(
             postService.list,
             async (p) => {
-                await postService.update(p as AuthorTypeUpdateInput & { id: string });
+                await postService.update({ id: p.id, authorId: null });
             },
             "authorId",
             id

--- a/src/entities/models/author/types.ts
+++ b/src/entities/models/author/types.ts
@@ -3,4 +3,5 @@ import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/co
 export type AuthorType = BaseModel<"Author">;
 export type AuthorTypeOmit = CreateOmit<"Author">;
 export type AuthorTypeUpdateInput = UpdateInput<"Author">;
+export type AuthorTypeCreateInput = Omit<AuthorTypeUpdateInput, "id" | "posts">;
 export type AuthorFormType = ModelForm<"Author", "posts", "post">;

--- a/src/entities/models/post/types.ts
+++ b/src/entities/models/post/types.ts
@@ -3,7 +3,9 @@ import { type SeoTypeOmit } from "@entities/customTypes/seo/types";
 
 export type PostType = BaseModel<"Post">;
 export type PostTypeOmit = CreateOmit<"Post">;
-export type PostTypeUpdateInput = UpdateInput<"Post">;
+export type PostTypeUpdateInput = Omit<UpdateInput<"Post">, "authorId"> & {
+    authorId?: string | null;
+};
 
 type PostCustomTypes = { seo: SeoTypeOmit };
 export type PostFormType = ModelForm<


### PR DESCRIPTION
## Description
- permettre à `AuthorService.create` d'accepter des données partielles sans `id`
- autoriser `authorId` nul dans `PostTypeUpdateInput`
- supprimer les casts inutiles dans `AuthorManager`

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échecs: plusieurs erreurs de typage hors périmètre)*
- `yarn build` *(échec: erreur de compilation Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b3d497883248d39189e9853505b