### PR TITLE
[Fix] renomme onUpdate en dispatchEvent

### DIFF
--- a/src/components/Blog/manage/BlogFormShell.tsx
+++ b/src/components/Blog/manage/BlogFormShell.tsx
@@ -17,7 +17,7 @@ export interface BlogFormManager<F> {
 interface Props<F> {
     manager: BlogFormManager<F>;
     initialForm: F;
-    onUpdate: () => void;
+    dispatchEvent: () => void;
     children: React.ReactNode; // <- tes champs contrôlés
     submitLabel?: { create: string; edit: string };
     className?: string;
@@ -27,7 +27,7 @@ const BlogFormShellInner = <F,>(
     {
         manager,
         initialForm,
-        onUpdate,
+        dispatchEvent,
         children,
         className,
         submitLabel = { create: "Créer", edit: "Mettre à jour" },
@@ -46,7 +46,7 @@ const BlogFormShellInner = <F,>(
             setMode("create");
             setForm(initialForm);
         }
-        onUpdate();
+        dispatchEvent();
     }
 
     return (

--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -7,11 +7,11 @@ import { type AuthorFormType, initialAuthorForm, useAuthorForm } from "@entities
 
 interface Props {
     manager: ReturnType<typeof useAuthorForm>;
-    onUpdate: () => void;
+    dispatchEvent: () => void;
 }
 
 const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
-    { manager, onUpdate },
+    { manager, dispatchEvent },
     ref
 ) {
     const { form, handleChange } = manager;
@@ -26,7 +26,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
             ref={ref}
             manager={manager}
             initialForm={initialAuthorForm}
-            onUpdate={onUpdate}
+            dispatchEvent={dispatchEvent}
             submitLabel={{ create: "Ajouter un auteur", edit: "Mettre à jour" }}
         >
             <EditableField

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -55,7 +55,7 @@ export default function AuthorManagerPage() {
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
                 <SectionHeader className="mt-8">Nouvel auteur</SectionHeader>
-                <AuthorForm ref={formRef} manager={manager} onUpdate={handleUpdate} />
+                <AuthorForm ref={formRef} manager={manager} dispatchEvent={handleUpdate} />
                 <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -67,7 +67,7 @@ export default function PostManagerPage() {
                     manager={manager}
                     posts={posts}
                     editingId={editingId}
-                    onUpdate={handleUpdate}
+                    dispatchEvent={handleUpdate}
                 />
                 <SectionHeader>Liste des articles</SectionHeader>
                 <PostList

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -20,13 +20,13 @@ import { type PostType } from "@entities/models/post";
 
 interface Props {
     manager: ReturnType<typeof usePostForm>;
-    onUpdate: () => void;
+    dispatchEvent: () => void;
     posts: PostType[];
     editingId: string | null;
 }
 
 const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
-    { manager, onUpdate, posts, editingId },
+    { manager, dispatchEvent, posts, editingId },
     ref
 ) {
     const {
@@ -86,7 +86,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
             ref={ref}
             manager={manager}
             initialForm={initialPostForm}
-            onUpdate={onUpdate}
+            dispatchEvent={dispatchEvent}
             submitLabel={{ create: "Créer l'article", edit: "Mettre à jour" }}
         >
             <EditableField

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -66,7 +66,7 @@ export default function SectionManagerPage() {
                     ref={formRef}
                     manager={manager}
                     editingId={editingId}
-                    onUpdate={handleUpdate}
+                    dispatchEvent={handleUpdate}
                 />
                 <SectionHeader>Liste des sections</SectionHeader>
                 <SectionList

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -18,12 +18,12 @@ import {
 
 interface Props {
     manager: ReturnType<typeof useSectionForm>;
-    onUpdate: () => void;
+    dispatchEvent: () => void;
     editingId: string | null;
 }
 
 const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
-    { manager, onUpdate, editingId },
+    { manager, dispatchEvent, editingId },
     ref
 ) {
     const {
@@ -80,7 +80,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
             ref={ref}
             manager={manager}
             initialForm={initialSectionForm}
-            onUpdate={onUpdate}
+            dispatchEvent={dispatchEvent}
         >
             <EditableField
                 name="title"

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -72,7 +72,7 @@ export default function CreateTagPage() {
                     <RefreshButton onRefresh={listTags} label="Rafraîchir" size="small" />
                 </div>
 
-                <TagForm ref={formRef} manager={manager} onUpdate={handleUpdated} />
+                <TagForm ref={formRef} manager={manager} dispatchEvent={handleUpdated} />
 
                 <SectionHeader>Liste des tags</SectionHeader>
                 <TagList

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -10,10 +10,13 @@ type UseTagFormReturn = ReturnType<typeof useTagForm>;
 
 interface Props {
     manager: UseTagFormReturn;
-    onUpdate: () => void;
+    dispatchEvent: () => void;
 }
 
-const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, onUpdate }, ref) {
+const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm(
+    { manager, dispatchEvent },
+    ref
+) {
     const { form, setForm } = manager;
     const normalizedManager = manager as BlogFormManager<TagFormType>;
 
@@ -22,7 +25,7 @@ const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm({ manager, o
             ref={ref}
             manager={normalizedManager}
             initialForm={initialTagForm}
-            onUpdate={onUpdate}
+            dispatchEvent={dispatchEvent}
             submitLabel={{ create: "Ajouter", edit: "Mettre à jour" }}
             className="!grid-cols-[1fr_auto]"
         >


### PR DESCRIPTION
## Description
- remplace la prop `onUpdate` par `dispatchEvent` dans `BlogFormShell`
- adapte les formulaires du blog et leurs composants parents

## Tests effectués
- `yarn prettier --write src/components/Blog/manage/BlogFormShell.tsx src/components/Blog/manage/authors/AuthorForm.tsx src/components/Blog/manage/authors/CreateAuthor.tsx src/components/Blog/manage/posts/CreatePost.tsx src/components/Blog/manage/posts/PostForm.tsx src/components/Blog/manage/sections/CreateSection.tsx src/components/Blog/manage/sections/SectionsForm.tsx src/components/Blog/manage/tags/CreateTag.tsx src/components/Blog/manage/tags/TagForm.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9906eabfc8324b9528ebde96e10a5