### PR TITLE
[Fix] Renommer prop manager en tagFormManager

### DIFF
--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -72,7 +72,7 @@ export default function CreateTagPage() {
                     <RefreshButton onRefresh={listTags} label="Rafraîchir" size="small" />
                 </div>
 
-                <TagForm ref={formRef} manager={manager} onSaveSuccess={handleUpdated} />
+                <TagForm ref={formRef} tagFormManager={manager} onSaveSuccess={handleUpdated} />
 
                 <SectionHeader>Liste des tags</SectionHeader>
                 <TagList

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -9,16 +9,16 @@ import type { TagFormType } from "@entities/models/tag/types";
 type UseTagFormReturn = ReturnType<typeof useTagForm>;
 
 interface Props {
-    manager: UseTagFormReturn;
+    tagFormManager: UseTagFormReturn;
     onSaveSuccess: () => void;
 }
 
 const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm(
-    { manager, onSaveSuccess },
+    { tagFormManager, onSaveSuccess },
     ref
 ) {
-    const { form, setForm } = manager;
-    const normalizedManager = manager as BlogFormManager<TagFormType>;
+    const { form, setForm } = tagFormManager;
+    const normalizedManager = tagFormManager as BlogFormManager<TagFormType>;
 
     return (
         <BlogFormShell


### PR DESCRIPTION
## Résumé
- renommer la prop `manager` en `tagFormManager` dans `TagForm`
- adapter l'usage de `TagForm` dans `CreateTag`

## Tests
- `yarn lint`
- `yarn build` *(échoue: Cannot find module './buttons' in src/types/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8fce2788324be7d0ea9061ca4ae