### PR TITLE
[Feat] ajout auth fallback

### DIFF
--- a/src/entities/core/services/doc.md
+++ b/src/entities/core/services/doc.md
@@ -25,8 +25,11 @@ import { crudService } from "@entities/core/services";
 
 const posts = crudService("Post");
 await posts.create({ title: "Hello" });
-const { data } = await posts.list();
+// Utilise un `selectionSet` pour limiter les champs retournés
+const { data } = await posts.list({}, ["id", "title"]);
 ```
+
+Par défaut, les lectures tentent successivement les modes `userPool` puis `apiKey` afin de maximiser les chances d'accès.
 
 ## `relationService`
 


### PR DESCRIPTION
## Description
- support des selectionSet dans get/list
- ajout d'un fallback sur les modes d'authentification

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue: Property 'data' does not exist on type 'unknown'...)*
- `yarn build` *(échoue: Property 'data' does not exist on type 'unknown'...)*

------
https://chatgpt.com/codex/tasks/task_e_68a692a60d4c83248517a97a21769c0b