### PR TITLE
[Feat] utilitaires de synchronisation des relations de post

### DIFF
--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -12,7 +12,8 @@ import { type PostFormType, type PostType } from "@entities/models/post/types";
 import { type AuthorType } from "@entities/models/author/types";
 import { type TagType } from "@entities/models/tag/types";
 import { type SectionType } from "@entities/models/section/types";
-import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
+import { syncPostTags } from "@entities/relations/postTag/sync";
+import { syncPostSections } from "@entities/relations/sectionPost/sync";
 
 interface Extras extends Record<string, unknown> {
     authors: AuthorType[];
@@ -56,23 +57,9 @@ export function usePostForm(post: PostType | null) {
             return data.id;
         },
         syncRelations: async (id, form) => {
-            const [currentTagIds, currentSectionIds] = await Promise.all([
-                postTagService.listByParent(id),
-                sectionPostService.listByChild(id),
-            ]);
             await Promise.all([
-                syncManyToMany(
-                    currentTagIds,
-                    form.tagIds,
-                    (tagId) => postTagService.create(id, tagId),
-                    (tagId) => postTagService.delete(id, tagId)
-                ),
-                syncManyToMany(
-                    currentSectionIds,
-                    form.sectionIds,
-                    (sectionId) => sectionPostService.create(sectionId, id),
-                    (sectionId) => sectionPostService.delete(sectionId, id)
-                ),
+                syncPostTags(id, form.tagIds),
+                syncPostSections(id, form.sectionIds),
             ]);
         },
     });

--- a/src/entities/relations/postTag/sync.ts
+++ b/src/entities/relations/postTag/sync.ts
@@ -1,0 +1,13 @@
+// src/entities/relations/postTag/sync.ts
+import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
+import { postTagService } from "./service";
+
+export async function syncPostTags(postId: string, targetTagIds: string[]) {
+    const currentTagIds = await postTagService.listByParent(postId);
+    await syncManyToMany(
+        currentTagIds,
+        targetTagIds,
+        (tagId) => postTagService.create(postId, tagId),
+        (tagId) => postTagService.delete(postId, tagId)
+    );
+}

--- a/src/entities/relations/sectionPost/sync.ts
+++ b/src/entities/relations/sectionPost/sync.ts
@@ -1,0 +1,13 @@
+// src/entities/relations/sectionPost/sync.ts
+import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
+import { sectionPostService } from "./service";
+
+export async function syncPostSections(postId: string, targetSectionIds: string[]) {
+    const currentSectionIds = await sectionPostService.listByChild(postId);
+    await syncManyToMany(
+        currentSectionIds,
+        targetSectionIds,
+        (sectionId) => sectionPostService.create(sectionId, postId),
+        (sectionId) => sectionPostService.delete(sectionId, postId)
+    );
+}


### PR DESCRIPTION
## Description
- extrait la synchronisation des tags et sections d'un post dans des helpers dédiés
- utilise ces helpers dans le hook du post

## Tests effectués
- `yarn prettier --write src/entities/relations/postTag/sync.ts src/entities/relations/sectionPost/sync.ts src/entities/models/post/hooks.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76f1d69088324b7439ce25250db0f