### PR TITLE
[Feat] associer l'utilisateur au profil

### DIFF
--- a/src/entities/models/userProfile/__tests__/manager.test.ts
+++ b/src/entities/models/userProfile/__tests__/manager.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { createUserProfileManager } from "@entities/models/userProfile/manager";
+
+vi.mock("aws-amplify/auth", () => ({
+    getCurrentUser: vi.fn().mockResolvedValue({ userId: "sub" }),
+}));
+
+vi.mock("@entities/models/userProfile/service", () => ({
+    userProfileService: {
+        create: vi.fn().mockResolvedValue({}),
+        get: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+import { userProfileService } from "@entities/models/userProfile/service";
+
+describe("userProfile manager", () => {
+    it("crée un profil avec l'id égal au sub", async () => {
+        const manager = createUserProfileManager();
+        const id = await manager.createEntity({
+            id: "",
+            firstName: "",
+            familyName: "",
+            address: "",
+            postalCode: "",
+            city: "",
+            country: "",
+            phoneNumber: "",
+        });
+
+        expect(id).toBe("sub");
+        expect(userProfileService.create).toHaveBeenCalledWith({
+            id: "sub",
+            firstName: "",
+            familyName: "",
+            address: "",
+            postalCode: "",
+            city: "",
+            country: "",
+            phoneNumber: "",
+        });
+    });
+});


### PR DESCRIPTION
## Objectif
- Associer le profil créé à l'utilisateur connecté via `getCurrentUser`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : erreurs de typage existantes)*
- `yarn test` *(échoue : imports manquants et assertions existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68a68edb0d008324ab8a1a542a9b667b