### PR TITLE
[Fix] Remove apiKey fallback for userProfile service

### DIFF
--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -12,5 +12,5 @@ export const userProfileService = crudService<
     { id: string },
     { id: string }
 >("UserProfile", {
-    auth: { read: ["apiKey", "userPool"], write: "userPool" },
+    auth: { read: "userPool", write: "userPool" },
 });


### PR DESCRIPTION
## Objective
- restrict userProfile service auth to userPool

## Testing
- `yarn prettier src/entities/models/userProfile/service.ts -w`
- `yarn lint` *(échoue: unused imports dans src/entities/models/tag/manager.ts)*
- `yarn tsc` *(échoue: type errors dans plusieurs modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a6822d0ea08324b6e5614dd1c8c42a