### PR TITLE
[Fix] supprime export commenté

### DIFF
--- a/src/entities/relations/postTag/index.ts
+++ b/src/entities/relations/postTag/index.ts
@@ -1,3 +1,2 @@
 export * from "./types";
-// export * from "./sectionForm";
 export { postTagService } from "./service";


### PR DESCRIPTION
## Objectif
- retirer la ligne commentée dans `postTag/index.ts`

## Tests effectués
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test` *(en échec: Failed to resolve import "@entities/models/author/hooks" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a729a3be2c83249229af0c243aa4a2