### PR TITLE
[Feat] synchroniser les posts d'un tag

### DIFF
--- a/src/components/Blog/manage/GenericList.tsx
+++ b/src/components/Blog/manage/GenericList.tsx
@@ -31,7 +31,6 @@ interface GenericListProps<T> {
     itemClassName?: (active: boolean) => string;
     /** Arrondis/ombres cohérents */
     rounded?: boolean;
-    variant?: string;
     editButtonlabel?: string;
     deleteButtonlabel?: string;
 }
@@ -52,7 +51,6 @@ export default function GenericList<T>({
     rounded = true,
     editButtonlabel,
     deleteButtonlabel,
-    variant,
 }: GenericListProps<T>) {
     const sorted = useMemo(() => {
         const indexed = items.map((item, originalIndex) => ({

--- a/src/components/Blog/manage/components/FormActionButtons.tsx
+++ b/src/components/Blog/manage/components/FormActionButtons.tsx
@@ -14,6 +14,8 @@ interface FormActionButtonsProps {
     addButtonLabel?: string;
     className?: string;
     variant?: "no-Icon" | "normal";
+    editButtonlabel?: string;
+    deleteButtonlabel?: string;
 }
 
 export default function FormActionButtons({

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -15,8 +15,6 @@ interface Props {
     onSave: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
-    editButtonlabel: string;
-    deleteButtonlabel: string;
 }
 
 export default function PostList(props: Props) {
@@ -35,8 +33,8 @@ export default function PostList(props: Props) {
             onSave={props.onSave}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
-            editButtonlabel={"Modifier"}
-            deleteButtonlabel={"Supprimer"}
+            editButtonlabel="Modifier"
+            deleteButtonlabel="Supprimer"
         />
     );
 }

--- a/src/components/Blog/manage/tags/TagList.tsx
+++ b/src/components/Blog/manage/tags/TagList.tsx
@@ -14,6 +14,8 @@ interface Props {
     onSave: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
+    editButtonlabel?: string;
+    deleteButtonlabel?: string;
 }
 
 function TagListInner({

--- a/src/components/buttons/Buttons.tsx
+++ b/src/components/buttons/Buttons.tsx
@@ -37,7 +37,7 @@ export function EditButton({ onClick, label, className, color, size, sx = {} }: 
             className={className}
             variant="outlined"
             size={size}
-            sx={{ ...getEditButtonStyles(color), ...sx }}
+            sx={{ ...getEditButtonStyles(color), ...(sx as object) }}
         />
     );
 }
@@ -53,7 +53,7 @@ export function DeleteButton({ onClick, label, className, size, sx = {} }: Butto
             className={className}
             variant="outlined"
             size={size}
-            sx={{ ...deleteButtonStyles, ...sx }}
+            sx={{ ...deleteButtonStyles, ...(sx as object) }}
         />
     );
 }
@@ -171,7 +171,7 @@ export function PowerButton({ onClick, label, className, size, sx = {} }: Button
             className={className}
             variant="outlined"
             size={size}
-            sx={{ ...deleteButtonStyles, ...sx }}
+            sx={{ ...deleteButtonStyles, ...(sx as object) }}
         />
     );
 }

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -7,7 +7,7 @@ import { postTagService } from "@entities/relations/postTag/service";
 import { type TagFormType, type TagType } from "@entities/models/tag/types";
 import { type PostType } from "@entities/models/post/types";
 import { initialTagForm, toTagForm } from "@entities/models/tag/form";
-import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
+import { syncTagPosts } from "@entities/relations/postTag/sync";
 
 // Pivot léger côté UI
 type PostTagLink = { postId: string; tagId: string };
@@ -45,17 +45,7 @@ export function useTagForm() {
             return data.id;
         },
         syncRelations: async (tagId, form) => {
-            // 🔁 compare des IDs (postIds actuels vs désirés)
-            const currentPostIds = await postTagService.listByChild(tagId); // idéal: string[]
-            // Si ton service renvoie des objets, décommente la normalisation :
-            // const currentPostIds = (await postTagService.listByChild(tagId)).map(x => x.postId);
-
-            await syncManyToMany(
-                currentPostIds,
-                form.postIds,
-                (postId) => postTagService.create(postId, tagId),
-                (postId) => postTagService.delete(postId, tagId)
-            );
+            await syncTagPosts(tagId, form.postIds);
         },
     });
 

--- a/src/entities/relations/postTag/index.ts
+++ b/src/entities/relations/postTag/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 // export * from "./sectionForm";
 export { postTagService } from "./service";
+export { syncTagPosts } from "./sync";

--- a/src/entities/relations/postTag/sync.ts
+++ b/src/entities/relations/postTag/sync.ts
@@ -1,0 +1,12 @@
+import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
+import { postTagService } from "./service";
+
+export async function syncTagPosts(tagId: string, targetPostIds: string[]) {
+    const currentPostIds = await postTagService.listByChild(tagId);
+    await syncManyToMany(
+        currentPostIds,
+        targetPostIds,
+        (postId) => postTagService.create(postId, tagId),
+        (postId) => postTagService.delete(postId, tagId)
+    );
+}


### PR DESCRIPTION
## Objectif
- introduire `syncTagPosts` pour gérer la synchro des articles liés à un tag
- utiliser cette fonction dans les hooks du modèle Tag
- corriger divers problèmes de typage pour permettre la construction du projet

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a76f3fa070832485d1d60005431ff9