### PR TITLE
[Feat] restreindre PostTagsRelationManager au résumé des posts

### DIFF
--- a/src/components/Blog/manage/tags/PostTagsRelationManager.tsx
+++ b/src/components/Blog/manage/tags/PostTagsRelationManager.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo } from "react";
 import ButtonBase from "@components/buttons/ButtonBase";
 import type { TagType } from "@entities/models/tag/types";
-import type { PostSummary } from "@entities/models/post/types";
+import type { PostType } from "@entities/models/post/types";
 
 type PostSummary = Pick<PostType, "id" | "title">;
 


### PR DESCRIPTION
## Summary
- définir un type `PostSummary` local (id et title)
- limiter `PostTagsRelationManager` à ces champs

## Testing
- `yarn prettier --write src/components/Blog/manage/tags/PostTagsRelationManager.tsx`
- `yarn lint` *(erreurs existantes dans d'autres fichiers, ex. unused imports)*
- `yarn tsc` *(erreurs de typage dans des modules non modifiés)*

------
https://chatgpt.com/codex/tasks/task_e_68a67999e3d483248fb9f8c916c1da18