### PR TITLE
[Fix] ajout des champs id et comments au formulaire Todo

### DIFF
--- a/src/entities/models/todo/manager.ts
+++ b/src/entities/models/todo/manager.ts
@@ -10,11 +10,17 @@ import type {
 type Id = string;
 
 const initialTodoForm: TodoFormType = {
+    id: "",
     content: "",
+    comments: [] as unknown as TodoModel["comments"],
 };
 
 function toTodoForm(todo: TodoModel): TodoFormType {
-    return { content: todo.content ?? "" };
+    return {
+        id: todo.id ?? "",
+        content: todo.content ?? "",
+        comments: todo.comments ?? ([] as unknown as TodoModel["comments"]),
+    };
 }
 
 function toTodoCreate(form: TodoFormType): TodoCreateInput {


### PR DESCRIPTION
## Summary
- ajoute les champs `id` et `comments` au formulaire Todo
- initialise correctement ces champs lors de la réinitialisation

## Testing
- `yarn lint`
- `yarn tsc` (échoue)
- `yarn build` (échoue)
- `yarn test` (échoue)


------
https://chatgpt.com/codex/tasks/task_e_68a66b46959c8324adee381c65fed68a