### PR TITLE
[Feat] lecture userName sans authentification

### DIFF
--- a/src/entities/models/userName/service.ts
+++ b/src/entities/models/userName/service.ts
@@ -5,13 +5,18 @@ import type {
     UserNameTypeUpdateInput,
 } from "@entities/models/userName/types";
 
-// ✅ Lecture et écriture privées via User Pool
-export const userNameService = crudService<
+// ✅ Lecture publique (API Key ou User Pool) & écriture via User Pool
+const base = crudService<
     "UserName",
     UserNameTypeCreateInput & { id: string },
     UserNameTypeUpdateInput & { id: string },
     { id: string },
     { id: string }
 >("UserName", {
-    auth: { read: "userPool", write: "userPool" },
+    auth: { read: ["userPool", "apiKey"], write: "userPool" },
 });
+
+export const userNameService = {
+    ...base,
+    defaultSelection: ["id", "userName"] as const,
+};


### PR DESCRIPTION
## Description
- lecture des `UserName` via API key ou User Pool
- ajout d'une `defaultSelection` pour limiter les champs retournés

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : Type 'null' is not assignable to type 'LazyLoader')*
- `yarn build` *(échoue : Type error in comment/manager.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a69293349883248e8ba900092a5e4b