### PR TITLE
[Fix] autoriser lecture API key pour userProfile

### DIFF
--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -12,5 +12,5 @@ export const userProfileService = crudService<
     { id: string },
     { id: string }
 >("UserProfile", {
-    auth: { read: "userPool", write: "userPool" },
+    auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });


### PR DESCRIPTION
## Description
- permet la lecture du profil utilisateur via `apiKey` ou `userPool`

## Tests effectués
- `yarn prettier --write src/entities/models/userProfile/service.ts`
- `yarn lint`
- `yarn tsc` *(échec : erreurs de types existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a673b6f65c832488e03fe98c194d27