### PR TITLE
[Fix] utilise CommentType dans le gestionnaire de todo

### DIFF
--- a/src/entities/models/todo/manager.ts
+++ b/src/entities/models/todo/manager.ts
@@ -9,10 +9,10 @@ import {
     toTodoUpdate,
 } from "@entities/models/todo/form";
 import type { TodoModel, TodoFormType } from "@entities/models/todo/types";
-import type { CommentModel } from "@src/types/models/comment";
+import type { CommentType } from "@src/types/models/comment";
 
 type Id = string;
-type Extras = { comments: CommentModel[] };
+type Extras = { comments: CommentType[] };
 
 export function createTodoManager() {
     return createManager<TodoModel, TodoFormType, Id, Extras>({


### PR DESCRIPTION
## Description
- remplace `CommentModel` par `CommentType` dans le gestionnaire de todo
- met à jour le type `Extras` pour utiliser `CommentType[]`

## Tests effectués
- `yarn lint`
- `yarn tsc` *(échoue : Module '@src/types/models/comment' n'exporte pas 'CommentModel' et autres types)*
- `yarn build` *(échoue pour la même raison que ci-dessus)*

------
https://chatgpt.com/codex/tasks/task_e_68a7271ae3948324a8a8eda7b4ca6e49