### PR TITLE
[Fix] utilise les CreateInput des relations

### DIFF
--- a/src/entities/core/types/amplifyBaseTypes.ts
+++ b/src/entities/core/types/amplifyBaseTypes.ts
@@ -5,6 +5,8 @@ export type BaseModel<K extends keyof Schema> = Schema[K]["type"];
 
 export type CreateOmit<K extends keyof Schema> = Omit<BaseModel<K>, "createdAt" | "updatedAt">;
 
+export type CreateInput<K extends keyof Schema> = CreateOmit<K>;
+
 export type UpdateInput<K extends keyof Schema> = Partial<CreateOmit<K>>;
 
 export type ModelForm<

--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -2,12 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 import { postTagService } from "@entities/relations/postTag/service";
+import type { PostTagTypeCreateInput } from "@entities/relations/postTag/types";
 import type { ListRequest, CreateRequest, DeleteRequest } from "@test/fixtures/relations";
-
-interface PostTagIds {
-    postId: string;
-    tagId: string;
-}
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const mockModel = {
@@ -74,10 +70,10 @@ describe("postTagService", () => {
     });
 
     it("create envoie les IDs corrects", async () => {
-        let received: CreateRequest<PostTagIds>;
+        let received: CreateRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<PostTagIds>;
+                received = (await request.json()) as CreateRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -86,10 +82,10 @@ describe("postTagService", () => {
     });
 
     it("delete envoie les IDs corrects", async () => {
-        let received: DeleteRequest<PostTagIds>;
+        let received: DeleteRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<PostTagIds>;
+                received = (await request.json()) as DeleteRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -98,10 +94,10 @@ describe("postTagService", () => {
     });
 
     it("échoue avec authMode apiKey", async () => {
-        let received: CreateRequest<PostTagIds>;
+        let received: CreateRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<PostTagIds>;
+                received = (await request.json()) as CreateRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -112,10 +108,10 @@ describe("postTagService", () => {
     });
 
     it("échoue avec authMode userPool", async () => {
-        let received: DeleteRequest<PostTagIds>;
+        let received: DeleteRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<PostTagIds>;
+                received = (await request.json()) as DeleteRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );

--- a/src/entities/relations/postTag/types.ts
+++ b/src/entities/relations/postTag/types.ts
@@ -1,5 +1,6 @@
-import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core";
+import type { BaseModel, CreateOmit, UpdateInput, CreateInput } from "@entities/core";
 
 export type PostTagType = BaseModel<"PostTag">;
 export type PostTagTypeOmit = CreateOmit<"PostTag">;
+export type PostTagTypeCreateInput = CreateInput<"PostTag">;
 export type PostTagTypeUpdateInput = UpdateInput<"PostTag">;

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -2,12 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
+import type { SectionPostTypeCreateInput } from "@entities/relations/sectionPost/types";
 import type { ListRequest, CreateRequest, DeleteRequest } from "@test/fixtures/relations";
-
-interface SectionPostIds {
-    sectionId: string;
-    postId: string;
-}
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const mockModel = {
@@ -80,10 +76,10 @@ describe("sectionPostService", () => {
     });
 
     it("create envoie les IDs corrects", async () => {
-        let received: CreateRequest<SectionPostIds>;
+        let received: CreateRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<SectionPostIds>;
+                received = (await request.json()) as CreateRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -92,10 +88,10 @@ describe("sectionPostService", () => {
     });
 
     it("delete envoie les IDs corrects", async () => {
-        let received: DeleteRequest<SectionPostIds>;
+        let received: DeleteRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<SectionPostIds>;
+                received = (await request.json()) as DeleteRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -104,10 +100,10 @@ describe("sectionPostService", () => {
     });
 
     it("échoue avec authMode apiKey", async () => {
-        let received: CreateRequest<SectionPostIds>;
+        let received: CreateRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<SectionPostIds>;
+                received = (await request.json()) as CreateRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -118,10 +114,10 @@ describe("sectionPostService", () => {
     });
 
     it("échoue avec authMode userPool", async () => {
-        let received: DeleteRequest<SectionPostIds>;
+        let received: DeleteRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<SectionPostIds>;
+                received = (await request.json()) as DeleteRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );

--- a/src/entities/relations/sectionPost/types.ts
+++ b/src/entities/relations/sectionPost/types.ts
@@ -1,5 +1,6 @@
-import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core";
+import type { BaseModel, CreateOmit, UpdateInput, CreateInput } from "@entities/core";
 
 export type SectionPostType = BaseModel<"SectionPost">;
 export type SectionPostTypeOmit = CreateOmit<"SectionPost">;
+export type SectionPostTypeCreateInput = CreateInput<"SectionPost">;
 export type SectionPostTypeUpdateInput = UpdateInput<"SectionPost">;


### PR DESCRIPTION
## Résumé
- expose les types PostTagTypeCreateInput et SectionPostTypeCreateInput
- remplace les interfaces de test par les CreateInput générés

## Tests effectués
- `yarn lint`
- `yarn tsc`
- `yarn build`
- `yarn test` *(échoue: modules manquants)*
- `yarn vitest run src/entities/relations/postTag/__tests__/service.test.ts src/entities/relations/sectionPost/__tests__/service.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a729a893b88324a571093254283faa