### PR TITLE
[Feat] ajouter alias de création pour les relations

### DIFF
--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -3,11 +3,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 import { postTagService } from "@entities/relations/postTag/service";
 import type { ListRequest, CreateRequest, DeleteRequest } from "@test/fixtures/relations";
-
-interface PostTagIds {
-    postId: string;
-    tagId: string;
-}
+import type { PostTagTypeCreateInput } from "@entities/relations/postTag/types";
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const mockModel = {
@@ -74,10 +70,10 @@ describe("postTagService", () => {
     });
 
     it("create envoie les IDs corrects", async () => {
-        let received: CreateRequest<PostTagIds>;
+        let received: CreateRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<PostTagIds>;
+                received = (await request.json()) as CreateRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -86,10 +82,10 @@ describe("postTagService", () => {
     });
 
     it("delete envoie les IDs corrects", async () => {
-        let received: DeleteRequest<PostTagIds>;
+        let received: DeleteRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<PostTagIds>;
+                received = (await request.json()) as DeleteRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -98,10 +94,10 @@ describe("postTagService", () => {
     });
 
     it("échoue avec authMode apiKey", async () => {
-        let received: CreateRequest<PostTagIds>;
+        let received: CreateRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<PostTagIds>;
+                received = (await request.json()) as CreateRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -112,10 +108,10 @@ describe("postTagService", () => {
     });
 
     it("échoue avec authMode userPool", async () => {
-        let received: DeleteRequest<PostTagIds>;
+        let received: DeleteRequest<PostTagTypeCreateInput>;
         server.use(
             http.post("https://api.test/postTag/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<PostTagIds>;
+                received = (await request.json()) as DeleteRequest<PostTagTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );

--- a/src/entities/relations/postTag/types.ts
+++ b/src/entities/relations/postTag/types.ts
@@ -2,4 +2,5 @@ import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core";
 
 export type PostTagType = BaseModel<"PostTag">;
 export type PostTagTypeOmit = CreateOmit<"PostTag">;
+export type PostTagTypeCreateInput = CreateOmit<"PostTag">;
 export type PostTagTypeUpdateInput = UpdateInput<"PostTag">;

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -3,11 +3,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 import { sectionPostService } from "@entities/relations/sectionPost/service";
 import type { ListRequest, CreateRequest, DeleteRequest } from "@test/fixtures/relations";
-
-interface SectionPostIds {
-    sectionId: string;
-    postId: string;
-}
+import type { SectionPostTypeCreateInput } from "@entities/relations/sectionPost/types";
 
 vi.mock("@entities/core/services/amplifyClient", () => {
     const mockModel = {
@@ -80,10 +76,10 @@ describe("sectionPostService", () => {
     });
 
     it("create envoie les IDs corrects", async () => {
-        let received: CreateRequest<SectionPostIds>;
+        let received: CreateRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<SectionPostIds>;
+                received = (await request.json()) as CreateRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -92,10 +88,10 @@ describe("sectionPostService", () => {
     });
 
     it("delete envoie les IDs corrects", async () => {
-        let received: DeleteRequest<SectionPostIds>;
+        let received: DeleteRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<SectionPostIds>;
+                received = (await request.json()) as DeleteRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ data: {} });
             })
         );
@@ -104,10 +100,10 @@ describe("sectionPostService", () => {
     });
 
     it("échoue avec authMode apiKey", async () => {
-        let received: CreateRequest<SectionPostIds>;
+        let received: CreateRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/create", async ({ request }) => {
-                received = (await request.json()) as CreateRequest<SectionPostIds>;
+                received = (await request.json()) as CreateRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );
@@ -118,10 +114,10 @@ describe("sectionPostService", () => {
     });
 
     it("échoue avec authMode userPool", async () => {
-        let received: DeleteRequest<SectionPostIds>;
+        let received: DeleteRequest<SectionPostTypeCreateInput>;
         server.use(
             http.post("https://api.test/sectionPost/delete", async ({ request }) => {
-                received = (await request.json()) as DeleteRequest<SectionPostIds>;
+                received = (await request.json()) as DeleteRequest<SectionPostTypeCreateInput>;
                 return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
             })
         );

--- a/src/entities/relations/sectionPost/types.ts
+++ b/src/entities/relations/sectionPost/types.ts
@@ -2,4 +2,5 @@ import type { BaseModel, CreateOmit, UpdateInput } from "@entities/core";
 
 export type SectionPostType = BaseModel<"SectionPost">;
 export type SectionPostTypeOmit = CreateOmit<"SectionPost">;
+export type SectionPostTypeCreateInput = CreateOmit<"SectionPost">;
 export type SectionPostTypeUpdateInput = UpdateInput<"SectionPost">;


### PR DESCRIPTION
## Description
- ajoute les types `PostTagTypeCreateInput` et `SectionPostTypeCreateInput`
- met à jour les tests des relations pour utiliser ces alias

## Tests effectués
- `yarn install`
- `yarn prettier --write .`
- `yarn lint`
- `yarn tsc`
- `yarn test` *(échec : imports introuvables et assertions dans d'autres suites)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a729a2495c8324bebf0a5a3179b234