### PR TITLE
[Feat] ajuster la création de UserProfile

### DIFF
--- a/src/entities/models/userProfile/form.ts
+++ b/src/entities/models/userProfile/form.ts
@@ -3,8 +3,8 @@ import { createModelForm } from "@entities/core";
 import type {
     UserProfileType,
     UserProfileFormType,
+    UserProfileTypeCreateInput,
     UserProfileTypeUpdateInput,
-    UserProfileTypeOmit,
 } from "./types";
 
 export const {
@@ -16,11 +16,11 @@ export const {
 } = createModelForm<
     UserProfileType,
     UserProfileFormType,
-    UserProfileTypeOmit,
+    UserProfileTypeCreateInput,
     UserProfileTypeUpdateInput
 >({
     zodSchema: z.object({
-        id: z.string(),
+        id: z.string().optional(),
         firstName: z.string(),
         familyName: z.string(),
         address: z.string(),
@@ -49,7 +49,11 @@ export const {
         country: profile.country ?? "",
         phoneNumber: profile.phoneNumber ?? "",
     }),
-    toCreate: (form: UserProfileFormType): UserProfileTypeOmit => ({ ...form }),
+    toCreate: (form: UserProfileFormType): UserProfileTypeCreateInput => {
+        const { id, ...values } = form;
+        void id;
+        return { ...values };
+    },
     toUpdate: (form: UserProfileFormType): UserProfileTypeUpdateInput => {
         const { id, ...values } = form;
         void id;

--- a/src/entities/models/userProfile/service.ts
+++ b/src/entities/models/userProfile/service.ts
@@ -1,13 +1,13 @@
 // src/entities/models/userProfile/service.ts
 import { crudService } from "@entities/core";
 import type {
-    UserProfileTypeOmit,
+    UserProfileTypeCreateInput,
     UserProfileTypeUpdateInput,
 } from "@entities/models/userProfile/types";
 
 export const userProfileService = crudService<
     "UserProfile",
-    Omit<UserProfileTypeOmit, "id">,
+    UserProfileTypeCreateInput,
     UserProfileTypeUpdateInput & { id: string },
     { id: string },
     { id: string }

--- a/src/entities/models/userProfile/types.ts
+++ b/src/entities/models/userProfile/types.ts
@@ -2,6 +2,7 @@ import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/co
 
 export type UserProfileType = BaseModel<"UserProfile">;
 export type UserProfileTypeOmit = CreateOmit<"UserProfile">;
+export type UserProfileTypeCreateInput = Omit<UserProfileTypeOmit, "id">;
 export type UserProfileTypeUpdateInput = UpdateInput<"UserProfile">;
 export type UserProfileFormType = ModelForm<"UserProfile">;
 


### PR DESCRIPTION
## Objectif
- isoler un type `UserProfileTypeCreateInput`
- rendre l'`id` optionnel dans le formulaire de profil utilisateur
- utiliser le nouveau type dans le service

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(erreurs de types existantes dans `src/entities/models/comment/manager.ts`)*
- `yarn test` *(échecs d'import et assertions dans plusieurs suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a71f5c843c832493ea8393f1824a43