### PR TITLE
[Fix] accès privé pour userName

### DIFF
--- a/src/entities/models/userName/service.ts
+++ b/src/entities/models/userName/service.ts
@@ -5,7 +5,7 @@ import type {
     UserNameTypeUpdateInput,
 } from "@entities/models/userName/types";
 
-// ✅ Lecture en public (API key), écritures avec User Pool
+// ✅ Lecture et écriture privées via User Pool
 export const userNameService = crudService<
     "UserName",
     UserNameTypeCreateInput,
@@ -13,5 +13,5 @@ export const userNameService = crudService<
     { id: string },
     { id: string }
 >("UserName", {
-    auth: { read: "apiKey", write: "userPool" },
+    auth: { read: "userPool", write: "userPool" },
 });


### PR DESCRIPTION
## Description
- restreindre la lecture du service userName au pool d'utilisateurs
- documenter l'accès privé via commentaire

## Tests effectués
- `yarn lint` *(échoue : unused imports et déclarations non utilisées)*
- `yarn tsc` *(échoue : erreurs de typage existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a682507f048324a08b3a54a8d14d32