### PR TITLE
[Feat] restreindre UserName à l'id courant

### DIFF
--- a/src/entities/models/userName/__tests__/manager.test.ts
+++ b/src/entities/models/userName/__tests__/manager.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createUserNameManager } from "@entities/models/userName/manager";
+import type { UserNameType } from "@entities/models/userName/types";
+
+vi.mock("@entities/models/userName/service", () => ({
+    userNameService: {
+        list: vi.fn(),
+        get: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+vi.mock("@entities/models/comment/service", () => ({
+    commentService: {
+        list: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        create: vi.fn(),
+    },
+}));
+
+import { userNameService } from "@entities/models/userName/service";
+
+describe("userName manager", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("ne fait aucun appel sans editingId", async () => {
+        const manager = createUserNameManager();
+        await manager.refresh();
+        expect(userNameService.get).not.toHaveBeenCalled();
+        expect(userNameService.list).not.toHaveBeenCalled();
+        expect(manager.entities).toEqual([]);
+    });
+
+    it("retourne uniquement l'entrée du sub courant", async () => {
+        const manager = createUserNameManager();
+        const item = { id: "sub", userName: "John" } as UserNameType;
+        (userNameService.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: item });
+        manager.enterEdit("sub");
+        await manager.refresh();
+        expect(userNameService.get).toHaveBeenCalledWith({ id: "sub" });
+        expect(userNameService.list).not.toHaveBeenCalled();
+        expect(manager.entities).toEqual([item]);
+    });
+});

--- a/src/entities/models/userName/manager.ts
+++ b/src/entities/models/userName/manager.ts
@@ -16,12 +16,18 @@ type Id = string;
 type Extras = { comments: CommentModel[]; postComments: CommentModel[] };
 
 export function createUserNameManager() {
-    return createManager<UserNameType, UserNameFormType, Id, Extras>({
+    let manager: ReturnType<typeof createManager<UserNameType, UserNameFormType, Id, Extras>>;
+
+    const listEntities = async () => {
+        const editingId = manager.getState().editingId;
+        if (!editingId) return { items: [] };
+        const { data } = await userNameService.get({ id: editingId });
+        return { items: data ? [data as UserNameType] : [] };
+    };
+
+    manager = createManager<UserNameType, UserNameFormType, Id, Extras>({
         getInitialForm: () => ({ ...initialUserNameForm }),
-        listEntities: async ({ limit }) => {
-            const { data } = await userNameService.list({ limit });
-            return { items: (data ?? []) as UserNameType[] };
-        },
+        listEntities,
         getEntityById: async (id) => {
             const { data } = await userNameService.get({ id });
             return (data ?? null) as UserNameType | null;
@@ -85,4 +91,5 @@ export function createUserNameManager() {
             );
         },
     });
+    return manager;
 }


### PR DESCRIPTION
## Description
- limite `listEntities` de `userName` à l'id en édition
- ajoute des tests pour vérifier le filtrage sur le sub courant

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : Type 'null' is not assignable to type 'LazyLoader'...)*
- `yarn build` *(échoue : Type 'null' is not assignable to type 'LazyLoader'...)*
- `yarn test` *(échoue : Failed to resolve import `@entities/models/author/hooks`...)*
- `yarn vitest run src/entities/models/userName/__tests__/manager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a691fd982483249d4c8364da036873