### PR TITLE
[Fix] Ajoute valeurs par défaut pour extras du PostForm

### DIFF
--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -29,7 +29,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
 ) {
     const {
         form,
-        extras: { authors, tags, sections },
+        extras: { authors = [], tags = [], sections = [] },
         updateField,
         patchForm,
         createEntity,


### PR DESCRIPTION
### Description
- Initialise `authors`, `tags` et `sections` à des tableaux vides lors de la déstructuration du `manager` dans `PostForm` afin d'éviter des erreurs lorsque les données ne sont pas encore chargées.

### Tests effectués
- `yarn lint`
- `yarn tsc` *(échoué : plusieurs erreurs de typage existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a66dc1fd188324b217fb9f7e217438