### PR TITLE
[Feat] centraliser requestSubmit dans les listes

### DIFF
--- a/src/components/Blog/manage/GenericList.tsx
+++ b/src/components/Blog/manage/GenericList.tsx
@@ -20,10 +20,11 @@ interface GenericListProps<T> {
     sortBy?: (a: T, b: T) => number;
 
     /** Actions */
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    enterEditModeById: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
+    onRequestSubmit?: () => void;
 
     /** Style */
     className?: string;
@@ -41,10 +42,11 @@ export default function GenericList<T>({
     getId,
     renderContent,
     sortBy,
-    onEditById,
-    onSave,
+    enterEditModeById,
+    requestSubmit,
     onCancel,
     onDeleteById,
+    onRequestSubmit,
     className,
     itemWrapperClassName,
     itemClassName,
@@ -77,8 +79,9 @@ export default function GenericList<T>({
                         <FormActionButtons
                             editingId={editingId}
                             currentId={id}
-                            onEdit={() => onEditById(id)}
-                            onSave={onSave}
+                            onEdit={() => enterEditModeById(id)}
+                            requestSubmit={requestSubmit}
+                            onRequestSubmit={onRequestSubmit}
                             onCancel={onCancel}
                             onDelete={() => onDeleteById(id)}
                             isFormNew={false}

--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -11,10 +11,11 @@ type IdLike = string | number;
 interface Props {
     authors: AuthorType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    enterEditModeById: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
+    onRequestSubmit?: () => void;
 }
 
 export default function AuthorList(props: Props) {
@@ -29,8 +30,9 @@ export default function AuthorList(props: Props) {
                 </p>
             )}
             sortBy={byAlpha((a) => a.authorName)}
-            onEditById={props.onEditById}
-            onSave={props.onSave}
+            enterEditModeById={props.enterEditModeById}
+            requestSubmit={props.requestSubmit}
+            onRequestSubmit={props.onRequestSubmit}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
         />

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -51,6 +51,10 @@ export default function AuthorManagerPage() {
         setEditingId(null);
     }, [fetchAuthors]);
 
+    const requestSubmit = useCallback(() => {
+        formRef.current?.requestSubmit();
+    }, []);
+
     return (
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
@@ -60,10 +64,8 @@ export default function AuthorManagerPage() {
                 <AuthorList
                     authors={authors}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={() => {
-                        formRef.current?.requestSubmit();
-                    }}
+                    enterEditModeById={handleEditById}
+                    requestSubmit={requestSubmit}
                     onCancel={() => {
                         setEditingAuthor(null);
                         setEditingId(null);

--- a/src/components/Blog/manage/components/FormActionButtons.tsx
+++ b/src/components/Blog/manage/components/FormActionButtons.tsx
@@ -7,7 +7,7 @@ interface FormActionButtonsProps {
     editingId: IdLike | null;
     currentId: IdLike;
     onEdit: () => void;
-    onSave: () => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDelete: () => void;
     isFormNew: boolean;
@@ -16,13 +16,14 @@ interface FormActionButtonsProps {
     variant?: "no-Icon" | "normal";
     editButtonLabel?: string;
     deleteButtonLabel?: string;
+    onRequestSubmit?: () => void;
 }
 
 export default function FormActionButtons({
     editingId,
     currentId,
     onEdit,
-    onSave,
+    requestSubmit,
     onCancel,
     onDelete,
     isFormNew,
@@ -31,12 +32,16 @@ export default function FormActionButtons({
     variant = "normal",
     editButtonLabel,
     deleteButtonLabel,
+    onRequestSubmit,
 }: FormActionButtonsProps): React.ReactElement {
     if (isFormNew && editingId === null) {
         return (
             <button
                 type="button"
-                onClick={onSave}
+                onClick={() => {
+                    requestSubmit();
+                    onRequestSubmit?.();
+                }}
                 className="bg-green-500 text-white py-2 rounded-lg hover:bg-green-600 transition"
             >
                 {addButtonLabel}
@@ -49,7 +54,10 @@ export default function FormActionButtons({
             <ActionButtons
                 isEditing={true}
                 onEdit={onEdit}
-                onSave={onSave}
+                requestSubmit={() => {
+                    requestSubmit();
+                    onRequestSubmit?.();
+                }}
                 onCancel={onCancel}
                 className={className}
             />

--- a/src/components/Blog/manage/components/buttons/ActionButtons.tsx
+++ b/src/components/Blog/manage/components/buttons/ActionButtons.tsx
@@ -4,7 +4,7 @@ import { EditButton, SaveButton, CancelButton } from "@components/buttons";
 type ActionButtonsProps = {
     isEditing: boolean;
     onEdit: () => void;
-    onSave: () => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     className?: string;
 };
@@ -12,7 +12,7 @@ type ActionButtonsProps = {
 const ActionButtons = ({
     isEditing,
     onEdit,
-    onSave,
+    requestSubmit,
     onCancel,
     className = "",
 }: ActionButtonsProps) => {
@@ -21,7 +21,7 @@ const ActionButtons = ({
             {!isEditing && <EditButton onClick={onEdit} label="Modifier" size="small" />}
             {isEditing && (
                 <>
-                    <SaveButton onClick={onSave} label="Enregistrer" size="small" />
+                    <SaveButton onClick={requestSubmit} label="Enregistrer" size="small" />
                     <CancelButton onClick={onCancel} label="Annuler" size="small" />
                 </>
             )}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -73,8 +73,8 @@ export default function PostManagerPage() {
                 <PostList
                     posts={posts}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={() => {
+                    enterEditModeById={handleEditById}
+                    requestSubmit={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -11,10 +11,11 @@ type IdLike = string | number;
 interface Props {
     posts: PostType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    enterEditModeById: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
+    onRequestSubmit?: () => void;
 }
 
 export default function PostList(props: Props) {
@@ -29,8 +30,9 @@ export default function PostList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEditById={props.onEditById}
-            onSave={props.onSave}
+            enterEditModeById={props.enterEditModeById}
+            requestSubmit={props.requestSubmit}
+            onRequestSubmit={props.onRequestSubmit}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
             editButtonLabel="Modifier"

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -72,8 +72,8 @@ export default function SectionManagerPage() {
                 <SectionList
                     sections={sections}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={() => {
+                    enterEditModeById={handleEditById}
+                    requestSubmit={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -10,10 +10,11 @@ type IdLike = string | number;
 interface Props {
     sections: SectionType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    enterEditModeById: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
+    onRequestSubmit?: () => void;
 }
 
 export default function SectionList(props: Props) {
@@ -28,8 +29,9 @@ export default function SectionList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEditById={props.onEditById}
-            onSave={props.onSave}
+            enterEditModeById={props.enterEditModeById}
+            requestSubmit={props.requestSubmit}
+            onRequestSubmit={props.onRequestSubmit}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
         />

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -78,8 +78,8 @@ export default function CreateTagPage() {
                 <TagList
                     tags={tags}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={submitForm}
+                    enterEditModeById={handleEditById}
+                    requestSubmit={submitForm}
                     onCancel={handleCancel}
                     onDeleteById={handleDeleteById}
                     editButtonLabel={""}

--- a/src/components/Blog/manage/tags/TagList.tsx
+++ b/src/components/Blog/manage/tags/TagList.tsx
@@ -10,23 +10,25 @@ type IdLike = string | number;
 interface Props {
     tags: TagType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    enterEditModeById: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
     editButtonLabel: string;
     deleteButtonLabel: string;
+    onRequestSubmit?: () => void;
 }
 
 function TagListInner({
     tags,
     editingId,
-    onEditById,
-    onSave,
+    enterEditModeById,
+    requestSubmit,
     onCancel,
     onDeleteById,
     editButtonLabel,
     deleteButtonLabel,
+    onRequestSubmit,
 }: Props) {
     return (
         <GenericList<TagType>
@@ -52,8 +54,9 @@ function TagListInner({
                 ].join(" ")
             }
             sortBy={byAlpha((t) => t.name)}
-            onEditById={onEditById}
-            onSave={onSave}
+            enterEditModeById={enterEditModeById}
+            requestSubmit={requestSubmit}
+            onRequestSubmit={onRequestSubmit}
             onCancel={onCancel}
             onDeleteById={onDeleteById}
             editButtonLabel={editButtonLabel}


### PR DESCRIPTION
## Description
- renomme onSave en requestSubmit
- renomme onEditById en enterEditModeById
- ajoute un callback optionnel onRequestSubmit et adapte FormActionButtons

## Tests effectués
- `yarn install` *(échoue: Fetch step bloqué)*
- `npx prettier --write src/components/Blog/manage/GenericList.tsx src/components/Blog/manage/authors/AuthorList.tsx src/components/Blog/manage/authors/CreateAuthor.tsx src/components/Blog/manage/components/FormActionButtons.tsx src/components/Blog/manage/components/buttons/ActionButtons.tsx src/components/Blog/manage/posts/CreatePost.tsx src/components/Blog/manage/posts/PostList.tsx src/components/Blog/manage/sections/CreateSection.tsx src/components/Blog/manage/sections/SectionList.tsx src/components/Blog/manage/tags/CreateTag.tsx src/components/Blog/manage/tags/TagList.tsx`
- `npx eslint .` *(échoue: ESLint config introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e111e40083249eb6aecab192eb0b