### PR TITLE
[Feat] harmoniser les callbacks des formulaires

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "eslint": "^8.57.0",
         "eslint-config-next": "15.3.1",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-unused-imports": "^4.1.4",
+        "eslint-plugin-unused-imports": "^4.2.0",
         "jsdom": "^24.1.1",
         "msw": "^2.6.2",
         "playwright": "^1.48.2",

--- a/src/components/Blog/manage/BlogFormShell.tsx
+++ b/src/components/Blog/manage/BlogFormShell.tsx
@@ -17,7 +17,7 @@ export interface BlogFormManager<F> {
 interface Props<F> {
     manager: BlogFormManager<F>;
     initialForm: F;
-    onSave: () => void;
+    onUpdate: () => void;
     children: React.ReactNode; // <- tes champs contrôlés
     submitLabel?: { create: string; edit: string };
     className?: string;
@@ -27,7 +27,7 @@ const BlogFormShellInner = <F,>(
     {
         manager,
         initialForm,
-        onSave,
+        onUpdate,
         children,
         className,
         submitLabel = { create: "Créer", edit: "Mettre à jour" },
@@ -46,7 +46,7 @@ const BlogFormShellInner = <F,>(
             setMode("create");
             setForm(initialForm);
         }
-        onSave();
+        onUpdate();
     }
 
     return (

--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -7,11 +7,11 @@ import { type AuthorFormType, initialAuthorForm, useAuthorForm } from "@entities
 
 interface Props {
     manager: ReturnType<typeof useAuthorForm>;
-    onSave: () => void;
+    onUpdate: () => void;
 }
 
 const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
-    { manager, onSave },
+    { manager, onUpdate },
     ref
 ) {
     const { form, handleChange } = manager;
@@ -26,7 +26,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
             ref={ref}
             manager={manager}
             initialForm={initialAuthorForm}
-            onSave={onSave}
+            onUpdate={onUpdate}
             submitLabel={{ create: "Ajouter un auteur", edit: "Mettre à jour" }}
         >
             <EditableField

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -45,7 +45,7 @@ export default function AuthorManagerPage() {
         [removeById]
     );
 
-    const handleSave = useCallback(async () => {
+    const handleUpdate = useCallback(async () => {
         await fetchAuthors();
         setEditingAuthor(null);
         setEditingId(null);
@@ -55,7 +55,7 @@ export default function AuthorManagerPage() {
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
                 <SectionHeader className="mt-8">Nouvel auteur</SectionHeader>
-                <AuthorForm ref={formRef} manager={manager} onSave={handleSave} />
+                <AuthorForm ref={formRef} manager={manager} onUpdate={handleUpdate} />
                 <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -47,7 +47,7 @@ export default function PostManagerPage() {
         [removeById]
     );
 
-    const handleSave = useCallback(async () => {
+    const handleUpdate = useCallback(async () => {
         await fetchPosts();
         setEditingPost(null);
         setEditingId(null);
@@ -67,7 +67,7 @@ export default function PostManagerPage() {
                     manager={manager}
                     posts={posts}
                     editingId={editingId}
-                    onSave={handleSave}
+                    onUpdate={handleUpdate}
                 />
                 <SectionHeader>Liste des articles</SectionHeader>
                 <PostList

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -20,13 +20,13 @@ import { type PostType } from "@entities/models/post";
 
 interface Props {
     manager: ReturnType<typeof usePostForm>;
-    onSave: () => void;
+    onUpdate: () => void;
     posts: PostType[];
     editingId: string | null;
 }
 
 const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
-    { manager, onSave, posts, editingId },
+    { manager, onUpdate, posts, editingId },
     ref
 ) {
     const {
@@ -86,7 +86,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
             ref={ref}
             manager={manager}
             initialForm={initialPostForm}
-            onSave={onSave}
+            onUpdate={onUpdate}
             submitLabel={{ create: "Créer l'article", edit: "Mettre à jour" }}
         >
             <EditableField

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -45,7 +45,7 @@ export default function SectionManagerPage() {
         [removeById]
     );
 
-    const handleSave = useCallback(async () => {
+    const handleUpdate = useCallback(async () => {
         await fetchList();
         setEditingSection(null);
         setEditingId(null);
@@ -66,7 +66,7 @@ export default function SectionManagerPage() {
                     ref={formRef}
                     manager={manager}
                     editingId={editingId}
-                    onSave={handleSave}
+                    onUpdate={handleUpdate}
                 />
                 <SectionHeader>Liste des sections</SectionHeader>
                 <SectionList

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -18,12 +18,12 @@ import {
 
 interface Props {
     manager: ReturnType<typeof useSectionForm>;
-    onSave: () => void;
+    onUpdate: () => void;
     editingId: string | null;
 }
 
 const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
-    { manager, onSave, editingId },
+    { manager, onUpdate, editingId },
     ref
 ) {
     const {
@@ -76,7 +76,12 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
     };
 
     return (
-        <BlogFormShell ref={ref} manager={manager} initialForm={initialSectionForm} onSave={onSave}>
+        <BlogFormShell
+            ref={ref}
+            manager={manager}
+            initialForm={initialSectionForm}
+            onUpdate={onUpdate}
+        >
             <EditableField
                 name="title"
                 label="Titre"

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -39,7 +39,7 @@ export default function CreateTagPage() {
     // ⇧ stable: évite de casser la mémo de TagList
     const submitForm = useCallback(() => formRef.current?.requestSubmit(), []);
 
-    const handleSaved = useCallback(async () => {
+    const handleUpdated = useCallback(async () => {
         await fetchAll?.();
         setEditingId(null);
     }, [fetchAll]);
@@ -72,7 +72,7 @@ export default function CreateTagPage() {
                     <RefreshButton onRefresh={fetchAll} label="Rafraîchir" size="small" />
                 </div>
 
-                <TagForm ref={formRef} manager={manager} onSave={handleSaved} />
+                <TagForm ref={formRef} manager={manager} onUpdate={handleUpdated} />
 
                 <SectionHeader>Liste des tags</SectionHeader>
                 <TagList

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -10,10 +10,10 @@ type UseTagFormReturn = ReturnType<typeof useTagForm>;
 
 interface Props {
     manager: UseTagFormReturn;
-    onSave: () => void;
+    onUpdate: () => void;
 }
 
-const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, onSave }, ref) {
+const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, onUpdate }, ref) {
     const { form, setForm } = manager;
     const normalizedManager = manager as BlogFormManager<TagFormType>;
 
@@ -22,7 +22,7 @@ const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, o
             ref={ref}
             manager={normalizedManager}
             initialForm={initialTagForm}
-            onSave={onSave}
+            onUpdate={onUpdate}
             submitLabel={{ create: "Ajouter", edit: "Mettre à jour" }}
             className="!grid-cols-[1fr_auto]"
         >

--- a/src/components/ui/Button/IconButton.tsx
+++ b/src/components/ui/Button/IconButton.tsx
@@ -6,12 +6,13 @@ import {
 
 export type IconButtonProps = MuiIconButtonProps & {
     href?: string;
+    ariaLabel: string;
 };
 
-export default function IconButton({ href, ...props }: IconButtonProps) {
+export default function IconButton({ href, ariaLabel, ...props }: IconButtonProps) {
     return href ? (
-        <MuiIconButton component={NextLink} href={href} {...props} />
+        <MuiIconButton component={NextLink} href={href} aria-label={ariaLabel} {...props} />
     ) : (
-        <MuiIconButton {...props} />
+        <MuiIconButton aria-label={ariaLabel} {...props} />
     );
 }

--- a/src/components/ui/Form/EditField.tsx
+++ b/src/components/ui/Form/EditField.tsx
@@ -1,4 +1,4 @@
-import { UpdateButton, BackButton } from "@components/ui/Button";
+import { UpdateButton, CancelButton } from "@components/ui/Button";
 import React from "react";
 import type { FieldKey } from "@entities/core/hooks";
 
@@ -46,8 +46,8 @@ export default function EditField<T extends Record<string, unknown>>({
                     className="flex-1 mr-2"
                     size="medium"
                 />
-                <BackButton
-                    onBack={() => setEditModeField(null)}
+                <CancelButton
+                    onCancel={() => setEditModeField(null)}
                     label="Retour"
                     className="flex-1 ml-2"
                     size="medium"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11545,7 +11545,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     eslint-config-next: "npm:15.3.1"
     eslint-plugin-import: "npm:^2.32.0"
-    eslint-plugin-unused-imports: "npm:^4.1.4"
+    eslint-plugin-unused-imports: "npm:^4.2.0"
     execa: "npm:^9.5.2"
     file-saver: "npm:^2.0.5"
     global: "npm:^4.4.0"
@@ -14004,16 +14004,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-unused-imports@npm:^4.1.4":
-  version: 4.1.4
-  resolution: "eslint-plugin-unused-imports@npm:4.1.4"
+"eslint-plugin-unused-imports@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "eslint-plugin-unused-imports@npm:4.2.0"
   peerDependencies:
     "@typescript-eslint/eslint-plugin": ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
     eslint: ^9.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@typescript-eslint/eslint-plugin":
       optional: true
-  checksum: 10c0/3899f64b0e8b23fa6b81e2754fc10f93d8741e051d70390a8100ca39af7878bde8625f234b76111af69562ef2512104b52c3703e986ccb3ac9adc07911896acf
+  checksum: 10c0/b6293323670dda64b0b5931ace1ab45f731e399e87da591c208da09c6bf89a84591b160b8e15e3b47f8f1f662dc80306368a60c09f833de0f6f1dbd97c247949
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- standardise les props onUpdate/onCancel sur les formulaires
- impose un aria-label pour les boutons icône

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Blog/manage/BlogFormShell.tsx src/components/Blog/manage/authors/AuthorForm.tsx src/components/Blog/manage/authors/CreateAuthor.tsx src/components/Blog/manage/posts/CreatePost.tsx src/components/Blog/manage/posts/PostForm.tsx src/components/Blog/manage/sections/CreateSection.tsx src/components/Blog/manage/sections/SectionsForm.tsx src/components/Blog/manage/tags/CreateTag.tsx src/components/Blog/manage/tags/TagForm.tsx src/components/ui/Button/IconButton.tsx src/components/ui/Form/EditField.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ad6507b48324844bd36eea66883a