### PR TITLE
[Fix] accept tag creation sans id

### DIFF
--- a/src/entities/models/tag/form.ts
+++ b/src/entities/models/tag/form.ts
@@ -1,4 +1,4 @@
-import { z, type ZodType } from "zod";
+import { z } from "zod";
 import { createModelForm } from "@entities/core";
 import {
     type TagType,
@@ -6,18 +6,19 @@ import {
     type TagTypeUpdateInput,
 } from "@entities/models/tag/types";
 
+export const tagSchema = z.object({
+    id: z.string(),
+    name: z.string().min(1),
+    postIds: z.array(z.string()),
+});
+
 export const {
-    zodSchema: tagSchema,
     initialForm: initialTagForm,
     toForm: toTagForm,
     toCreate: toTagCreate,
     toUpdate: toTagUpdate,
 } = createModelForm<TagType, TagFormType, TagTypeUpdateInput, TagTypeUpdateInput, [string[]]>({
-    zodSchema: z.object({
-        id: z.string().optional(),
-        name: z.string().min(1),
-        postIds: z.array(z.string()),
-    }) as ZodType<TagFormType>,
+    zodSchema: tagSchema,
     initialForm: {
         id: "",
         name: "",

--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -5,7 +5,6 @@ import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
 import { tagService } from "./service";
 import { tagSchema, initialTagForm, toTagForm, toTagCreate, toTagUpdate } from "./form";
 import type { TagType, TagFormType } from "./types";
-import type { ZodObject, ZodRawShape } from "zod";
 
 type Id = string;
 type Extras = { posts: { id: string; title?: string }[] };
@@ -113,7 +112,7 @@ export function createTagManager() {
             }
         ) => {
             if (name === "name") return validateName(value as string, ctx);
-            const schema = (tagSchema as unknown as ZodObject<ZodRawShape>).pick({
+            const schema = tagSchema.pick({
                 [name]: true,
             } as Record<keyof TagFormType, true>);
             const result = schema.safeParse({ [name]: value });

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,10 +1,10 @@
 import { crudService, deleteEdges } from "@entities/core";
 import { postTagService } from "@entities/relations/postTag/service";
-import type { TagTypeOmit, TagTypeUpdateInput } from "@entities/models/tag/types";
+import type { TagTypeUpdateInput } from "@entities/models/tag/types";
 
 const base = crudService<
     "Tag",
-    Omit<TagTypeOmit, "posts">,
+    Omit<TagTypeUpdateInput, "posts">,
     TagTypeUpdateInput & { id: string },
     { id: string },
     { id: string }


### PR DESCRIPTION
## Description
- assouplir `tagService.create` pour accepter les données sans identifiant
- typage strict de la validation de champ des tags

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : erreurs de typage existantes)*
- `yarn build` *(échoue : erreurs de typage existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b4511dc832499cce67d871e9ec7