### PR TITLE
[Feat] nettoyage des exports de Button

### DIFF
--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,14 +1,2 @@
-import NextLink from "next/link";
-import { Button as MuiButton, type ButtonProps as MuiButtonProps } from "@mui/material";
-
-export type ButtonProps = MuiButtonProps & {
-    href?: string;
-};
-
-export default function Button({ href, ...props }: ButtonProps) {
-    return href ? (
-        <MuiButton component={NextLink} href={href} {...props} />
-    ) : (
-        <MuiButton {...props} />
-    );
-}
+export { UiButton as default } from "./UiButton";
+export type { UiButtonProps as ButtonProps } from "./UiButton";

--- a/src/components/ui/Button/IconButton.tsx
+++ b/src/components/ui/Button/IconButton.tsx
@@ -1,18 +1,2 @@
-import NextLink from "next/link";
-import {
-    IconButton as MuiIconButton,
-    type IconButtonProps as MuiIconButtonProps,
-} from "@mui/material";
-
-export type IconButtonProps = MuiIconButtonProps & {
-    href?: string;
-    ariaLabel: string;
-};
-
-export default function IconButton({ href, ariaLabel, ...props }: IconButtonProps) {
-    return href ? (
-        <MuiIconButton component={NextLink} href={href} aria-label={ariaLabel} {...props} />
-    ) : (
-        <MuiIconButton aria-label={ariaLabel} {...props} />
-    );
-}
+export { UiButton as default } from "./UiButton";
+export type { UiButtonProps as IconButtonProps } from "./UiButton";

--- a/src/components/ui/Button/index.ts
+++ b/src/components/ui/Button/index.ts
@@ -1,8 +1,4 @@
+export { UiButton } from "./UiButton";
+export type { UiButtonProps } from "./UiButton";
 export * from "./Buttons";
-export * from "./UiButton";
-export * from "./buttonStyles";
 export { default as ActionButtons } from "./ActionButtons";
-export { default as Button } from "./Button";
-export type { ButtonProps } from "./Button";
-export { default as IconButton } from "./IconButton";
-export type { IconButtonProps } from "./IconButton";


### PR DESCRIPTION
## Summary
- simplifie les exports du module Button pour ne conserver que UiButton, ses props, les wrappers et ActionButtons
- ajoute des fichiers de compatibilité Button et IconButton réexportant UiButton

## Testing
- `yarn prettier --write src/components/ui/Button/index.ts src/components/ui/Button/Button.tsx src/components/ui/Button/IconButton.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b1fb0748832485bb06134a2480f0