### PR TITLE
[Fix] gestion de l'id lors de la création de post

### DIFF
--- a/src/entities/models/post/form.ts
+++ b/src/entities/models/post/form.ts
@@ -3,10 +3,13 @@ import {
     type PostType,
     type PostFormType,
     type PostTypeUpdateInput,
+    type PostTypeOmit,
 } from "@entities/models/post/types";
 import { toSeoForm, initialSeoForm, seoSchema } from "@entities/customTypes/seo";
 import type { SeoType } from "@entities/customTypes/seo";
 import { createModelForm } from "@entities/core";
+
+type PostTypeCreateInput = Omit<PostTypeOmit, "comments" | "author" | "sections" | "tags">;
 
 export const {
     zodSchema: postSchema,
@@ -17,7 +20,7 @@ export const {
 } = createModelForm<
     PostType,
     PostFormType,
-    PostTypeUpdateInput,
+    PostTypeCreateInput,
     PostTypeUpdateInput,
     [string[], string[]]
 >({
@@ -66,11 +69,12 @@ export const {
         tagIds,
         sectionIds,
     }),
-    toCreate: (form: PostFormType): PostTypeUpdateInput => {
-        const { tagIds, sectionIds, ...values } = form;
+    toCreate: (form: PostFormType): PostTypeCreateInput => {
+        const { id, tagIds, sectionIds, ...values } = form;
+        void id;
         void tagIds;
         void sectionIds;
-        return values;
+        return values as PostTypeCreateInput;
     },
     toUpdate: (form: PostFormType): PostTypeUpdateInput => {
         const { tagIds, sectionIds, ...values } = form;

--- a/src/entities/models/post/manager.ts
+++ b/src/entities/models/post/manager.ts
@@ -63,7 +63,7 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
                 sections: s.data ?? [],
             };
         },
-        toForm: toPostForm,
+        toForm: (entity) => toPostForm(entity, [], []),
         syncManyToMany: async (id, link, options) => {
             const relation = options?.relation ?? "tags";
             if (relation === "tags") {
@@ -96,11 +96,11 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
                 );
             }
         },
-        validateField: async <K extends keyof PostFormType>(
+        validateField: <K extends keyof PostFormType>(
             _name: K,
             _value: PostFormType[K]
         ): MaybePromise<string | null> => null,
-        validateForm: async (): MaybePromise<{
+        validateForm: (): MaybePromise<{
             valid: boolean;
             errors: Partial<Record<keyof PostFormType, string>>;
         }> => ({ valid: true, errors: {} }),


### PR DESCRIPTION
## Description
- ne pas envoyer d'identifiant lors de la création d'un post
- adapter `toForm` et simplifier les fonctions de validation

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : Argument of type 'string'...)*
- `yarn build` *(échoue : Argument of type 'string' is not assignable to parameter of type 'FieldValue<T>'.)*


------
https://chatgpt.com/codex/tasks/task_e_68a6892bff6c832495d4386ca9776fa5