### PR TITLE
[Feat] refactorisation des callbacks d'édition

### DIFF
--- a/src/components/Blog/manage/EntityFormShell.tsx
+++ b/src/components/Blog/manage/EntityFormShell.tsx
@@ -17,7 +17,7 @@ export interface EntityFormManager<F> {
 interface Props<F> {
     manager: EntityFormManager<F>;
     initialForm: F;
-    onSave: () => void;
+    afterSave: () => void;
     children: React.ReactNode; // <- tes champs contrôlés
     submitLabel?: { create: string; edit: string };
     className?: string;
@@ -27,7 +27,7 @@ const EntityFormShellInner = <F,>(
     {
         manager,
         initialForm,
-        onSave,
+        afterSave,
         children,
         className,
         submitLabel = { create: "Créer", edit: "Mettre à jour" },
@@ -46,7 +46,7 @@ const EntityFormShellInner = <F,>(
             setMode("create");
             setForm(initialForm);
         }
-        onSave();
+        afterSave();
     }
 
     return (

--- a/src/components/Blog/manage/GenericList.tsx
+++ b/src/components/Blog/manage/GenericList.tsx
@@ -20,8 +20,9 @@ interface GenericListProps<T> {
     sortBy?: (a: T, b: T) => number;
 
     /** Actions */
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    selectById: (id: IdLike) => void;
+    enterEditMode: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
 
@@ -41,8 +42,9 @@ export default function GenericList<T>({
     getId,
     renderContent,
     sortBy,
-    onEditById,
-    onSave,
+    selectById,
+    enterEditMode,
+    requestSubmit,
     onCancel,
     onDeleteById,
     className,
@@ -77,8 +79,11 @@ export default function GenericList<T>({
                         <FormActionButtons
                             editingId={editingId}
                             currentId={id}
-                            onEdit={() => onEditById(id)}
-                            onSave={onSave}
+                            onEdit={() => {
+                                selectById(id);
+                                enterEditMode(id);
+                            }}
+                            requestSubmit={requestSubmit}
                             onCancel={onCancel}
                             onDelete={() => onDeleteById(id)}
                             isFormNew={false}

--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -8,11 +8,11 @@ import { type AuthorFormType, initialAuthorForm, useAuthorForm } from "@entities
 
 interface Props {
     manager: ReturnType<typeof useAuthorForm>;
-    onSave: () => void;
+    afterSave: () => void;
 }
 
 const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
-    { manager, onSave },
+    { manager, afterSave },
     ref
 ) {
     const { form, handleChange } = manager;
@@ -27,7 +27,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
             ref={ref}
             manager={manager}
             initialForm={initialAuthorForm}
-            onSave={onSave}
+            afterSave={afterSave}
             submitLabel={{ create: "Ajouter un auteur", edit: "Mettre à jour" }}
         >
             <EditableField

--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -11,8 +11,9 @@ type IdLike = string | number;
 interface Props {
     authors: AuthorType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    selectById: (id: IdLike) => void;
+    enterEditMode: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
 }
@@ -29,8 +30,9 @@ export default function AuthorList(props: Props) {
                 </p>
             )}
             sortBy={byAlpha((a) => a.authorName)}
-            onEditById={props.onEditById}
-            onSave={props.onSave}
+            selectById={props.selectById}
+            enterEditMode={props.enterEditMode}
+            requestSubmit={props.requestSubmit}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
         />

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -28,15 +28,17 @@ export default function AuthorManagerPage() {
         fetchAuthors();
     }, [fetchAuthors]);
 
-    const handleEditById = useCallback(
+    const selectAuthor = useCallback(
         (id: IdLike) => {
             const author = selectById(String(id));
-            if (!author) return;
-            setEditingAuthor(author);
-            setEditingId(String(id));
+            setEditingAuthor(author ?? null);
         },
         [selectById]
     );
+
+    const enterEditMode = useCallback((id: IdLike) => {
+        setEditingId(String(id));
+    }, []);
 
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
@@ -55,13 +57,14 @@ export default function AuthorManagerPage() {
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
                 <SectionHeader className="mt-8">Nouvel auteur</SectionHeader>
-                <AuthorForm ref={formRef} manager={manager} onSave={handleSave} />
+                <AuthorForm ref={formRef} manager={manager} afterSave={handleSave} />
                 <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={() => {
+                    selectById={selectAuthor}
+                    enterEditMode={enterEditMode}
+                    requestSubmit={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={() => {

--- a/src/components/Blog/manage/components/FormActionButtons.tsx
+++ b/src/components/Blog/manage/components/FormActionButtons.tsx
@@ -7,7 +7,7 @@ interface FormActionButtonsProps {
     editingId: IdLike | null;
     currentId: IdLike;
     onEdit: () => void;
-    onSave: () => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDelete: () => void;
     isFormNew: boolean;
@@ -22,7 +22,7 @@ export default function FormActionButtons({
     editingId,
     currentId,
     onEdit,
-    onSave,
+    requestSubmit,
     onCancel,
     onDelete,
     isFormNew,
@@ -36,7 +36,7 @@ export default function FormActionButtons({
         return (
             <button
                 type="button"
-                onClick={onSave}
+                onClick={requestSubmit}
                 className="bg-green-500 text-white py-2 rounded-lg hover:bg-green-600 transition"
             >
                 {addButtonLabel}
@@ -49,7 +49,7 @@ export default function FormActionButtons({
             <ActionButtons
                 isEditing={true}
                 onEdit={onEdit}
-                onSave={onSave}
+                requestSubmit={requestSubmit}
                 onCancel={onCancel}
                 className={className}
             />

--- a/src/components/Blog/manage/components/buttons/ActionButtons.tsx
+++ b/src/components/Blog/manage/components/buttons/ActionButtons.tsx
@@ -4,7 +4,7 @@ import { EditButton, SaveButton, CancelButton } from "@components/buttons";
 type ActionButtonsProps = {
     isEditing: boolean;
     onEdit: () => void;
-    onSave: () => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     className?: string;
 };
@@ -12,7 +12,7 @@ type ActionButtonsProps = {
 const ActionButtons = ({
     isEditing,
     onEdit,
-    onSave,
+    requestSubmit,
     onCancel,
     className = "",
 }: ActionButtonsProps) => {
@@ -21,7 +21,7 @@ const ActionButtons = ({
             {!isEditing && <EditButton onClick={onEdit} label="Modifier" size="small" />}
             {isEditing && (
                 <>
-                    <SaveButton onClick={onSave} label="Enregistrer" size="small" />
+                    <SaveButton onClick={requestSubmit} label="Enregistrer" size="small" />
                     <CancelButton onClick={onCancel} label="Annuler" size="small" />
                 </>
             )}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -30,15 +30,17 @@ export default function PostManagerPage() {
         void fetchPosts();
     }, [fetchPosts]);
 
-    const handleEditById = useCallback(
+    const selectPost = useCallback(
         (id: IdLike) => {
             const post = selectById(String(id));
-            if (!post) return;
-            setEditingPost(post);
-            setEditingId(String(id));
+            setEditingPost(post ?? null);
         },
         [selectById]
     );
+
+    const enterEditMode = useCallback((id: IdLike) => {
+        setEditingId(String(id));
+    }, []);
 
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
@@ -67,14 +69,15 @@ export default function PostManagerPage() {
                     manager={manager}
                     posts={posts}
                     editingId={editingId}
-                    onSave={handleSave}
+                    afterSave={handleSave}
                 />
                 <SectionHeader>Liste des articles</SectionHeader>
                 <PostList
                     posts={posts}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={() => {
+                    selectById={selectPost}
+                    enterEditMode={enterEditMode}
+                    requestSubmit={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -18,13 +18,13 @@ import { type PostType } from "@entities/models/post";
 
 interface Props {
     manager: ReturnType<typeof usePostForm>;
-    onSave: () => void;
+    afterSave: () => void;
     posts: PostType[];
     editingId: string | null;
 }
 
 const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
-    { manager, onSave, posts, editingId },
+    { manager, afterSave, posts, editingId },
     ref
 ) {
     const {
@@ -84,7 +84,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
             ref={ref}
             manager={manager}
             initialForm={initialPostForm}
-            onSave={onSave}
+            afterSave={afterSave}
             submitLabel={{ create: "Créer l'article", edit: "Mettre à jour" }}
         >
             <EditableField

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -11,8 +11,9 @@ type IdLike = string | number;
 interface Props {
     posts: PostType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    selectById: (id: IdLike) => void;
+    enterEditMode: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
 }
@@ -29,8 +30,9 @@ export default function PostList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEditById={props.onEditById}
-            onSave={props.onSave}
+            selectById={props.selectById}
+            enterEditMode={props.enterEditMode}
+            requestSubmit={props.requestSubmit}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
             editButtonLabel="Modifier"

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -28,15 +28,17 @@ export default function SectionManagerPage() {
         fetchList();
     }, [fetchList]);
 
-    const handleEditById = useCallback(
+    const selectSection = useCallback(
         (id: IdLike) => {
             const section = selectById(String(id));
-            if (!section) return;
-            setEditingSection(section);
-            setEditingId(String(id));
+            setEditingSection(section ?? null);
         },
         [selectById]
     );
+
+    const enterEditMode = useCallback((id: IdLike) => {
+        setEditingId(String(id));
+    }, []);
 
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
@@ -66,14 +68,15 @@ export default function SectionManagerPage() {
                     ref={formRef}
                     manager={manager}
                     editingId={editingId}
-                    onSave={handleSave}
+                    afterSave={handleSave}
                 />
                 <SectionHeader>Liste des sections</SectionHeader>
                 <SectionList
                     sections={sections}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={() => {
+                    selectById={selectSection}
+                    enterEditMode={enterEditMode}
+                    requestSubmit={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={handleCancel}

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -10,8 +10,9 @@ type IdLike = string | number;
 interface Props {
     sections: SectionType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    selectById: (id: IdLike) => void;
+    enterEditMode: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
 }
@@ -28,8 +29,9 @@ export default function SectionList(props: Props) {
                 </p>
             )}
             sortBy={byOptionalOrder}
-            onEditById={props.onEditById}
-            onSave={props.onSave}
+            selectById={props.selectById}
+            enterEditMode={props.enterEditMode}
+            requestSubmit={props.requestSubmit}
             onCancel={props.onCancel}
             onDeleteById={props.onDeleteById}
         />

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -16,12 +16,12 @@ import {
 
 interface Props {
     manager: ReturnType<typeof useSectionForm>;
-    onSave: () => void;
+    afterSave: () => void;
     editingId: string | null;
 }
 
 const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
-    { manager, onSave, editingId },
+    { manager, afterSave, editingId },
     ref
 ) {
     const {
@@ -78,7 +78,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
             ref={ref}
             manager={manager}
             initialForm={initialSectionForm}
-            onSave={onSave}
+            afterSave={afterSave}
         >
             <EditableField
                 name="title"

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -44,13 +44,9 @@ export default function CreateTagPage() {
         setEditingId(null);
     }, [fetchAll]);
 
-    const handleEditById = useCallback(
-        (id: IdLike) => {
-            void selectById(String(id));
-            setEditingId(String(id));
-        },
-        [selectById]
-    );
+    const enterEditMode = useCallback((id: IdLike) => {
+        setEditingId(String(id));
+    }, []);
 
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
@@ -72,14 +68,15 @@ export default function CreateTagPage() {
                     <RefreshButton onClick={fetchAll} label="Rafraîchir" size="small" />
                 </div>
 
-                <TagForm ref={formRef} manager={manager} onSave={handleSaved} />
+                <TagForm ref={formRef} manager={manager} afterSave={handleSaved} />
 
                 <SectionHeader>Liste des tags</SectionHeader>
                 <TagList
                     tags={tags}
                     editingId={editingId}
-                    onEditById={handleEditById}
-                    onSave={submitForm}
+                    selectById={selectById}
+                    enterEditMode={enterEditMode}
+                    requestSubmit={submitForm}
                     onCancel={handleCancel}
                     onDeleteById={handleDeleteById}
                     editButtonLabel={""}

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -10,10 +10,10 @@ type UseTagFormReturn = ReturnType<typeof useTagForm>;
 
 interface Props {
     manager: UseTagFormReturn;
-    onSave: () => void;
+    afterSave: () => void;
 }
 
-const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, onSave }, ref) {
+const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, afterSave }, ref) {
     const { form, setForm } = manager;
     const normalizedManager = manager as EntityFormManager<TagFormType>;
 
@@ -22,7 +22,7 @@ const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, o
             ref={ref}
             manager={normalizedManager}
             initialForm={initialTagForm}
-            onSave={onSave}
+            afterSave={afterSave}
             submitLabel={{ create: "Ajouter", edit: "Mettre à jour" }}
             className="!grid-cols-[1fr_auto]"
         >

--- a/src/components/Blog/manage/tags/TagList.tsx
+++ b/src/components/Blog/manage/tags/TagList.tsx
@@ -10,8 +10,9 @@ type IdLike = string | number;
 interface Props {
     tags: TagType[];
     editingId: IdLike | null;
-    onEditById: (id: IdLike) => void;
-    onSave: () => void;
+    selectById: (id: IdLike) => void;
+    enterEditMode: (id: IdLike) => void;
+    requestSubmit: () => void;
     onCancel: () => void;
     onDeleteById: (id: IdLike) => void;
     editButtonLabel: string;
@@ -21,8 +22,9 @@ interface Props {
 function TagListInner({
     tags,
     editingId,
-    onEditById,
-    onSave,
+    selectById,
+    enterEditMode,
+    requestSubmit,
     onCancel,
     onDeleteById,
     editButtonLabel,
@@ -52,8 +54,9 @@ function TagListInner({
                 ].join(" ")
             }
             sortBy={byAlpha((t) => t.name)}
-            onEditById={onEditById}
-            onSave={onSave}
+            selectById={selectById}
+            enterEditMode={enterEditMode}
+            requestSubmit={requestSubmit}
             onCancel={onCancel}
             onDeleteById={onDeleteById}
             editButtonLabel={editButtonLabel}

--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -14,7 +14,6 @@ import { type TagType } from "@entities/models/tag/types";
 import { type SectionType } from "@entities/models/section/types";
 import { syncPost2Tags } from "@entities/relations/postTag";
 import { syncPost2Sections } from "@entities/relations/sectionPost";
-import { unknown } from "zod";
 interface Extras extends Record<string, unknown> {
     authors: AuthorType[];
     tags: TagType[];


### PR DESCRIPTION
## Description
- renommage de `onSave` en `afterSave`/`requestSubmit`
- séparation de `handleEditById` en `selectById` et `enterEditMode`
- mise à jour de `CreateSection`

## Tests effectués
- `yarn install`
- `yarn prettier --write .`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7e1031a848324a711f67bda6ffb29