### PR TITLE
[Feat] gérer l'utilisateur non authentifié

### DIFF
--- a/src/entities/core/auth/getUserSub.ts
+++ b/src/entities/core/auth/getUserSub.ts
@@ -1,7 +1,17 @@
 import { getCurrentUser } from "aws-amplify/auth";
 
 // src/entities/core/auth/getUserSub.ts
+export async function tryGetUserSub(): Promise<string | null> {
+    try {
+        const u = await getCurrentUser();
+        return u.userId ?? (u as any)?.attributes?.sub ?? u.username ?? null;
+    } catch {
+        return null;
+    }
+}
+
 export async function getUserSub(): Promise<string> {
-    const u = await getCurrentUser();
-    return u.userId ?? (u as any)?.attributes?.sub ?? u.username;
+    const sub = await tryGetUserSub();
+    if (!sub) throw new Error("User not authenticated");
+    return sub;
 }


### PR DESCRIPTION
## Objectif
- éviter les crashes silencieux lorsque l'utilisateur n'est pas connecté
- sécuriser les managers userName et userProfile

## Changements
- ajout de `tryGetUserSub` pour renvoyer `null` si absence de session
- gestion explicite de l'absence de `sub` avant create/update/delete

## Tests effectués
- `yarn install`
- `yarn prettier src/entities/core/auth/getUserSub.ts src/entities/models/userName/manager.ts src/entities/models/userProfile/manager.ts --write`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a742509e8c83249a000a61f2ba02e4