### PR TITLE
[Fix] prise en charge des relations nulles pour Comment

### DIFF
--- a/src/entities/models/comment/__tests__/service.test.ts
+++ b/src/entities/models/comment/__tests__/service.test.ts
@@ -75,9 +75,14 @@ describe("commentService", () => {
         fetchSpy.mockRestore();
     });
 
-    it("create utilise userPool", async () => {
+    it("create accepte les ID null et utilise userPool", async () => {
         const fetchSpy = vi.spyOn(global, "fetch");
-        const res = await commentService.create({ content: "", userNameId: "" });
+        const res = await commentService.create({
+            content: "",
+            todoId: null,
+            postId: null,
+            userNameId: null,
+        });
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         const headers = (fetchSpy.mock.calls[0][1]?.headers as Record<string, string>)[
             "x-auth-mode"

--- a/src/entities/models/comment/manager.ts
+++ b/src/entities/models/comment/manager.ts
@@ -43,18 +43,18 @@ function toCommentForm(comment: CommentModel): CommentFormType {
 function toCommentCreate(form: CommentFormType): CommentCreateInput {
     return {
         content: form.content,
-        todoId: form.todoId || undefined,
-        postId: form.postId || undefined,
-        userNameId: form.userNameId,
+        todoId: form.todoId || null,
+        postId: form.postId || null,
+        userNameId: form.userNameId || null,
     };
 }
 
 function toCommentUpdate(form: CommentFormType): CommentUpdateInput {
     return {
         content: form.content,
-        todoId: form.todoId || undefined,
-        postId: form.postId || undefined,
-        userNameId: form.userNameId,
+        todoId: form.todoId || null,
+        postId: form.postId || null,
+        userNameId: form.userNameId || null,
     } as CommentUpdateInput;
 }
 

--- a/src/types/models/comment.ts
+++ b/src/types/models/comment.ts
@@ -1,13 +1,26 @@
 import type { BaseModel, UpdateInput, ModelForm } from "@entities/core";
+import type { LazyLoader } from "@aws-amplify/data-schema-types";
+import type { TodoModel } from "@src/types/models/todo";
+import type { PostType } from "@entities/models/post/types";
+import type { UserNameType } from "@entities/models/userName/types";
 
 export type CommentModel = BaseModel<"Comment">;
 export type CommentCreateInput = {
     content: string;
-    todoId?: string;
-    postId?: string;
-    userNameId: string;
-};
-export type CommentUpdateInput = Omit<UpdateInput<"Comment">, "userNameId"> & {
+    todoId?: string | null;
+    postId?: string | null;
     userNameId?: string | null;
 };
-export type CommentFormType = ModelForm<"Comment">;
+export type CommentUpdateInput = Omit<
+    UpdateInput<"Comment">,
+    "todoId" | "postId" | "userNameId"
+> & {
+    todoId?: string | null;
+    postId?: string | null;
+    userNameId?: string | null;
+};
+export type CommentFormType = Omit<ModelForm<"Comment">, "todo" | "post" | "userName"> & {
+    todo: LazyLoader<TodoModel | null, false> | null;
+    post: LazyLoader<PostType | null, false> | null;
+    userName: LazyLoader<UserNameType | null, false> | null;
+};


### PR DESCRIPTION
## Résumé
- autorise les identifiants null dans `Comment` et les transforme en LazyLoader nullable
- transmet `null` aux services lors de la création ou mise à jour d’un commentaire
- couvre les ids nulls dans les tests du service

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue: Argument of type 'string' is not assignable...)*
- `yarn test` *(échoue: Failed to resolve import "@entities/models/author/hooks"...)*

------
https://chatgpt.com/codex/tasks/task_e_68a689273a3083248a82bcd3ce7db9df