### PR TITLE
[Feat] centraliser la récupération du sub utilisateur

### DIFF
--- a/src/components/todo/useTodosWithComments.ts
+++ b/src/components/todo/useTodosWithComments.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Schema } from "@/amplify/data/resource";
 import { getCurrentUser } from "aws-amplify/auth";
+import { getUserSub } from "@src/entities/core/auth";
 import { useTodoService, todoService } from "@src/entities/models/todo";
 import { useCommentService, commentService } from "@src/entities/models/comment";
 import { userNameService } from "@src/entities/models/userName";
@@ -90,7 +91,7 @@ export default function useTodosWithComments() {
     const addComment = async (todoId: string) => {
         const content = window.prompt("Contenu du commentaire ?");
         if (!content) return;
-        const { userId: userNameId } = await getCurrentUser();
+        const userNameId = await getUserSub();
         const { data } = await userNameService.get({ id: userNameId });
         if (!data?.userName) {
             window.alert("Pseudo manquant");

--- a/src/entities/core/auth/getUserSub.ts
+++ b/src/entities/core/auth/getUserSub.ts
@@ -1,0 +1,6 @@
+import { getCurrentUser } from "aws-amplify/auth";
+
+export async function getUserSub(): Promise<string> {
+    const { userId } = await getCurrentUser();
+    return userId;
+}

--- a/src/entities/core/auth/index.ts
+++ b/src/entities/core/auth/index.ts
@@ -1,4 +1,4 @@
-import type { AuthRule } from "./types";
+import type { AuthRule } from "../types";
 
 export interface AuthUser {
     username?: string;
@@ -42,3 +42,5 @@ export function canAccess(
     }
     return false;
 }
+
+export { getUserSub } from "./getUserSub";

--- a/src/entities/models/userName/manager.ts
+++ b/src/entities/models/userName/manager.ts
@@ -1,8 +1,7 @@
-import { createManager } from "@entities/core";
+import { createManager, getUserSub } from "@entities/core";
 import { userNameService } from "@entities/models/userName/service";
 import { commentService } from "@entities/models/comment/service";
 import { syncManyToMany as syncNN } from "@entities/core/utils/syncManyToMany";
-import { getCurrentUser } from "aws-amplify/auth";
 import {
     initialUserNameForm,
     toUserNameForm,
@@ -27,7 +26,7 @@ export function createUserNameManager() {
             return (data ?? null) as UserNameType | null;
         },
         createEntity: async (form) => {
-            const { userId } = await getCurrentUser();
+            const userId = await getUserSub();
             const { data, errors } = await userNameService.create(
                 toUserNameCreate({ ...form, id: userId })
             );

--- a/src/hooks/useCommentPermissions.ts
+++ b/src/hooks/useCommentPermissions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
-import { fetchAuthSession, getCurrentUser } from "aws-amplify/auth";
+import { fetchAuthSession } from "aws-amplify/auth";
+import { getUserSub } from "@src/entities/core/auth";
 
 export function useCommentPermissions() {
     const [userId, setUserId] = useState<string | null>(null);
@@ -8,7 +9,7 @@ export function useCommentPermissions() {
     useEffect(() => {
         void (async () => {
             try {
-                const { userId } = await getCurrentUser();
+                const userId = await getUserSub();
                 setUserId(userId);
             } catch {
                 setUserId(null);


### PR DESCRIPTION
## Objectif
- exposer `getUserSub()` pour récupérer le `sub`
- utiliser `getUserSub()` à la place de `getCurrentUser().userId`

## Tests effectués
- `yarn prettier --write src/entities/core/auth/index.ts src/entities/core/auth/getUserSub.ts src/components/todo/useTodosWithComments.ts src/hooks/useCommentPermissions.ts src/entities/models/userName/manager.ts`
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoue : erreurs dans `comment/manager.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68a692ba19988324a901a81db28c201b