### PR TITLE
[Feat] support du variant mini pour FormActionButtons

### DIFF
--- a/src/components/Blog/manage/components/FormActionButtons.tsx
+++ b/src/components/Blog/manage/components/FormActionButtons.tsx
@@ -13,6 +13,7 @@ interface FormActionButtonsProps {
     isFormNew: boolean;
     addButtonLabel?: string;
     className?: string;
+    variant?: "mini" | "normal";
 }
 
 export default function FormActionButtons({
@@ -25,6 +26,7 @@ export default function FormActionButtons({
     isFormNew,
     addButtonLabel = "Ajouter",
     className = "",
+    variant = "normal",
 }: FormActionButtonsProps): React.ReactElement {
     if (isFormNew && editingId === null) {
         return (
@@ -50,49 +52,41 @@ export default function FormActionButtons({
         );
     }
 
-    return (
-        <>
-            <div className="flex gap-2 ">
-                <EditButton
-                    onClick={onEdit}
-                    className="!p-2 !h-8"
-                    color="#1976d2"
-                    label="Modifier"
-                />
-                <DeleteButton onClick={onDelete} className="!p-2 !h-8" label="Supprimer" />
-            </div>
-            <div className="flex gap-2 ">
+    const miniButtonSx = {
+        borderColor: "#bbb",
+        minHeight: 32,
+        borderRadius: 2,
+        fontSize: 14,
+        fontWeight: 400,
+        transition: "all .15s",
+    };
+
+    if (variant === "mini") {
+        return (
+            <div className="flex gap-2">
                 <ButtonBase
                     label="Modifier"
                     onClick={onEdit}
-                    color={onClick() ? "primary" : "inherit"}
-                    variant={onClick() ? "contained" : "outlined"}
-                    sx={{
-                        fontWeight: onClick() ? 700 : 400,
-                        opacity: onClick() ? 1 : 0.7,
-                        borderColor: "#bbb",
-                        minHeight: 32,
-                        borderRadius: 2,
-                        fontSize: 14,
-                        transition: "all .15s",
-                    }}
+                    size="small"
+                    variant="outlined"
+                    sx={miniButtonSx}
                 />
                 <ButtonBase
                     label="Supprimer"
                     onClick={onDelete}
-                    color={onClick() ? "primary" : "inherit"}
-                    variant={onClick() ? "contained" : "outlined"}
-                    sx={{
-                        fontWeight: onClick() ? 700 : 400,
-                        opacity: onClick() ? 1 : 0.7,
-                        borderColor: "#bbb",
-                        minHeight: 32,
-                        borderRadius: 2,
-                        fontSize: 14,
-                        transition: "all .15s",
-                    }}
+                    size="small"
+                    color="error"
+                    variant="outlined"
+                    sx={miniButtonSx}
                 />
             </div>
-        </>
+        );
+    }
+
+    return (
+        <div className="flex gap-2">
+            <EditButton onClick={onEdit} className="!p-2 !h-8" color="#1976d2" label="Modifier" />
+            <DeleteButton onClick={onDelete} className="!p-2 !h-8" label="Supprimer" />
+        </div>
     );
 }


### PR DESCRIPTION
## Résumé
- ajoute un prop `variant` pour basculer entre les boutons normaux et mini
- utilise `ButtonBase` en taille `small` pour le variant mini
- supprime les rendus dupliqués et ne renvoie qu'un groupe de boutons

## Tests effectués
- `yarn install`
- `yarn prettier src/components/Blog/manage/components/FormActionButtons.tsx --write`
- `yarn lint` *(échoue : Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a755c86e2c83248e984bccd0fa7ef2