### PR TITLE
[Fix] autoriser lecture publique de UserProfile

### DIFF
--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -12,5 +12,5 @@ export const userProfileService = crudService<
     { id: string },
     { id: string }
 >("UserProfile", {
-    auth: { read: "userPool", write: "userPool" },
+    auth: { read: ["apiKey", "userPool"], write: "userPool" },
 });


### PR DESCRIPTION
## Description
- permettre la lecture publique du service `userProfile`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échec: plusieurs erreurs de typage existantes)*


------
https://chatgpt.com/codex/tasks/task_e_68a6716fcb5883248e8bdbb0fa70e0f6