### PR TITLE
[Feat] documentation des boutons

### DIFF
--- a/src/components/ui/Button/docs/AddButton.md
+++ b/src/components/ui/Button/docs/AddButton.md
@@ -1,0 +1,27 @@
+# AddButton
+
+Bouton d'ajout d'un nouvel élément.
+
+## Usage
+
+```tsx
+import { AddButton } from "@src/components/ui/Button";
+
+<AddButton onAdd={handleAdd} label="Ajouter" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                 |
+| ----------- | ------------------------ | ----------- | ----------------------------------------------------------- |
+| `onAdd`     | `() => void`             | oui         | Callback exécuté au clic.                                   |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Ajouter"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Ajouter"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                   |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                 |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                           |
+
+## Accessibilité
+
+- `variantType="button"` : le `label` rend le bouton accessible.
+- L'icône d'ajout (`<AddIcon />`) est purement visuelle.

--- a/src/components/ui/Button/docs/BackButton.md
+++ b/src/components/ui/Button/docs/BackButton.md
@@ -1,0 +1,36 @@
+# BackButton
+
+Bouton de retour en arrière ou de navigation.
+
+## Usage
+
+### Navigation
+
+```tsx
+import { BackButton } from "@src/components/ui/Button";
+
+<BackButton href="/" label="Retour" />;
+```
+
+### Action
+
+```tsx
+<BackButton onBack={handleBack} label="Retour" />
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                          |
+| ----------- | ------------------------ | ----------- | -------------------------------------------------------------------- |
+| `href`      | `string`                 | non\*       | Navigue vers l'URL indiquée (\*mutuellement exclusif avec `onBack`). |
+| `onBack`    | `() => void`             | non\*       | Callback exécuté au clic (\*mutuellement exclusif avec `href`).      |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Retour"`).                                 |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Retour"`).           |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                            |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                          |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                                    |
+
+## Accessibilité
+
+- `variantType="button"` : le `label` suffit pour l'a11y.
+- Icône de retour (`<ArrowBackIcon />`).

--- a/src/components/ui/Button/docs/CancelButton.md
+++ b/src/components/ui/Button/docs/CancelButton.md
@@ -1,0 +1,27 @@
+# CancelButton
+
+Bouton d'annulation d'une action en cours.
+
+## Usage
+
+```tsx
+import { CancelButton } from "@src/components/ui/Button";
+
+<CancelButton onCancel={handleCancel} label="Annuler" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                 |
+| ----------- | ------------------------ | ----------- | ----------------------------------------------------------- |
+| `onCancel`  | `() => void`             | oui         | Callback exécuté au clic.                                   |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Annuler"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Annuler"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                   |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                 |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                           |
+
+## Accessibilité
+
+- `variantType="button"` : le libellé est suffisant pour les lecteurs d'écran.
+- L'icône (`<CancelIcon />`) est décorative.

--- a/src/components/ui/Button/docs/ClearFieldButton.md
+++ b/src/components/ui/Button/docs/ClearFieldButton.md
@@ -1,0 +1,27 @@
+# ClearFieldButton
+
+Bouton permettant de vider la valeur d'un champ de formulaire.
+
+## Usage
+
+```tsx
+import { ClearFieldButton } from "@src/components/ui/Button";
+
+<ClearFieldButton onClear={handleClear} label="Vider le champ" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                        |
+| ----------- | ------------------------ | ----------- | ------------------------------------------------------------------ |
+| `onClear`   | `() => void`             | oui         | Callback exécuté au clic.                                          |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Vider le champ"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Vider le champ"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                          |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                        |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                                  |
+
+## Accessibilité
+
+- `variantType="button"` : le texte visible rend le bouton accessible.
+- Icône de suppression de texte (`<BackspaceIcon />`).

--- a/src/components/ui/Button/docs/DeleteButton.md
+++ b/src/components/ui/Button/docs/DeleteButton.md
@@ -1,0 +1,27 @@
+# DeleteButton
+
+Bouton de suppression d'un élément.
+
+## Usage
+
+```tsx
+import { DeleteButton } from "@src/components/ui/Button";
+
+<DeleteButton onDelete={handleDelete} label="Supprimer" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                   |
+| ----------- | ------------------------ | ----------- | ------------------------------------------------------------- |
+| `onDelete`  | `() => void`             | oui         | Callback exécuté au clic.                                     |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Supprimer"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Supprimer"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                     |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                   |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                             |
+
+## Accessibilité
+
+- `variantType="button"` : le libellé rend le bouton accessible, aucun `ariaLabel` requis.
+- Icône de suppression fournie par MUI (`<DeleteIcon />`).

--- a/src/components/ui/Button/docs/EditButton.md
+++ b/src/components/ui/Button/docs/EditButton.md
@@ -1,0 +1,27 @@
+# EditButton
+
+Bouton d'édition d'un élément.
+
+## Usage
+
+```tsx
+import { EditButton } from "@src/components/ui/Button";
+
+<EditButton onEdit={handleEdit} label="Modifier" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                  |
+| ----------- | ------------------------ | ----------- | ------------------------------------------------------------ |
+| `onEdit`    | `() => void`             | oui         | Callback exécuté au clic.                                    |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Modifier"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Modifier"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                    |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                  |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                            |
+
+## Accessibilité
+
+- `variantType="button"` : le libellé rend le bouton accessible, `ariaLabel` n'est pas nécessaire.
+- L'icône est décorative et fournie par MUI (`<EditIcon />`).

--- a/src/components/ui/Button/docs/PowerButton.md
+++ b/src/components/ui/Button/docs/PowerButton.md
@@ -1,0 +1,27 @@
+# PowerButton
+
+Bouton de déconnexion de l'utilisateur.
+
+## Usage
+
+```tsx
+import { PowerButton } from "@src/components/ui/Button";
+
+<PowerButton onPowerOff={handleLogout} label="Déconnexion" />;
+```
+
+## Props
+
+| Nom          | Type                     | Obligatoire | Description                                                     |
+| ------------ | ------------------------ | ----------- | --------------------------------------------------------------- |
+| `onPowerOff` | `() => void`             | oui         | Callback exécuté au clic.                                       |
+| `label`      | `string`                 | non         | Libellé visible (défaut `"Déconnexion"`).                       |
+| `title`      | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Déconnexion"`). |
+| `className`  | `string`                 | non         | Classe CSS personnalisée.                                       |
+| `sx`         | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                     |
+| `size`       | `MuiButtonProps["size"]` | non         | Taille du bouton.                                               |
+
+## Accessibilité
+
+- `variantType="button"` : le libellé est lu par les lecteurs d'écran.
+- Icône d'arrêt (`<PowerIcon />`).

--- a/src/components/ui/Button/docs/RefreshButton.md
+++ b/src/components/ui/Button/docs/RefreshButton.md
@@ -1,0 +1,27 @@
+# RefreshButton
+
+Bouton de rafraîchissement de la page ou des données.
+
+## Usage
+
+```tsx
+import { RefreshButton } from "@src/components/ui/Button";
+
+<RefreshButton onRefresh={handleRefresh} label="Rafraîchir la page" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                            |
+| ----------- | ------------------------ | ----------- | ---------------------------------------------------------------------- |
+| `onRefresh` | `() => void`             | oui         | Callback exécuté au clic.                                              |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Rafraîchir la page"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Rafraîchir la page"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                              |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                            |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                                      |
+
+## Accessibilité
+
+- `variantType="button"` : le libellé est exposé aux technologies d'assistance.
+- Icône de rafraîchissement (`<RefreshIcon />`).

--- a/src/components/ui/Button/docs/SubmitButton.md
+++ b/src/components/ui/Button/docs/SubmitButton.md
@@ -1,0 +1,27 @@
+# SubmitButton
+
+Bouton de soumission pour créer un élément.
+
+## Usage
+
+```tsx
+import { SubmitButton } from "@src/components/ui/Button";
+
+<SubmitButton onSubmit={handleSubmit} label="Créer" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                               |
+| ----------- | ------------------------ | ----------- | --------------------------------------------------------- |
+| `onSubmit`  | `() => void`             | oui         | Callback exécuté au clic.                                 |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Créer"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Créer"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                 |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                               |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                         |
+
+## Accessibilité
+
+- `variantType="button"` : le libellé suffit pour l'a11y.
+- Icône de sauvegarde (`<SaveIcon />`).

--- a/src/components/ui/Button/docs/UiButton.md
+++ b/src/components/ui/Button/docs/UiButton.md
@@ -1,0 +1,41 @@
+# UiButton
+
+Composant de base pour tous les boutons. Il se décline en deux variantes via la prop `variantType`.
+
+## Variante `button`
+
+Bouton classique avec un libellé visible.
+
+```tsx
+import { UiButton } from "@src/components/ui/Button";
+import { Edit } from "@mui/icons-material";
+
+<UiButton
+    variantType="button"
+    label="Modifier"
+    icon={<Edit />}
+    buttonProps={{ onClick: handleEdit }}
+/>;
+```
+
+- Le texte `label` assure l'accessibilité.
+- `ariaLabel` est inutile dans cette variante.
+
+## Variante `icon`
+
+Bouton icône sans texte visible. L'accessibilité repose sur `ariaLabel`.
+
+```tsx
+import { UiButton } from "@src/components/ui/Button";
+import { Delete } from "@mui/icons-material";
+
+<UiButton
+    variantType="icon"
+    icon={<Delete />}
+    ariaLabel="Supprimer"
+    iconButtonProps={{ onClick: handleDelete }}
+/>;
+```
+
+- `ariaLabel` est **obligatoire**.
+- Aucun `label` ne doit être fourni.

--- a/src/components/ui/Button/docs/UpdateButton.md
+++ b/src/components/ui/Button/docs/UpdateButton.md
@@ -1,0 +1,27 @@
+# UpdateButton
+
+Bouton pour enregistrer les modifications d'un élément existant.
+
+## Usage
+
+```tsx
+import { UpdateButton } from "@src/components/ui/Button";
+
+<UpdateButton onUpdate={handleUpdate} label="Enregistrer" />;
+```
+
+## Props
+
+| Nom         | Type                     | Obligatoire | Description                                                     |
+| ----------- | ------------------------ | ----------- | --------------------------------------------------------------- |
+| `onUpdate`  | `() => void`             | oui         | Callback exécuté au clic.                                       |
+| `label`     | `string`                 | non         | Libellé visible (défaut `"Enregistrer"`).                       |
+| `title`     | `string`                 | non         | Attribut `title` pour l'accessibilité (défaut `"Enregistrer"`). |
+| `className` | `string`                 | non         | Classe CSS personnalisée.                                       |
+| `sx`        | `SxProps<Theme>`         | non         | Styles MUI complémentaires.                                     |
+| `size`      | `MuiButtonProps["size"]` | non         | Taille du bouton.                                               |
+
+## Accessibilité
+
+- `variantType="button"` : le `label` suffit pour l'accessibilité.
+- Icône de sauvegarde (`<SaveIcon />`).

--- a/src/components/ui/Button/docs/index.md
+++ b/src/components/ui/Button/docs/index.md
@@ -1,0 +1,14 @@
+# Documentation des boutons
+
+- [UiButton](./UiButton.md)
+- Wrappers spécifiques :
+    - [AddButton](./AddButton.md)
+    - [BackButton](./BackButton.md)
+    - [CancelButton](./CancelButton.md)
+    - [ClearFieldButton](./ClearFieldButton.md)
+    - [DeleteButton](./DeleteButton.md)
+    - [EditButton](./EditButton.md)
+    - [PowerButton](./PowerButton.md)
+    - [RefreshButton](./RefreshButton.md)
+    - [SubmitButton](./SubmitButton.md)
+    - [UpdateButton](./UpdateButton.md)


### PR DESCRIPTION
## Résumé
- ajouter une documentation pour chaque wrapper de bouton
- documenter `UiButton` avec les variantes `button` et `icon`
- centraliser les liens de documentation dans `src/components/ui/Button/docs/index.md`

## Tests
- `yarn prettier --write src/components/ui/Button/docs`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8bac353f88324bb6ede329b9eafb0