### PR TITLE
[Fix] cast generic field value in EntityForm

### DIFF
--- a/src/components/forms/EntityForm.tsx
+++ b/src/components/forms/EntityForm.tsx
@@ -43,7 +43,7 @@ export default function EntityForm<T extends Record<string, unknown>>({
                         name={String(field)}
                         placeholder={labels(field)}
                         value={String(formData[field] ?? "")}
-                        onChange={(e) => handleChange(field, e.target.value)}
+                        onChange={(e) => handleChange(field, e.target.value as FieldValue<T>)}
                         className="w-full p-2 border rounded"
                         required={requiredFields.includes(field)}
                     />

--- a/src/entities/core/hooks/useModelForm.ts
+++ b/src/entities/core/hooks/useModelForm.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 export type FormMode = "create" | "edit";
 // export type FieldKey<T> = keyof T & string;
 export type FieldKey<T> = Extract<keyof T, string>;
-export type FieldValue<T> = T[FieldKey<T>];
+export type FieldValue<T> = Extract<T[FieldKey<T>], string | number | boolean>;
 export interface UseModelFormOptions<F extends object, E = Record<string, unknown>> {
     initialForm: F;
     initialExtras?: E;


### PR DESCRIPTION
## Description
- force generic field value typing in `EntityForm`
- restrict `FieldValue` to primitive values

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoué : erreurs de types existantes dans les fichiers non modifiés)*
- `yarn build` *(échoué : erreurs de compilation existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a6891dab588324b586db218328bdb6