### PR TITLE
[Fix] typer les callbacks observeQuery

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,8 +16,8 @@ export default function TodosPublicPage() {
                 authMode: "apiKey", // 👈 force l'accès public même sans connexion
             })
             .subscribe({
-                next: ({ items }) => setTodos(items),
-                error: (err) => console.error("observeQuery error", err),
+                next: ({ items }: { items: Schema["Todo"]["type"][] }) => setTodos(items),
+                error: (err: unknown) => console.error("observeQuery error", err),
             });
 
         return () => sub.unsubscribe();


### PR DESCRIPTION
## Objectif
- typer les callbacks `next` et `error` dans `app/page.tsx`.

## Tests effectués
- `yarn install`
- `yarn prettier app/page.tsx --write`
- `yarn lint`
- `yarn tsc -p tsconfig.json` *(échoué : erreurs TypeScript existantes)*
- `yarn build`
- `yarn test` *(échoué : tests existants)*

------
https://chatgpt.com/codex/tasks/task_e_68a727187e8083249bd176196d20cda5