### PR TITLE
[Fix] renommage des props manager

### DIFF
--- a/src/components/Blog/manage/BlogFormShell.tsx
+++ b/src/components/Blog/manage/BlogFormShell.tsx
@@ -15,7 +15,7 @@ export interface BlogFormManager<F> {
 }
 
 interface Props<F> {
-    manager: BlogFormManager<F>;
+    blogFormManager: BlogFormManager<F>;
     initialForm: F;
     onSaveSuccess: () => void;
     children: React.ReactNode; // <- tes champs contrôlés
@@ -25,7 +25,7 @@ interface Props<F> {
 
 const BlogFormShellInner = <F,>(
     {
-        manager,
+        blogFormManager,
         initialForm,
         onSaveSuccess,
         children,
@@ -34,7 +34,7 @@ const BlogFormShellInner = <F,>(
     }: Props<F>,
     ref: React.ForwardedRef<HTMLFormElement>
 ) => {
-    const { submit, setForm, setMode, mode, saving, message } = manager;
+    const { submit, setForm, setMode, mode, saving, message } = blogFormManager;
 
     async function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();

--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -6,15 +6,15 @@ import { EditableField, EditableTextArea } from "@components/ui/Form";
 import { type AuthorFormType, initialAuthorForm, useAuthorForm } from "@entities/models/author";
 
 interface Props {
-    manager: ReturnType<typeof useAuthorForm>;
+    authorFormManager: ReturnType<typeof useAuthorForm>;
     onSaveSuccess: () => void;
 }
 
 const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
-    { manager, onSaveSuccess },
+    { authorFormManager, onSaveSuccess },
     ref
 ) {
-    const { form, setFieldValue } = manager;
+    const { form, setFieldValue } = authorFormManager;
 
     const onChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
@@ -24,7 +24,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
     return (
         <BlogFormShell
             ref={ref}
-            manager={manager}
+            blogFormManager={authorFormManager}
             initialForm={initialAuthorForm}
             onSaveSuccess={onSaveSuccess}
             submitLabel={{ create: "Ajouter un auteur", edit: "Mettre à jour" }}

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -55,7 +55,11 @@ export default function AuthorManagerPage() {
         <RequireAdmin>
             <BlogEditorLayout title="Éditeur de blog : Auteurs">
                 <SectionHeader className="mt-8">Nouvel auteur</SectionHeader>
-                <AuthorForm ref={formRef} manager={manager} onSaveSuccess={handleUpdate} />
+                <AuthorForm
+                    ref={formRef}
+                    authorFormManager={manager}
+                    onSaveSuccess={handleUpdate}
+                />
                 <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -64,7 +64,7 @@ export default function PostManagerPage() {
                 <SectionHeader className="mt-8">Nouvel article</SectionHeader>
                 <PostForm
                     ref={formRef}
-                    manager={manager}
+                    postFormManager={manager}
                     posts={posts}
                     editingId={editingId}
                     onSaveSuccess={handleUpdate}

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -19,14 +19,14 @@ import { type PostFormType } from "@entities/models/post/types";
 import { type PostType } from "@entities/models/post";
 
 interface Props {
-    manager: ReturnType<typeof usePostForm>;
+    postFormManager: ReturnType<typeof usePostForm>;
     onSaveSuccess: () => void;
     posts: PostType[];
     editingId: string | null;
 }
 
 const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
-    { manager, onSaveSuccess, posts, editingId },
+    { postFormManager, onSaveSuccess, posts, editingId },
     ref
 ) {
     const {
@@ -35,7 +35,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
         setFieldValue,
         toggleTag,
         toggleSection,
-    } = manager;
+    } = postFormManager;
 
     const { handleSourceFocus, handleManualEdit } = useAutoGenFields({
         configs: [
@@ -84,7 +84,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
     return (
         <BlogFormShell
             ref={ref}
-            manager={manager}
+            blogFormManager={postFormManager}
             initialForm={initialPostForm}
             onSaveSuccess={onSaveSuccess}
             submitLabel={{ create: "Créer l'article", edit: "Mettre à jour" }}

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -64,7 +64,7 @@ export default function SectionManagerPage() {
                 <SectionHeader className="mt-8">Nouvelle section</SectionHeader>
                 <SectionForm
                     ref={formRef}
-                    manager={manager}
+                    sectionFormManager={manager}
                     editingId={editingId}
                     onSaveSuccess={handleUpdate}
                 />

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -17,13 +17,13 @@ import {
 } from "@entities/models/section";
 
 interface Props {
-    manager: ReturnType<typeof useSectionForm>;
+    sectionFormManager: ReturnType<typeof useSectionForm>;
     onSaveSuccess: () => void;
     editingId: string | null;
 }
 
 const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
-    { manager, onSaveSuccess, editingId },
+    { sectionFormManager, onSaveSuccess, editingId },
     ref
 ) {
     const {
@@ -31,7 +31,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
         extras: { posts, sections },
         setFieldValue,
         setForm,
-    } = manager;
+    } = sectionFormManager;
 
     const { handleSourceFocus, handleManualEdit } = useAutoGenFields({
         configs: [
@@ -78,7 +78,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
     return (
         <BlogFormShell
             ref={ref}
-            manager={manager}
+            blogFormManager={sectionFormManager}
             initialForm={initialSectionForm}
             onSaveSuccess={onSaveSuccess}
         >

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -23,7 +23,7 @@ const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm(
     return (
         <BlogFormShell
             ref={ref}
-            manager={normalizedManager}
+            blogFormManager={normalizedManager}
             initialForm={initialTagForm}
             onSaveSuccess={onSaveSuccess}
             submitLabel={{ create: "Ajouter", edit: "Mettre à jour" }}


### PR DESCRIPTION
## Description
- renomme la prop `manager` en `blogFormManager` dans `BlogFormShell`
- introduit `tagFormManager`, `authorFormManager`, `sectionFormManager` et `postFormManager`
- met à jour les pages de création pour utiliser les nouveaux noms de props

## Tests effectués
- `yarn lint`
- `yarn build` *(échoue: Cannot find module './buttons')*


------
https://chatgpt.com/codex/tasks/task_e_68a9ce56411483249354b1d71822e42d