### PR TITLE
[Feat] synchronisation des posts d'une section

### DIFF
--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -6,7 +6,7 @@ import { sectionPostService } from "@entities/relations/sectionPost/service";
 import { initialSectionForm, toSectionForm } from "@entities/models/section/form";
 import { type SectionFormTypes, type SectionType } from "@entities/models/section/types";
 import { type PostType } from "@entities/models/post/types";
-import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
+import { syncSectionPosts } from "@entities/relations/sectionPost/sync";
 
 type Extras = { posts: PostType[]; sections: SectionType[] };
 
@@ -39,15 +39,7 @@ export function useSectionForm(section: SectionType | null) {
             return data.id;
         },
         syncRelations: async (id, form) => {
-            const [currentPostIds] = await Promise.all([sectionPostService.listByParent(id)]);
-            await Promise.all([
-                syncManyToMany(
-                    currentPostIds,
-                    form.postIds,
-                    (postId) => sectionPostService.create(id, postId),
-                    (postId) => sectionPostService.delete(id, postId)
-                ),
-            ]);
+            await syncSectionPosts(id, form.postIds);
         },
     });
 

--- a/src/entities/relations/sectionPost/index.ts
+++ b/src/entities/relations/sectionPost/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export { sectionPostService } from "./service";
+export { syncSectionPosts } from "./sync";

--- a/src/entities/relations/sectionPost/sync.ts
+++ b/src/entities/relations/sectionPost/sync.ts
@@ -1,0 +1,12 @@
+import { syncManyToMany } from "@entities/core/utils/syncManyToMany";
+import { sectionPostService } from "@entities/relations/sectionPost/service";
+
+export async function syncSectionPosts(sectionId: string, targetPostIds: string[]) {
+    const currentPostIds = await sectionPostService.listByParent(sectionId);
+    await syncManyToMany(
+        currentPostIds,
+        targetPostIds,
+        (postId) => sectionPostService.create(sectionId, postId),
+        (postId) => sectionPostService.delete(sectionId, postId)
+    );
+}


### PR DESCRIPTION
## Description
- crée `syncSectionPosts` pour encapsuler la synchronisation section/post
- utilise `syncSectionPosts` dans `useSectionForm`

## Tests effectués
- `yarn install`
- `yarn prettier --write src/entities/relations/sectionPost/sync.ts src/entities/relations/sectionPost/index.ts src/entities/models/section/hooks.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76f49b0c883249958e397e585a11c