### PR TITLE
[Feat] Utilisation de l’ID utilisateur dans UserProfileManager

### DIFF
--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -25,7 +25,7 @@ const fields: (keyof UserProfileFormType)[] = [
 
 export default function UserProfileManager() {
     const { user } = useAuthenticator();
-    const manager = useUserProfileManager();
+    const manager = useUserProfileManager(user?.userId);
     const { form, isEditing, editingId } = manager;
 
     const handleDeleteById = useCallback(

--- a/src/entities/models/userProfile/useUserProfileManager.ts
+++ b/src/entities/models/userProfile/useUserProfileManager.ts
@@ -4,15 +4,18 @@ import { createUserProfileManager } from "./manager";
 /**
  * Hook React pour gérer l'entité UserProfile.
  */
-export function useUserProfileManager() {
+export function useUserProfileManager(userId?: string | null) {
     const mgr = useMemo(() => createUserProfileManager(), []);
     const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
     const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
     useEffect(() => {
-        void mgr.refresh();
-        void mgr.refreshExtras();
-    }, [mgr]);
+        if (userId) {
+            mgr.enterEdit(userId);
+            void mgr.refresh();
+            void mgr.refreshExtras();
+        }
+    }, [mgr, userId]);
 
     return { ...state, ...mgr };
 }


### PR DESCRIPTION
## Objectif
- Passer l'identifiant utilisateur au hook de gestion de profil.

## Changements
- `useUserProfileManager` accepte un paramètre `userId` et déclenche l'édition et le rafraîchissement uniquement lorsque l'identifiant est présent.
- `UserProfileManager.tsx` transmet `user.userId` au hook.

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Profile/UserProfileManager.tsx src/entities/models/userProfile/useUserProfileManager.ts`
- `yarn lint` *(échoue : erreurs existantes dans le projet)*
- `yarn tsc -p tsconfig.json` *(échoue : erreurs de typage existantes)*


------
https://chatgpt.com/codex/tasks/task_e_68a6823cd6588324a4226424dccad73c