### PR TITLE
[Fix] utiliser PostSummary importé

### DIFF
--- a/src/entities/models/tag/manager.ts
+++ b/src/entities/models/tag/manager.ts
@@ -5,11 +5,9 @@ import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
 import { tagService } from "./service";
 import { tagSchema, initialTagForm, toTagForm, toTagCreate, toTagUpdate } from "./form";
 import type { TagType, TagFormType } from "./types";
-import type { PostType } from "@entities/models/post/types";
+import type { PostSummary } from "@entities/models/post/types";
 
 type Id = string;
-type PostSummary = Pick<PostType, "id" | "title">;
-
 type Extras = { posts: PostSummary[] };
 
 export function createTagManager() {


### PR DESCRIPTION
## Description
- éviter la redéfinition locale de `PostSummary`

## Tests effectués
- `yarn install`
- `yarn prettier src/entities/models/tag/manager.ts --write`
- `yarn lint`
- `yarn tsc` *(échoue: Argument of type 'string' is not assignable to parameter of type 'FieldValue<T>' et autres erreurs existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a6892e82a4832491d370d598fdbaae