### PR TITLE
[Fix] conserver l'identifiant du profil

### DIFF
--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -91,7 +91,7 @@ export default function UserNameManager() {
             saveField={saveField}
             clearField={clearField}
             deleteEntity={async (id?: string) => {
-                const target = id ?? editingId ?? user?.userId ?? user?.username ?? undefined;
+                const target = id ?? editingId ?? user?.userId ?? undefined;
                 if (!target) return;
                 await handleDeleteById(target);
             }}

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -86,8 +86,9 @@ export default function UserProfileManager() {
         if (isEditing && editingId) {
             await manager.updateEntity(editingId, form);
         } else {
-            const id = await manager.createEntity(form);
-            manager.enterEdit(id);
+            const id = await manager.createEntity({ ...form, id: user.userId });
+            void id;
+            manager.enterEdit(user.userId);
         }
     };
 
@@ -137,7 +138,7 @@ export default function UserProfileManager() {
                 clearField={clearField}
                 // Wrapper “à la AuthorList.onDeleteById”
                 deleteEntity={async (id?: string) => {
-                    const target = id ?? editingId ?? user?.userId ?? user?.username ?? undefined;
+                    const target = id ?? editingId ?? user?.userId ?? undefined;
                     if (!target) return;
                     await handleDeleteById(target);
                 }}

--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -1,14 +1,11 @@
 import { createManager } from "@entities/core";
 import { postService } from "@entities/models/post/service";
-import type { PostSummary } from "@entities/models/post/types";
 import { postTagService } from "@entities/relations/postTag/service";
 import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
 import { tagService } from "./service";
 import { tagSchema, initialTagForm, toTagForm, toTagCreate, toTagUpdate } from "./form";
 import type { TagType, TagFormType } from "./types";
 import type { PostType } from "@entities/models/post/types";
-import type { ZodObject, ZodRawShape } from "zod";
-
 
 type Id = string;
 type PostSummary = Pick<PostType, "id" | "title">;
@@ -86,7 +83,6 @@ export function createTagManager() {
             const { data } = await postService.list({ limit: 999 });
             const posts: PostSummary[] = (data ?? []).map(({ id, title }) => ({ id, title }));
             return { posts };
-
         },
         loadEntityForm: async (id) => {
             const { data } = await tagService.get({ id });

--- a/src/entities/models/userProfile/form.ts
+++ b/src/entities/models/userProfile/form.ts
@@ -16,7 +16,7 @@ export const {
 } = createModelForm<
     UserProfileType,
     UserProfileFormType,
-    Omit<UserProfileTypeOmit, "id">,
+    UserProfileTypeOmit,
     UserProfileTypeUpdateInput
 >({
     zodSchema: z.object({
@@ -49,11 +49,7 @@ export const {
         country: profile.country ?? "",
         phoneNumber: profile.phoneNumber ?? "",
     }),
-    toCreate: (form: UserProfileFormType): Omit<UserProfileTypeOmit, "id"> => {
-        const { id, ...values } = form;
-        void id;
-        return { ...values };
-    },
+    toCreate: (form: UserProfileFormType): UserProfileTypeOmit => ({ ...form }),
     toUpdate: (form: UserProfileFormType): UserProfileTypeUpdateInput => {
         const { id, ...values } = form;
         void id;

--- a/src/entities/models/userProfile/manager.ts
+++ b/src/entities/models/userProfile/manager.ts
@@ -22,9 +22,9 @@ export function createUserProfileManager() {
             return (data ?? null) as UserProfileType | null;
         },
         createEntity: async (form) => {
-            const { data, errors } = await userProfileService.create(toUserProfileCreate(form));
+            const { errors } = await userProfileService.create(toUserProfileCreate(form));
             if (errors?.length) throw new Error(errors[0].message);
-            return data.id;
+            return form.id;
         },
         updateEntity: async (id, data, { form }) => {
             const { errors } = await userProfileService.update({

--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -7,7 +7,7 @@ import type {
 
 export const userProfileService = crudService<
     "UserProfile",
-    Omit<UserProfileTypeOmit, "id">,
+    UserProfileTypeOmit,
     UserProfileTypeUpdateInput & { id: string },
     { id: string },
     { id: string }


### PR DESCRIPTION
## Description
- conserver l'id lors de la création d'un profil utilisateur
- utiliser uniquement `user.userId` pour les opérations liées aux profils et pseudos
- ajuster le gestionnaire de profil pour renvoyer l'id fourni

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoué : erreurs de typage existantes)*
- `yarn build` *(échoué : erreurs de typage existantes)*


------
https://chatgpt.com/codex/tasks/task_e_68a68234bfd083248254ec20086b72a5