### PR TITLE
[Feat] renommer les handlers de commentaires

### DIFF
--- a/app/todo/TodosWithCommentsPage.tsx
+++ b/app/todo/TodosWithCommentsPage.tsx
@@ -9,8 +9,8 @@ export default function TodosWithCommentsPage() {
         comments,
         createTodo,
         addComment,
-        editComment,
-        deleteComment,
+        enterEditMode,
+        deleteForm,
         deleteTodo,
         canModifyComment,
     } = useTodosWithComments();
@@ -28,8 +28,8 @@ export default function TodosWithCommentsPage() {
                 comments={comments}
                 onDeleteTodo={deleteTodo}
                 onAddComment={addComment}
-                onEditComment={editComment}
-                onDeleteComment={deleteComment}
+                enterEditMode={enterEditMode}
+                deleteForm={deleteForm}
                 canModify={canModifyComment}
             />
         </section>

--- a/src/components/todo/CommentList.tsx
+++ b/src/components/todo/CommentList.tsx
@@ -4,15 +4,18 @@ import { EditButton, DeleteButton } from "@/src/components/buttons/Buttons";
 
 interface CommentListProps {
     comments: CommentWithTodoId[];
-    onEditComment: (id: string, ownerId?: string) => void;
-    onDeleteComment: (id: string, ownerId?: string) => void;
+    enterEditMode: (id: string, ownerId?: string) => void;
+    deleteForm: (id: string, ownerId?: string) => void;
+    /**
+     * Indique si l'utilisateur peut modifier ou supprimer le commentaire.
+     */
     canModify: (ownerId?: string) => boolean;
 }
 
 export default function CommentList({
     comments,
-    onEditComment,
-    onDeleteComment,
+    enterEditMode,
+    deleteForm,
     canModify,
 }: CommentListProps) {
     return (
@@ -32,13 +35,13 @@ export default function CommentList({
                         {canModify(comment.userNameId) && (
                             <div className="flex gap-2">
                                 <EditButton
-                                    onClick={() => onEditComment(comment.id, comment.userNameId)}
+                                    onClick={() => enterEditMode(comment.id, comment.userNameId)}
                                     label="Modifier"
                                     className="text-xs"
                                     size="small"
                                 />
                                 <DeleteButton
-                                    onClick={() => onDeleteComment(comment.id, comment.userNameId)}
+                                    onClick={() => deleteForm(comment.id, comment.userNameId)}
                                     label="Supprimer"
                                     className="text-xs"
                                     size="small"

--- a/src/components/todo/TodoList.tsx
+++ b/src/components/todo/TodoList.tsx
@@ -9,8 +9,11 @@ interface TodoListProps {
     comments: CommentWithTodoId[];
     onDeleteTodo: (id: string) => void;
     onAddComment: (todoId: string) => void;
-    onEditComment: (id: string, ownerId?: string) => void;
-    onDeleteComment: (id: string, ownerId?: string) => void;
+    enterEditMode: (id: string, ownerId?: string) => void;
+    deleteForm: (id: string, ownerId?: string) => void;
+    /**
+     * Vérifie si l'utilisateur courant est autorisé à modifier un contenu.
+     */
     canModify: (ownerId?: string | null) => boolean;
 }
 
@@ -19,8 +22,8 @@ export default function TodoList({
     comments,
     onDeleteTodo,
     onAddComment,
-    onEditComment,
-    onDeleteComment,
+    enterEditMode,
+    deleteForm,
     canModify,
 }: TodoListProps) {
     if (todos.length === 0)
@@ -55,8 +58,8 @@ export default function TodoList({
                         {todoComments.length > 0 && (
                             <CommentList
                                 comments={todoComments}
-                                onEditComment={onEditComment}
-                                onDeleteComment={onDeleteComment}
+                                enterEditMode={enterEditMode}
+                                deleteForm={deleteForm}
                                 canModify={canModify}
                             />
                         )}

--- a/src/components/todo/useTodosWithComments.ts
+++ b/src/components/todo/useTodosWithComments.ts
@@ -100,14 +100,14 @@ export default function useTodosWithComments() {
         await commentService.create(input);
     };
 
-    const editComment = async (id: string, ownerId?: string) => {
+    const enterEditMode = async (id: string, ownerId?: string) => {
         if (!canModifyComment(ownerId)) return;
         const content = window.prompt("Modifier ce commentaire ?");
         if (!content) return;
         await commentService.update({ id, content });
     };
 
-    const deleteComment = (id: string, ownerId?: string) => {
+    const deleteForm = (id: string, ownerId?: string) => {
         if (!canModifyComment(ownerId)) return;
         if (confirm("Supprimer ce commentaire ?")) {
             void commentService.delete({ id });
@@ -133,8 +133,8 @@ export default function useTodosWithComments() {
         comments,
         createTodo,
         addComment,
-        editComment,
-        deleteComment,
+        enterEditMode,
+        deleteForm,
         deleteTodo,
         canModifyComment,
     };

--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -14,7 +14,6 @@ import { type TagType } from "@entities/models/tag/types";
 import { type SectionType } from "@entities/models/section/types";
 import { syncPost2Tags } from "@entities/relations/postTag";
 import { syncPost2Sections } from "@entities/relations/sectionPost";
-import { unknown } from "zod";
 interface Extras extends Record<string, unknown> {
     authors: AuthorType[];
     tags: TagType[];


### PR DESCRIPTION
## Description
- renommer `onEditComment` en `enterEditMode`
- exposer `onDeleteComment` sous `deleteForm`
- documenter `canModify`
- retirer une importation inutilisée dans `usePostForm`

## Tests effectués
- `yarn lint`
- `yarn build` *(échoué: Type error: Type '() => Promise<boolean>' is not assignable to type '() => Promise<void>')*

------
https://chatgpt.com/codex/tasks/task_e_68a7e13c64b883248e5b68b53e6f5cac