### PR TITLE
[Feat] uniformiser le modèle Comment

### DIFF
--- a/src/components/todo/useTodosWithComments.ts
+++ b/src/components/todo/useTodosWithComments.ts
@@ -6,7 +6,7 @@ import { useTodoService, todoService } from "@src/entities/models/todo";
 import { useCommentService, commentService } from "@src/entities/models/comment";
 import { userNameService } from "@src/entities/models/userName";
 import { useCommentPermissions } from "@src/hooks/useCommentPermissions";
-import type { CommentCreateInput } from "@src/types/models/comment";
+import type { CommentTypeCreateInput } from "@src/types/models/comment";
 
 export type CommentWithTodoId = {
     id: string;
@@ -97,7 +97,7 @@ export default function useTodosWithComments() {
             window.alert("Pseudo manquant");
             return;
         }
-        const input: CommentCreateInput = { content, todoId, userNameId };
+        const input: CommentTypeCreateInput = { content, todoId, userNameId };
         await commentService.create(input);
     };
 

--- a/src/entities/models/comment/__tests__/service.test.ts
+++ b/src/entities/models/comment/__tests__/service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { commentService } from "@entities/models/comment";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
-import type { CommentCreateInput, CommentUpdateInput } from "@src/types/models/comment";
+import type { CommentTypeCreateInput, CommentTypeUpdateInput } from "@src/types/models/comment";
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const baseFetch = (op: string, { authMode, body }: { authMode?: string; body?: unknown }) =>
@@ -19,9 +19,9 @@ vi.mock("@entities/core/services/amplifyClient", () => {
         Comment: {
             get: (args: { id: string }, opts?: { authMode?: string }) =>
                 baseFetch("get", { ...opts, body: args }),
-            create: (data: CommentCreateInput, opts?: { authMode?: string }) =>
+            create: (data: CommentTypeCreateInput, opts?: { authMode?: string }) =>
                 baseFetch("create", { ...opts, body: data }),
-            update: (data: CommentUpdateInput & { id: string }, opts?: { authMode?: string }) =>
+            update: (data: CommentTypeUpdateInput & { id: string }, opts?: { authMode?: string }) =>
                 baseFetch("update", { ...opts, body: data }),
             delete: (args: { id: string }, opts?: { authMode?: string }) =>
                 baseFetch("delete", { ...opts, body: args }),

--- a/src/entities/models/comment/config.ts
+++ b/src/entities/models/comment/config.ts
@@ -1,0 +1,19 @@
+import {
+    commentSchema,
+    initialCommentForm,
+    toCommentForm,
+    toCommentCreate,
+    toCommentUpdate,
+} from "./form";
+
+export const commentConfig = {
+    auth: "admin",
+    identifier: "id",
+    fields: ["content", "todoId", "postId", "userNameId"],
+    relations: ["todo", "post", "userName"],
+    zodSchema: commentSchema,
+    toForm: toCommentForm,
+    toCreate: toCommentCreate,
+    toUpdate: toCommentUpdate,
+    initialForm: initialCommentForm,
+};

--- a/src/entities/models/comment/form.ts
+++ b/src/entities/models/comment/form.ts
@@ -1,0 +1,56 @@
+import { z, type ZodType } from "zod";
+import { createModelForm } from "@entities/core";
+import type {
+    CommentType,
+    CommentFormType,
+    CommentTypeCreateInput,
+    CommentTypeUpdateInput,
+} from "./types";
+
+export const {
+    zodSchema: commentSchema,
+    initialForm: initialCommentForm,
+    toForm: toCommentForm,
+    toCreate: toCommentCreate,
+    toUpdate: toCommentUpdate,
+} = createModelForm<CommentType, CommentFormType, CommentTypeCreateInput, CommentTypeUpdateInput>({
+    zodSchema: z.object({
+        id: z.string().optional(),
+        content: z.string(),
+        todoId: z.string().optional(),
+        postId: z.string().optional(),
+        userNameId: z.string(),
+    }) as ZodType<CommentFormType>,
+    initialForm: {
+        id: "",
+        content: "",
+        todoId: "",
+        postId: "",
+        userNameId: "",
+    },
+    toForm: (comment) => ({
+        id: comment.id ?? "",
+        content: comment.content ?? "",
+        todoId: comment.todoId ?? "",
+        postId: comment.postId ?? "",
+        userNameId: comment.userNameId ?? "",
+    }),
+    toCreate: (form: CommentFormType): CommentTypeCreateInput => {
+        const { id, todoId, postId, ...rest } = form;
+        void id;
+        return {
+            ...rest,
+            todoId: todoId || undefined,
+            postId: postId || undefined,
+        };
+    },
+    toUpdate: (form: CommentFormType): CommentTypeUpdateInput => {
+        const { id, todoId, postId, ...rest } = form;
+        void id;
+        return {
+            ...rest,
+            todoId: todoId || undefined,
+            postId: postId || undefined,
+        };
+    },
+});

--- a/src/entities/models/comment/index.ts
+++ b/src/entities/models/comment/index.ts
@@ -1,3 +1,6 @@
+export * from "./types";
+export * from "./form";
 export { commentService, useCommentService } from "./service";
+export { commentConfig } from "./config";
 export { createCommentManager } from "./manager";
 export { useCommentManager } from "./useCommentManager";

--- a/src/entities/models/comment/manager.ts
+++ b/src/entities/models/comment/manager.ts
@@ -1,14 +1,10 @@
 import { createManager } from "@entities/core";
-import { commentService } from "@entities/models/comment/service";
+import { commentService } from "./service";
 import { userNameService } from "@entities/models/userName/service";
 import { todoService } from "@entities/models/todo/service";
 import { postService } from "@entities/models/post/service";
-import type {
-    CommentModel,
-    CommentFormType,
-    CommentCreateInput,
-    CommentUpdateInput,
-} from "@src/types/models/comment";
+import { initialCommentForm, toCommentForm, toCommentCreate, toCommentUpdate } from "./form";
+import type { CommentType, CommentFormType } from "./types";
 import type { UserNameType } from "@entities/models/userName/types";
 import type { TodoModel } from "@src/types/models/todo";
 import type { PostType } from "@entities/models/post/types";
@@ -16,68 +12,26 @@ import type { PostType } from "@entities/models/post/types";
 type Id = string;
 type Extras = { userNames: UserNameType[]; todos: TodoModel[]; posts: PostType[] };
 
-const initialCommentForm: CommentFormType = {
-    id: "",
-    content: "",
-    todoId: "",
-    postId: "",
-    userNameId: "",
-    todo: null,
-    post: null,
-    userName: null,
-};
-
-function toCommentForm(comment: CommentModel): CommentFormType {
-    return {
-        id: comment.id ?? "",
-        content: comment.content ?? "",
-        todoId: comment.todoId ?? "",
-        postId: comment.postId ?? "",
-        userNameId: comment.userNameId ?? "",
-        todo: comment.todo ?? null,
-        post: comment.post ?? null,
-        userName: comment.userName ?? null,
-    };
-}
-
-function toCommentCreate(form: CommentFormType): CommentCreateInput {
-    return {
-        content: form.content,
-        todoId: form.todoId || undefined,
-        postId: form.postId || undefined,
-        userNameId: form.userNameId,
-    };
-}
-
-function toCommentUpdate(form: CommentFormType): CommentUpdateInput {
-    return {
-        content: form.content,
-        todoId: form.todoId || undefined,
-        postId: form.postId || undefined,
-        userNameId: form.userNameId,
-    } as CommentUpdateInput;
-}
-
 export function createCommentManager() {
-    return createManager<CommentModel, CommentFormType, Id, Extras>({
+    return createManager<CommentType, CommentFormType, Id, Extras>({
         getInitialForm: () => ({ ...initialCommentForm }),
         listEntities: async ({ limit }) => {
             const { data } = await commentService.list({ limit });
-            return { items: (data ?? []) as CommentModel[] };
+            return { items: (data ?? []) as CommentType[] };
         },
         getEntityById: async (id) => {
             const { data } = await commentService.get({ id });
-            return (data ?? null) as CommentModel | null;
+            return (data ?? null) as CommentType | null;
         },
         createEntity: async (form) => {
             const { data, errors } = await commentService.create(toCommentCreate(form));
             if (errors?.length) throw new Error(errors[0].message);
             return data.id;
         },
-        updateEntity: async (id, data, { form }) => {
+        updateEntity: async (id, patch, { form }) => {
             const { errors } = await commentService.update({
                 id,
-                ...toCommentUpdate({ ...form, ...data }),
+                ...toCommentUpdate({ ...form, ...patch }),
             });
             if (errors?.length) throw new Error(errors[0].message);
         },
@@ -99,7 +53,7 @@ export function createCommentManager() {
         loadEntityForm: async (id) => {
             const { data } = await commentService.get({ id });
             if (!data) throw new Error("Comment not found");
-            return toCommentForm(data as CommentModel);
+            return toCommentForm(data as CommentType);
         },
     });
 }

--- a/src/entities/models/comment/service.ts
+++ b/src/entities/models/comment/service.ts
@@ -1,10 +1,10 @@
 import { client, crudService } from "@src/entities/core";
-import type { CommentCreateInput, CommentUpdateInput } from "@src/types/models/comment";
+import type { CommentTypeCreateInput, CommentTypeUpdateInput } from "./types";
 
 export const commentService = crudService<
     "Comment",
-    CommentCreateInput,
-    CommentUpdateInput & { id: string },
+    CommentTypeCreateInput,
+    CommentTypeUpdateInput & { id: string },
     { id: string },
     { id: string }
 >("Comment", {

--- a/src/entities/models/comment/types.ts
+++ b/src/entities/models/comment/types.ts
@@ -1,0 +1,14 @@
+import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/core";
+
+export type CommentType = BaseModel<"Comment">;
+export type CommentTypeOmit = CreateOmit<"Comment">;
+export type CommentTypeCreateInput = {
+    content: string;
+    todoId?: string;
+    postId?: string;
+    userNameId: string;
+};
+export type CommentTypeUpdateInput = Omit<UpdateInput<"Comment">, "userNameId"> & {
+    userNameId?: string | null;
+};
+export type CommentFormType = ModelForm<"Comment", "todo" | "post" | "userName">;

--- a/src/entities/models/userName/manager.ts
+++ b/src/entities/models/userName/manager.ts
@@ -11,11 +11,11 @@ import {
     toUserNameUpdate,
 } from "@entities/models/userName/form";
 import type { UserNameType, UserNameFormType } from "@entities/models/userName/types";
-import type { CommentModel } from "@src/types/models/comment";
+import type { CommentType } from "@src/types/models/comment";
 import { emitUserNameUpdated } from "@entities/models/userName/bus";
 
 type Id = string;
-type Extras = { comments: CommentModel[]; postComments: CommentModel[] };
+type Extras = { comments: CommentType[]; postComments: CommentType[] };
 
 // src/entities/models/userName/manager.ts
 export function createUserNameManager() {

--- a/src/types/models/comment.ts
+++ b/src/types/models/comment.ts
@@ -1,13 +1,7 @@
-import type { BaseModel, UpdateInput, ModelForm } from "@entities/core";
-
-export type CommentModel = BaseModel<"Comment">;
-export type CommentCreateInput = {
-    content: string;
-    todoId?: string;
-    postId?: string;
-    userNameId: string;
-};
-export type CommentUpdateInput = Omit<UpdateInput<"Comment">, "userNameId"> & {
-    userNameId?: string | null;
-};
-export type CommentFormType = ModelForm<"Comment">;
+export type {
+    CommentType,
+    CommentTypeOmit,
+    CommentTypeCreateInput,
+    CommentTypeUpdateInput,
+    CommentFormType,
+} from "@entities/models/comment/types";


### PR DESCRIPTION
## Description
- centralise les types et formulaires de Comment
- met à jour service et manager avec le schéma standard
- réexporte les nouveaux types pour l'écosystème

## Tests
- `yarn lint`
- `yarn tsc`
- `yarn test` *(échoue : Failed to resolve import "@entities/models/author/hooks", ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a71f557fb88324b597b9276fbcd8f1