### PR TITLE
[Fix] Nettoyer le formulaire de commentaire

### DIFF
--- a/src/entities/models/comment/manager.ts
+++ b/src/entities/models/comment/manager.ts
@@ -4,10 +4,10 @@ import { userNameService } from "@entities/models/userName/service";
 import { todoService } from "@entities/models/todo/service";
 import { postService } from "@entities/models/post/service";
 import type {
-    CommentModel,
+    CommentType,
     CommentFormType,
-    CommentCreateInput,
-    CommentUpdateInput,
+    CommentTypeCreateInput,
+    CommentTypeUpdateInput,
 } from "@src/types/models/comment";
 import type { UserNameType } from "@entities/models/userName/types";
 import type { TodoModel } from "@src/types/models/todo";
@@ -22,25 +22,19 @@ const initialCommentForm: CommentFormType = {
     todoId: "",
     postId: "",
     userNameId: "",
-    todo: null as unknown as CommentFormType["todo"],
-    post: null as unknown as CommentFormType["post"],
-    userName: null as unknown as CommentFormType["userName"],
 };
 
-function toCommentForm(comment: CommentModel): CommentFormType {
+function toCommentForm(comment: CommentType): CommentFormType {
     return {
         id: comment.id ?? "",
         content: comment.content ?? "",
         todoId: comment.todoId ?? "",
         postId: comment.postId ?? "",
         userNameId: comment.userNameId ?? "",
-        todo: (comment.todo ?? null) as unknown as CommentFormType["todo"],
-        post: (comment.post ?? null) as unknown as CommentFormType["post"],
-        userName: (comment.userName ?? null) as unknown as CommentFormType["userName"],
     };
 }
 
-function toCommentCreate(form: CommentFormType): CommentCreateInput {
+function toCommentCreate(form: CommentFormType): CommentTypeCreateInput {
     return {
         content: form.content,
         todoId: form.todoId || undefined,
@@ -49,13 +43,13 @@ function toCommentCreate(form: CommentFormType): CommentCreateInput {
     };
 }
 
-function toCommentUpdate(form: CommentFormType): CommentUpdateInput {
+function toCommentUpdate(form: CommentFormType): CommentTypeUpdateInput {
     return {
         content: form.content,
         todoId: form.todoId || undefined,
         postId: form.postId || undefined,
         userNameId: form.userNameId,
-    } as CommentUpdateInput;
+    } as CommentTypeUpdateInput;
 }
 
 export function createCommentManager() {

--- a/src/entities/models/todo/manager.ts
+++ b/src/entities/models/todo/manager.ts
@@ -9,10 +9,10 @@ import {
     toTodoUpdate,
 } from "@entities/models/todo/form";
 import type { TodoModel, TodoFormType } from "@entities/models/todo/types";
-import type { CommentModel } from "@src/types/models/comment";
+import type { CommentType } from "@src/types/models/comment";
 
 type Id = string;
-type Extras = { comments: CommentModel[] };
+type Extras = { comments: CommentType[] };
 
 export function createTodoManager() {
     return createManager<TodoModel, TodoFormType, Id, Extras>({


### PR DESCRIPTION
## Description
- correction des types et du formulaire de commentaire
- alignement du gestionnaire Todo avec `CommentType`

## Tests effectués
- `yarn lint`
- `yarn tsc -p tsconfig.json`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a72719bd3483249fbca17c477b1ba3