### PR TITLE
[Feat] chargement des relations du formulaire Post

### DIFF
--- a/src/entities/models/post/__tests__/manager.test.ts
+++ b/src/entities/models/post/__tests__/manager.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PostType } from "@entities/models/post/types";
+import { createPostManager } from "@entities/models/post/manager";
+import { postService } from "@entities/models/post/service";
+import { postTagService } from "@entities/relations/postTag/service";
+import { sectionPostService } from "@entities/relations/sectionPost/service";
+
+vi.mock("@entities/models/post/service", () => ({
+    postService: {
+        get: vi.fn(),
+    },
+}));
+
+vi.mock("@entities/relations/postTag/service", () => ({
+    postTagService: {
+        listByParent: vi.fn(),
+    },
+}));
+
+vi.mock("@entities/relations/sectionPost/service", () => ({
+    sectionPostService: {
+        listByChild: vi.fn(),
+    },
+}));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("post manager", () => {
+    it("charge les tagIds et sectionIds existants", async () => {
+        const post: PostType = {
+            id: "p1",
+            slug: "slug",
+            title: "titre",
+            excerpt: "extrait",
+            content: "contenu",
+            status: "draft",
+            authorId: "a1",
+            order: 1,
+            videoUrl: "",
+            type: "type",
+            seo: {},
+        } as unknown as PostType;
+
+        (postService.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: post });
+        (postTagService.listByParent as ReturnType<typeof vi.fn>).mockResolvedValue([
+            "tag1",
+            "tag2",
+        ]);
+        (sectionPostService.listByChild as ReturnType<typeof vi.fn>).mockResolvedValue([
+            "section1",
+        ]);
+
+        const manager = createPostManager();
+        await manager.loadEntityById("p1");
+
+        expect(postService.get).toHaveBeenCalledWith({ id: "p1" });
+        expect(postTagService.listByParent).toHaveBeenCalledWith("p1");
+        expect(sectionPostService.listByChild).toHaveBeenCalledWith("p1");
+        expect(manager.form.tagIds).toEqual(["tag1", "tag2"]);
+        expect(manager.form.sectionIds).toEqual(["section1"]);
+    });
+});

--- a/src/entities/models/post/manager.ts
+++ b/src/entities/models/post/manager.ts
@@ -63,6 +63,15 @@ export function createPostManager(): ManagerContract<PostType, PostFormType, Id,
                 sections: s.data ?? [],
             };
         },
+        loadEntityForm: async (id) => {
+            const [{ data }, tagIds, sectionIds] = await Promise.all([
+                postService.get({ id }),
+                postTagService.listByParent(id),
+                sectionPostService.listByChild(id),
+            ]);
+            if (!data) throw new Error("Post not found");
+            return toPostForm(data as PostType, tagIds, sectionIds);
+        },
         toForm: (entity) => toPostForm(entity, [], []),
         syncManyToMany: async (id, link, options) => {
             const relation = options?.relation ?? "tags";


### PR DESCRIPTION
## Description
- ajoute `loadEntityForm` pour précharger les tags et sections d'un post
- couvre le chargement des `tagIds` et `sectionIds` via un test dédié

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(erreurs existantes)*
- `yarn test` *(échecs liés à des imports manquants et attentes de tests)
- `yarn test src/entities/models/post/__tests__/manager.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a6921b66f08324b977bbf306298b95