### PR TITLE
[Feat] compléter le formulaire de commentaire

### DIFF
--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -52,7 +52,7 @@ export interface UseModelFormResult<F, E> {
 
     /** Enchaîne create/update (+ syncRelations) puis refresh/load */
     submit: () => Promise<void>;
-    reset: () => void;
+    reset: () => F;
 
     setForm: React.Dispatch<React.SetStateAction<F>>;
     setExtras: React.Dispatch<React.SetStateAction<E>>;
@@ -125,10 +125,11 @@ export default function useModelForm<
         setForm((prev) => ({ ...prev, ...partial }));
     }, []);
 
-    const reset = useCallback(() => {
+    const reset = useCallback((): F => {
         setForm(initialRef.current);
         setMode(initialMode);
         setError(null);
+        return initialRef.current;
     }, [initialMode]);
 
     const adoptInitial = useCallback((next: F, nextMode: FormMode = "edit") => {

--- a/src/entities/models/comment/manager.ts
+++ b/src/entities/models/comment/manager.ts
@@ -17,18 +17,26 @@ type Id = string;
 type Extras = { userNames: UserNameType[]; todos: TodoModel[]; posts: PostType[] };
 
 const initialCommentForm: CommentFormType = {
+    id: "",
     content: "",
     todoId: "",
     postId: "",
     userNameId: "",
+    todo: null,
+    post: null,
+    userName: null,
 };
 
 function toCommentForm(comment: CommentModel): CommentFormType {
     return {
+        id: comment.id ?? "",
         content: comment.content ?? "",
         todoId: comment.todoId ?? "",
         postId: comment.postId ?? "",
         userNameId: comment.userNameId ?? "",
+        todo: comment.todo ?? null,
+        post: comment.post ?? null,
+        userName: comment.userName ?? null,
     };
 }
 


### PR DESCRIPTION
## Objectif
- ajouter les champs manquants dans le formulaire des commentaires
- adapter `reset` pour renvoyer un `CommentFormType`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échec : plusieurs erreurs de types existantes)*
- `yarn build` *(échec : erreurs de compilation Next.js)*
- `yarn test` *(échec : imports manquants et assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b3ef8a8832480b7d639e66addbd