### PR TITLE
[Feat] améliorations du modèle Tag

### DIFF
--- a/src/entities/models/tag/form.ts
+++ b/src/entities/models/tag/form.ts
@@ -3,11 +3,12 @@ import { createModelForm } from "@entities/core";
 import {
     type TagType,
     type TagFormType,
+    type TagTypeCreateInput,
     type TagTypeUpdateInput,
 } from "@entities/models/tag/types";
 
 export const tagSchema = z.object({
-    id: z.string(),
+    id: z.string().optional().default(""),
     name: z.string().min(1),
     postIds: z.array(z.string()),
 });
@@ -17,7 +18,7 @@ export const {
     toForm: toTagForm,
     toCreate: toTagCreate,
     toUpdate: toTagUpdate,
-} = createModelForm<TagType, TagFormType, TagTypeUpdateInput, TagTypeUpdateInput, [string[]]>({
+} = createModelForm<TagType, TagFormType, TagTypeCreateInput, TagTypeUpdateInput, [string[]]>({
     zodSchema: tagSchema,
     initialForm: {
         id: "",
@@ -30,9 +31,10 @@ export const {
         postIds,
     }),
 
-    toCreate: (form: TagFormType): TagTypeUpdateInput => {
-        const { postIds, ...values } = form;
+    toCreate: (form: TagFormType): TagTypeCreateInput => {
+        const { postIds, id: _id, ...values } = form;
         void postIds;
+        void _id;
         return values;
     },
     toUpdate: (form: TagFormType): TagTypeUpdateInput => {

--- a/src/entities/models/tag/service.ts
+++ b/src/entities/models/tag/service.ts
@@ -1,10 +1,10 @@
 import { crudService, deleteEdges } from "@entities/core";
 import { postTagService } from "@entities/relations/postTag/service";
-import type { TagTypeUpdateInput } from "@entities/models/tag/types";
+import type { TagTypeCreateInput, TagTypeUpdateInput } from "@entities/models/tag/types";
 
 const base = crudService<
     "Tag",
-    Omit<TagTypeUpdateInput, "posts">,
+    TagTypeCreateInput,
     TagTypeUpdateInput & { id: string },
     { id: string },
     { id: string }

--- a/src/entities/models/tag/types.ts
+++ b/src/entities/models/tag/types.ts
@@ -2,5 +2,6 @@ import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/co
 
 export type TagType = BaseModel<"Tag">;
 export type TagTypeOmit = CreateOmit<"Tag">;
+export type TagTypeCreateInput = Omit<TagTypeOmit, "id" | "posts">;
 export type TagTypeUpdateInput = UpdateInput<"Tag">;
 export type TagFormType = ModelForm<"Tag", "posts", "post">;


### PR DESCRIPTION
## Résumé
- introduit `TagTypeCreateInput` pour les créations
- refactorise `tag/form` avec `createModelForm` et schéma `id` optionnel
- adapte le service Tag pour utiliser `TagTypeCreateInput`

## Tests effectués
- `yarn prettier --write .`
- `yarn lint`
- `yarn tsc` *(échoue : Type 'null' is not assignable to type 'LazyLoader<...>')*
- `yarn build` *(échoue : Type error: Type 'null' is not assignable to type 'LazyLoader<...>')*
- `yarn test` *(échoue : Failed to resolve import "@entities/models/author/hooks"...)*

------
https://chatgpt.com/codex/tasks/task_e_68a71f58f5f483249e32cd23aad64706