### PR TITLE
[Feat] renommer callbacks d'édition et de sauvegarde

### DIFF
--- a/src/components/Blog/manage/GenericList.tsx
+++ b/src/components/Blog/manage/GenericList.tsx
@@ -20,7 +20,7 @@ interface GenericListProps<T> {
     sortBy?: (a: T, b: T) => number;
 
     /** Actions */
-    onEditById: (id: IdLike) => void;
+    enterEditModeById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
@@ -41,7 +41,7 @@ export default function GenericList<T>({
     getId,
     renderContent,
     sortBy,
-    onEditById,
+    enterEditModeById,
     onSave,
     onCancel,
     onDeleteById,
@@ -77,7 +77,7 @@ export default function GenericList<T>({
                         <FormActionButtons
                             editingId={editingId}
                             currentId={id}
-                            onEdit={() => onEditById(id)}
+                            onEdit={() => enterEditModeById(id)}
                             onSave={onSave}
                             onCancel={onCancel}
                             onDelete={() => onDeleteById(id)}

--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -8,11 +8,11 @@ import { type AuthorFormType, initialAuthorForm, useAuthorForm } from "@entities
 
 interface Props {
     manager: ReturnType<typeof useAuthorForm>;
-    onSave: () => void;
+    afterSave: () => void;
 }
 
 const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
-    { manager, onSave },
+    { manager, afterSave },
     ref
 ) {
     const { form, handleChange } = manager;
@@ -27,7 +27,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
             ref={ref}
             manager={manager}
             initialForm={initialAuthorForm}
-            onSave={onSave}
+            onSave={afterSave}
             submitLabel={{ create: "Ajouter un auteur", edit: "Mettre à jour" }}
         >
             <EditableField

--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -11,8 +11,8 @@ type IdLike = string | number;
 interface Props {
     authors: AuthorType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    enterEditModeById: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
 }
@@ -29,8 +29,8 @@ export default function AuthorList(props: Props) {
                 </p>
             )}
             sortBy={byAlpha((a) => a.authorName)}
-            onEditById={props.onEditById}
-            onSave={props.onSave}
+            enterEditModeById={props.enterEditModeById}
+            onSave={props.requestSubmit}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
         />

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -55,13 +55,13 @@ export default function AuthorManagerPage() {
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
                 <SectionHeader className="mt-8">Nouvel auteur</SectionHeader>
-                <AuthorForm ref={formRef} manager={manager} onSave={handleSave} />
+                <AuthorForm ref={formRef} manager={manager} afterSave={handleSave} />
                 <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={() => {
+                    enterEditModeById={handleEditById}
+                    requestSubmit={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={() => {

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -73,7 +73,7 @@ export default function PostManagerPage() {
                 <PostList
                     posts={posts}
                     editingId={editingId}
-                    onEditById={handleEditById}
+                    enterEditModeById={handleEditById}
                     onSave={() => {
                         formRef.current?.requestSubmit();
                     }}

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -11,7 +11,7 @@ type IdLike = string | number;
 interface Props {
     posts: PostType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
+    enterEditModeById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
@@ -29,7 +29,7 @@ export default function PostList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEditById={props.onEditById}
+            enterEditModeById={props.enterEditModeById}
             onSave={props.onSave}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -72,7 +72,7 @@ export default function SectionManagerPage() {
                 <SectionList
                     sections={sections}
                     editingId={editingId}
-                    onEditById={handleEditById}
+                    enterEditModeById={handleEditById}
                     onSave={() => {
                         formRef.current?.requestSubmit();
                     }}

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -10,7 +10,7 @@ type IdLike = string | number;
 interface Props {
     sections: SectionType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
+    enterEditModeById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
@@ -28,7 +28,7 @@ export default function SectionList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEditById={props.onEditById}
+            enterEditModeById={props.enterEditModeById}
             onSave={props.onSave}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -78,7 +78,7 @@ export default function CreateTagPage() {
                 <TagList
                     tags={tags}
                     editingId={editingId}
-                    onEditById={handleEditById}
+                    enterEditModeById={handleEditById}
                     onSave={submitForm}
                     onCancel={handleCancel}
                     onDeleteById={handleDeleteById}

--- a/src/components/Blog/manage/tags/TagList.tsx
+++ b/src/components/Blog/manage/tags/TagList.tsx
@@ -10,7 +10,7 @@ type IdLike = string | number;
 interface Props {
     tags: TagType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
+    enterEditModeById: (id: IdLike) => void;
     onSave: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
@@ -21,7 +21,7 @@ interface Props {
 function TagListInner({
     tags,
     editingId,
-    onEditById,
+    enterEditModeById,
     onSave,
     onCancel,
     onDeleteById,
@@ -52,7 +52,7 @@ function TagListInner({
                 ].join(" ")
             }
             sortBy={byAlpha((t) => t.name)}
-            onEditById={onEditById}
+            enterEditModeById={enterEditModeById}
             onSave={onSave}
             onCancel={onCancel}
             onDeleteById={onDeleteById}

--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -14,7 +14,6 @@ import { type TagType } from "@entities/models/tag/types";
 import { type SectionType } from "@entities/models/section/types";
 import { syncPost2Tags } from "@entities/relations/postTag";
 import { syncPost2Sections } from "@entities/relations/sectionPost";
-import { unknown } from "zod";
 interface Extras extends Record<string, unknown> {
     authors: AuthorType[];
     tags: TagType[];


### PR DESCRIPTION
## Résumé
- harmonise la prop de rappel d'AuthorForm via `afterSave`
- remplace `onSave` d'AuthorList par `requestSubmit`
- généralise `enterEditModeById` pour l'édition dans les listes

## Tests
- `yarn prettier --write src/components/Blog/manage/GenericList.tsx src/components/Blog/manage/authors/AuthorForm.tsx src/components/Blog/manage/authors/AuthorList.tsx src/components/Blog/manage/authors/CreateAuthor.tsx src/components/Blog/manage/sections/SectionList.tsx src/components/Blog/manage/sections/CreateSection.tsx src/components/Blog/manage/posts/PostList.tsx src/components/Blog/manage/posts/CreatePost.tsx src/components/Blog/manage/tags/TagList.tsx src/components/Blog/manage/tags/CreateTag.tsx src/entities/models/post/hooks.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7e108413c83248f634e36c7204924