### PR TITLE
[Fix] Conserver l'id lors de la mise à jour d'auteur

### DIFF
--- a/src/entities/models/author/form.ts
+++ b/src/entities/models/author/form.ts
@@ -47,10 +47,11 @@ export const {
     toCreate: (form: AuthorFormType): AuthorTypeCreateInput => {
         const { postIds, id: _id, ...values } = form;
         void postIds;
+        void _id;
         return values;
     },
     toUpdate: (form: AuthorFormType): AuthorTypeUpdateInput => {
-        const { postIds, id: _id, ...values } = form;
+        const { postIds, ...values } = form;
         void postIds;
         return values;
     },

--- a/src/entities/models/author/manager.ts
+++ b/src/entities/models/author/manager.ts
@@ -32,8 +32,8 @@ export function createAuthorManager() {
         },
         updateEntity: async (id, data, { form }) => {
             const { errors } = await authorService.update({
-                id,
                 ...toAuthorUpdate({ ...form, ...data }),
+                id,
             });
             if (errors?.length) throw new Error(errors[0].message);
         },

--- a/src/entities/models/author/types.ts
+++ b/src/entities/models/author/types.ts
@@ -3,5 +3,5 @@ import type { BaseModel, CreateOmit, UpdateInput, ModelForm } from "@entities/co
 export type AuthorType = BaseModel<"Author">;
 export type AuthorTypeOmit = CreateOmit<"Author">;
 export type AuthorTypeUpdateInput = UpdateInput<"Author">;
-export type AuthorTypeCreateInput = Omit<AuthorTypeUpdateInput, "id" | "posts">;
+export type AuthorTypeCreateInput = Omit<AuthorTypeOmit, "id" | "posts">;
 export type AuthorFormType = ModelForm<"Author", "posts", "post">;


### PR DESCRIPTION
## Résumé
- conserve l'id dans `toAuthorUpdate`
- priorise l'id passé en paramètre dans `createAuthorManager`
- définit `AuthorTypeCreateInput` via `Omit<AuthorTypeOmit, "id" | "posts">`

## Tests
- `yarn lint`
- `yarn tsc` *(erreurs dans `comment/manager.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68a71f5ad6688324bed5a06fdf877567