### PR TITLE
[Feat] conserve l'id lors de la création du pseudo

### DIFF
--- a/ContratManager.md
+++ b/ContratManager.md
@@ -52,6 +52,7 @@ De nouvelles étapes nécessaires peuvent être ajoutées au fur et à mesure.
 - [x] Implémenter `ManagerContract<UserName, UserNameForm>`
 - [x] CRUD + form local (`updateField/patchForm/clear*`)
 - [x] `loadEntityById` (profil simple)
+- [x] `createEntity` renseigne `id` via le `sub` courant
 
 ### UserProfile
 

--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -18,6 +18,7 @@ export default function Authentication() {
             if (!userId) throw new Error("userId manquant");
             try {
                 await userNameService.create({
+                    id: userId,
                     userName: formData.username,
                 });
             } catch (err) {

--- a/src/entities/models/userName/__tests__/form.test.ts
+++ b/src/entities/models/userName/__tests__/form.test.ts
@@ -6,6 +6,7 @@ import type { UserNameType, UserNameFormType } from "@entities/models/userName/t
 describe("toUserNameForm", () => {
     it("convertit UserNameType en UserNameFormType", () => {
         const userName = {
+            id: faker.string.uuid(),
             userName: faker.internet.username(),
         } as unknown as UserNameType;
 
@@ -13,6 +14,7 @@ describe("toUserNameForm", () => {
         const postCommentsIds = [faker.string.uuid()];
         const form = toUserNameForm(userName, commentsIds, postCommentsIds);
         expect(form).toEqual({
+            id: userName.id,
             userName: userName.userName,
             commentsIds,
             postCommentsIds,
@@ -21,15 +23,17 @@ describe("toUserNameForm", () => {
 });
 
 describe("toUserNameCreate / toUserNameUpdate", () => {
-    it("supprime commentsIds et postCommentsIds", () => {
+    it("conserve id et supprime commentsIds et postCommentsIds", () => {
         const form: UserNameFormType = {
+            id: faker.string.uuid(),
             userName: faker.internet.username(),
             commentsIds: [faker.string.uuid()],
             postCommentsIds: [faker.string.uuid()],
         };
 
-        const expected = { userName: form.userName };
-        expect(toUserNameCreate(form)).toEqual(expected);
-        expect(toUserNameUpdate(form)).toEqual(expected);
+        const expectedCreate = { id: form.id, userName: form.userName };
+        const expectedUpdate = { userName: form.userName };
+        expect(toUserNameCreate(form)).toEqual(expectedCreate);
+        expect(toUserNameUpdate(form)).toEqual(expectedUpdate);
     });
 });

--- a/src/entities/models/userName/form.ts
+++ b/src/entities/models/userName/form.ts
@@ -16,7 +16,7 @@ export const {
 } = createModelForm<
     UserNameType,
     UserNameFormType,
-    UserNameTypeCreateInput,
+    UserNameTypeCreateInput & { id: string },
     UserNameTypeUpdateInput,
     [string[], string[]]
 >({
@@ -38,9 +38,8 @@ export const {
         commentsIds,
         postCommentsIds,
     }),
-    toCreate: (form: UserNameFormType): UserNameTypeCreateInput => {
-        const { id, commentsIds, postCommentsIds, ...values } = form;
-        void id;
+    toCreate: (form: UserNameFormType): UserNameTypeCreateInput & { id: string } => {
+        const { commentsIds, postCommentsIds, ...values } = form;
         void commentsIds;
         void postCommentsIds;
         return values;

--- a/src/entities/models/userName/manager.ts
+++ b/src/entities/models/userName/manager.ts
@@ -2,6 +2,7 @@ import { createManager } from "@entities/core";
 import { userNameService } from "@entities/models/userName/service";
 import { commentService } from "@entities/models/comment/service";
 import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
+import { getCurrentUser } from "aws-amplify/auth";
 import {
     initialUserNameForm,
     toUserNameForm,
@@ -26,7 +27,10 @@ export function createUserNameManager() {
             return (data ?? null) as UserNameType | null;
         },
         createEntity: async (form) => {
-            const { data, errors } = await userNameService.create(toUserNameCreate(form));
+            const { userId } = await getCurrentUser();
+            const { data, errors } = await userNameService.create(
+                toUserNameCreate({ ...form, id: userId })
+            );
             if (errors?.length) throw new Error(errors[0].message);
             return data.id;
         },

--- a/src/entities/models/userName/service.ts
+++ b/src/entities/models/userName/service.ts
@@ -8,7 +8,7 @@ import type {
 // ✅ Lecture en public (API key), écritures avec User Pool
 export const userNameService = crudService<
     "UserName",
-    UserNameTypeCreateInput,
+    UserNameTypeCreateInput & { id: string },
     UserNameTypeUpdateInput & { id: string },
     { id: string },
     { id: string }


### PR DESCRIPTION
## Description
- conserve l'identifiant dans `toUserNameCreate`
- le service `userName` exige désormais un `id` à la création
- `createEntity` renseigne l'`id` depuis le `sub` courant
- ajustements de l'inscription et des tests

## Tests effectués
- `yarn lint` *(erreurs existantes : import inutilisé, hooks, etc.)*
- `yarn tsc` *(erreurs existantes : types non conformes dans d'autres modules)*
- `yarn test` *(échecs liés à des imports manquants et attentes de tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a68251f67483248feb4b1162ed9ddc