### PR TITLE
[Feat] ajouter les fonctions list pour les entités

### DIFF
--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -17,7 +17,7 @@ export default function AuthorManagerPage() {
     const manager = useAuthorForm(editingAuthor);
     const {
         extras: { authors, loading },
-        fetchAuthors,
+        listAuthors,
         selectById,
         removeById,
         setForm,
@@ -25,8 +25,8 @@ export default function AuthorManagerPage() {
     } = manager;
 
     useEffect(() => {
-        fetchAuthors();
-    }, [fetchAuthors]);
+        listAuthors();
+    }, [listAuthors]);
 
     const handleEditById = useCallback(
         (id: IdLike) => {
@@ -46,10 +46,10 @@ export default function AuthorManagerPage() {
     );
 
     const handleUpdate = useCallback(async () => {
-        await fetchAuthors();
+        await listAuthors();
         setEditingAuthor(null);
         setEditingId(null);
-    }, [fetchAuthors]);
+    }, [listAuthors]);
 
     return (
         <RequireAdmin>

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -20,15 +20,15 @@ export default function PostManagerPage() {
     const manager = usePostForm(editingPost);
     const {
         extras: { posts },
-        fetchPosts,
+        listPosts,
         selectById,
         removeById,
         // reset,
     } = manager;
 
     useEffect(() => {
-        void fetchPosts();
-    }, [fetchPosts]);
+        void listPosts();
+    }, [listPosts]);
 
     const handleEditById = useCallback(
         (id: IdLike) => {
@@ -48,10 +48,10 @@ export default function PostManagerPage() {
     );
 
     const handleUpdate = useCallback(async () => {
-        await fetchPosts();
+        await listPosts();
         setEditingPost(null);
         setEditingId(null);
-    }, [fetchPosts]);
+    }, [listPosts]);
 
     const handleCancel = useCallback(() => {
         setEditingPost(null);

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -17,7 +17,7 @@ export default function SectionManagerPage() {
     const manager = useSectionForm(editingSection);
     const {
         extras: { sections },
-        fetchList,
+        listSections,
         selectById,
         removeById,
         setForm,
@@ -25,8 +25,8 @@ export default function SectionManagerPage() {
     } = manager;
 
     useEffect(() => {
-        fetchList();
-    }, [fetchList]);
+        listSections();
+    }, [listSections]);
 
     const handleEditById = useCallback(
         (id: IdLike) => {
@@ -46,10 +46,10 @@ export default function SectionManagerPage() {
     );
 
     const handleUpdate = useCallback(async () => {
-        await fetchList();
+        await listSections();
         setEditingSection(null);
         setEditingId(null);
-    }, [fetchList]);
+    }, [listSections]);
 
     const handleCancel = useCallback(() => {
         setEditingSection(null);

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -23,7 +23,7 @@ export default function CreateTagPage() {
     const {
         extras: { tags, posts },
         loading,
-        fetchAll,
+        listTags,
         selectById,
         cancel,
         removeById,
@@ -33,16 +33,16 @@ export default function CreateTagPage() {
     } = manager;
 
     useEffect(() => {
-        void fetchAll?.();
-    }, [fetchAll]);
+        void listTags();
+    }, [listTags]);
 
     // ⇧ stable: évite de casser la mémo de TagList
     const submitForm = useCallback(() => formRef.current?.requestSubmit(), []);
 
     const handleUpdated = useCallback(async () => {
-        await fetchAll?.();
+        await listTags();
         setEditingId(null);
-    }, [fetchAll]);
+    }, [listTags]);
 
     const handleEditById = useCallback(
         (id: IdLike) => {
@@ -69,7 +69,7 @@ export default function CreateTagPage() {
             <BlogEditorLayout title="Gestion des Tags">
                 <div className="flex items-center gap-2">
                     <SectionHeader className="!mb-0 flex-1">Nouveau tag</SectionHeader>
-                    <RefreshButton onRefresh={fetchAll} label="Rafraîchir" size="small" />
+                    <RefreshButton onRefresh={listTags} label="Rafraîchir" size="small" />
                 </div>
 
                 <TagForm ref={formRef} manager={manager} onUpdate={handleUpdated} />

--- a/src/components/ui/Form/EditField.tsx
+++ b/src/components/ui/Form/EditField.tsx
@@ -1,4 +1,4 @@
-import { UpdateButton, CancelButton, BackButton } from "@components/ui/Button";
+import { UpdateButton, BackButton } from "@components/ui/Button";
 import React from "react";
 import type { FieldKey } from "@entities/core/hooks";
 

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -52,6 +52,7 @@ export function useAuthorForm(author: AuthorType | null) {
             setExtras((prev) => ({ ...prev, loading: false }));
         }
     }, [setExtras]);
+    const listAuthors = fetchAuthors;
 
     const selectById = useCallback(
         (id: string) => {
@@ -95,5 +96,5 @@ export function useAuthorForm(author: AuthorType | null) {
         }
     }, [author, setForm, setMode]);
 
-    return { ...modelForm, editingId, fetchAuthors, selectById, removeById };
+    return { ...modelForm, editingId, listAuthors, fetchAuthors, selectById, removeById };
 }

--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -82,6 +82,7 @@ export function usePostForm(post: PostType | null) {
         const { data } = await postService.list();
         setExtras((e) => ({ ...e, posts: data ?? [] }));
     }, [setExtras]);
+    const listPosts = fetchPosts;
 
     useEffect(() => {
         void (async () => {
@@ -182,6 +183,7 @@ export function usePostForm(post: PostType | null) {
     return {
         ...modelForm,
         editingId,
+        listPosts,
         fetchPosts,
         selectById,
         removeById,

--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -50,6 +50,7 @@ export function useSectionForm(section: SectionType | null) {
         const { data } = await sectionService.list();
         setExtras((e) => ({ ...e, sections: data ?? [] }));
     }, [setExtras]);
+    const listSections = fetchList;
 
     useEffect(() => {
         void (async () => {
@@ -105,5 +106,5 @@ export function useSectionForm(section: SectionType | null) {
         [selectById, fetchList, editingId, reset]
     );
 
-    return { ...modelForm, editingId, fetchList, selectById, removeById };
+    return { ...modelForm, editingId, listSections, fetchList, selectById, removeById };
 }

--- a/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -50,10 +50,10 @@ beforeEach(() => {
 });
 
 describe("useTagForm", () => {
-    it("fetchAll charge tags, posts et liaisons", async () => {
+    it("listTags charge tags, posts et liaisons", async () => {
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
-            await result.current.fetchAll();
+            await result.current.listTags();
         });
         expect(result.current.extras.tags).toEqual(tags);
         expect(result.current.extras.posts).toEqual(posts);
@@ -67,7 +67,7 @@ describe("useTagForm", () => {
         deleteMock.mockResolvedValue({});
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
-            await result.current.fetchAll();
+            await result.current.listTags();
         });
         await act(async () => {
             await result.current.toggle("p1", "t2");
@@ -84,7 +84,7 @@ describe("useTagForm", () => {
     it("selectById préremplit le formulaire et fixe editingId", async () => {
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
-            await result.current.fetchAll();
+            await result.current.listTags();
         });
         await act(async () => {
             await result.current.selectById("t1");
@@ -96,7 +96,7 @@ describe("useTagForm", () => {
     it("reset réinitialise le formulaire et l'id", async () => {
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
-            await result.current.fetchAll();
+            await result.current.listTags();
         });
         await act(async () => {
             await result.current.selectById("t1");
@@ -114,7 +114,7 @@ describe("useTagForm", () => {
         vi.spyOn(window, "confirm").mockReturnValue(true);
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
-            await result.current.fetchAll();
+            await result.current.listTags();
         });
         await act(async () => {
             await result.current.selectById("t1");

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -71,6 +71,7 @@ export function useTagForm() {
             setLoading(false);
         }
     }, [setExtras]);
+    const listTags = fetchAll;
 
     useEffect(() => {
         void fetchAll();
@@ -151,6 +152,7 @@ export function useTagForm() {
         reset,
         cancel: reset,
         loading,
+        listTags,
         fetchAll,
         selectById,
         removeById,


### PR DESCRIPTION
## Résumé
- ajouter les fonctions listPosts, listTags, listSections et listAuthors dans les hooks
- utiliser ces nouvelles fonctions dans les composants d'édition
- ajuster les tests et supprimer un import inutilisé pour le lint

## Tests
- `yarn lint`
- `yarn test` *(échoue : ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a90bbd89b48324ba411db237c2c244