### PR TITLE
[Fix] assouplir la création de Post

### DIFF
--- a/src/entities/models/post/__tests__/form.test.ts
+++ b/src/entities/models/post/__tests__/form.test.ts
@@ -5,6 +5,9 @@ import type { PostType, PostFormType } from "@entities/models/post/types";
 
 describe("toPostForm", () => {
     it("convertit PostType en PostFormType", () => {
+        const tagIds = [faker.string.uuid(), faker.string.uuid()];
+        const sectionIds = [faker.string.uuid()];
+
         const post = {
             slug: faker.lorem.slug(),
             title: faker.lorem.words(3),
@@ -20,12 +23,11 @@ describe("toPostForm", () => {
                 description: faker.lorem.sentence(),
                 image: faker.image.url(),
             },
+            tags: tagIds.map((tagId) => ({ tagId })),
+            sections: sectionIds.map((sectionId) => ({ sectionId })),
         } as unknown as PostType;
 
-        const tagIds = [faker.string.uuid(), faker.string.uuid()];
-        const sectionIds = [faker.string.uuid()];
-
-        const form = toPostForm(post, tagIds, sectionIds);
+        const form = toPostForm(post);
         expect(form).toEqual({
             slug: post.slug,
             title: post.title,

--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -14,13 +14,7 @@ export const {
     toForm: toPostForm,
     toCreate: toPostCreate,
     toUpdate: toPostUpdate,
-} = createModelForm<
-    PostType,
-    PostFormType,
-    PostTypeUpdateInput,
-    PostTypeUpdateInput,
-    [string[], string[]]
->({
+} = createModelForm<PostType, PostFormType, PostTypeUpdateInput, PostTypeUpdateInput>({
     zodSchema: z.object({
         id: z.string().optional(),
         slug: z.string(),
@@ -51,7 +45,7 @@ export const {
         tagIds: [],
         sectionIds: [],
     },
-    toForm: (post, tagIds: string[] = [], sectionIds: string[] = []) => ({
+    toForm: (post): PostFormType => ({
         id: post.id ?? "",
         slug: post.slug ?? "",
         title: post.title ?? "",
@@ -63,19 +57,21 @@ export const {
         videoUrl: post.videoUrl ?? "",
         type: post.type ?? "",
         seo: toSeoForm((post.seo ?? {}) as SeoType),
-        tagIds,
-        sectionIds,
+        tagIds: (post.tags ?? []).map((t) => t.tagId),
+        sectionIds: (post.sections ?? []).map((s) => s.sectionId),
     }),
     toCreate: (form: PostFormType): PostTypeUpdateInput => {
-        const { tagIds, sectionIds, ...values } = form;
+        const { id: _id, tagIds, sectionIds, ...values } = form;
         void tagIds;
         void sectionIds;
+        void _id;
         return values;
     },
     toUpdate: (form: PostFormType): PostTypeUpdateInput => {
-        const { tagIds, sectionIds, ...values } = form;
+        const { id: _id, tagIds, sectionIds, ...values } = form;
         void tagIds;
         void sectionIds;
+        void _id;
         return values;
     },
 });

--- a/src/entities/models/post/manager.ts
+++ b/src/entities/models/post/manager.ts
@@ -96,11 +96,11 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
                 );
             }
         },
-        validateField: async <K extends keyof PostFormType>(
+        validateField: <K extends keyof PostFormType>(
             _name: K,
             _value: PostFormType[K]
         ): MaybePromise<string | null> => null,
-        validateForm: async (): MaybePromise<{
+        validateForm: (): MaybePromise<{
             valid: boolean;
             errors: Partial<Record<keyof PostFormType, string>>;
         }> => ({ valid: true, errors: {} }),

--- a/src/entities/models/post/service.ts
+++ b/src/entities/models/post/service.ts
@@ -6,7 +6,7 @@ import type { PostTypeOmit, PostTypeUpdateInput } from "@entities/models/post/ty
 
 const base = crudService<
     "Post",
-    Omit<PostTypeOmit, "comments" | "author" | "sections" | "tags">,
+    Omit<PostTypeOmit, "comments" | "author" | "sections" | "tags" | "id">,
     PostTypeUpdateInput & { id: string },
     { id: string },
     { id: string }

--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -102,7 +102,7 @@ export function createTagManager() {
                 (postId) => postTagService.delete(postId, id)
             );
         },
-        validateField: async <K extends keyof TagFormType>(
+        validateField: <K extends keyof TagFormType>(
             name: K,
             value: TagFormType[K],
             ctx?: {


### PR DESCRIPTION
## Objectif
- rendre l'identifiant optionnel lors de la création d'un Post
- simplifier la conversion Post -> formulaire
- ajuster les validations de champs

## Tests effectués
- `yarn prettier --write src/entities/models/post/service.ts src/entities/models/post/form.ts src/entities/models/post/__tests__/form.test.ts src/entities/models/post/manager.ts src/entities/models/tag/manager.ts`
- `yarn lint`
- `yarn tsc` *(échec : erreurs de type existantes)*
- `yarn test` *(échec : imports introuvables et assertions)*
- `yarn build` *(échec : erreur de compilation Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b40058c83249388c9b613f04839