### PR TITLE
[Feat] Gestion du pseudo selon l'utilisateur

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,7 +15,8 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ className }) => {
     const { user, signOut } = useAuthenticator();
-    const { form, refresh } = useUserNameManager();
+    const sub = user?.userId ?? user?.username;
+    const { form, refresh } = useUserNameManager(sub);
     const { userName } = form;
 
     const [showModal, setShowModal] = useState(false);

--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -15,7 +15,7 @@ const fields: (keyof UserNameFormType)[] = ["userName"];
 
 export default function UserNameManager() {
     const { user } = useAuthenticator();
-    const manager = useUserNameManager();
+    const manager = useUserNameManager(user?.userId ?? user?.username);
     const { refresh, form, isEditing, editingId } = manager;
 
     // ⚡ un seul hook pour auth-change + bus

--- a/src/entities/models/userName/useUserNameManager.ts
+++ b/src/entities/models/userName/useUserNameManager.ts
@@ -4,16 +4,17 @@ import { createUserNameManager } from "./manager";
 /**
  * Hook React pour gérer l'entité UserName.
  */
-export function useUserNameManager() {
+export function useUserNameManager(sub?: string) {
     const mgr = useMemo(() => createUserNameManager(), []);
     const serverSnapshot = useMemo(() => mgr.getState(), [mgr]);
     const state = useSyncExternalStore(mgr.subscribe, mgr.getState, () => serverSnapshot);
 
-
     useEffect(() => {
+        if (!sub) return;
+        mgr.enterEdit(sub);
         void mgr.refresh();
         void mgr.refreshExtras();
-    }, [mgr]);
+    }, [mgr, sub]);
 
     return { ...state, ...mgr };
 }


### PR DESCRIPTION
## Description
- `useUserNameManager` accepte désormais l'ID utilisateur et évite les appels réseau si l'utilisateur n'est pas authentifié.
- `Header` et `UserNameManager` transmettent l'ID utilisateur au hook.

## Tests effectués
- `yarn install`
- `yarn prettier --write src/entities/models/userName/useUserNameManager.ts src/components/Header/Header.tsx src/components/Profile/UserNameManager.tsx`
- `yarn lint` *(bloqué, aucune sortie)*
- `yarn tsc -p tsconfig.eslint.json` *(bloqué, aucune sortie)*
- `yarn build` *(bloqué, aucune sortie)*

------
https://chatgpt.com/codex/tasks/task_e_68a68253008c83248b843083b86c6dc6