### PR TITLE
[Feat] remplace editingId par identifiants spécifiques

### DIFF
--- a/src/components/Blog/manage/authors/AuthorList.tsx
+++ b/src/components/Blog/manage/authors/AuthorList.tsx
@@ -10,7 +10,7 @@ type IdLike = string | number;
 
 interface Props {
     authors: AuthorType[];
-    editingId: IdLike | null;
+    authorId: IdLike | null;
     onEditById: (id: IdLike) => void;
     onUpdate: () => void;
     onCancel: () => void;
@@ -21,7 +21,7 @@ export default function AuthorList(props: Props) {
     return (
         <GenericList<AuthorType>
             items={props.authors}
-            editingId={props.editingId}
+            editingId={props.authorId}
             getId={(a) => a.id}
             renderContent={(a) => (
                 <p className="self-center">

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -11,10 +11,10 @@ import { type AuthorType, initialAuthorForm, useAuthorForm } from "@entities/mod
 type IdLike = string | number;
 
 export default function AuthorManagerPage() {
-    const [editingAuthor, setEditingAuthor] = useState<AuthorType | null>(null);
-    const [editingId, setEditingId] = useState<string | null>(null);
+    const [authorToEdit, setAuthorToEdit] = useState<AuthorType | null>(null);
+    const [authorId, setAuthorId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
-    const manager = useAuthorForm(editingAuthor);
+    const manager = useAuthorForm(authorToEdit);
     const {
         extras: { authors, loading },
         listAuthors,
@@ -32,8 +32,8 @@ export default function AuthorManagerPage() {
         (id: IdLike) => {
             const author = selectById(String(id));
             if (!author) return;
-            setEditingAuthor(author);
-            setEditingId(String(id));
+            setAuthorToEdit(author);
+            setAuthorId(String(id));
         },
         [selectById]
     );
@@ -47,8 +47,8 @@ export default function AuthorManagerPage() {
 
     const handleUpdate = useCallback(async () => {
         await listAuthors();
-        setEditingAuthor(null);
-        setEditingId(null);
+        setAuthorToEdit(null);
+        setAuthorId(null);
     }, [listAuthors]);
 
     return (
@@ -63,14 +63,14 @@ export default function AuthorManagerPage() {
                 <SectionHeader loading={loading}>Liste d&apos;auteurs</SectionHeader>
                 <AuthorList
                     authors={authors}
-                    editingId={editingId}
+                    authorId={authorId}
                     onEditById={handleEditById}
                     onUpdate={() => {
                         formRef.current?.requestSubmit();
                     }}
                     onCancel={() => {
-                        setEditingAuthor(null);
-                        setEditingId(null);
+                        setAuthorToEdit(null);
+                        setAuthorId(null);
                         setMode("create");
                         setForm(initialAuthorForm);
                     }}

--- a/src/components/Blog/manage/posts/CreatePost.tsx
+++ b/src/components/Blog/manage/posts/CreatePost.tsx
@@ -13,11 +13,11 @@ import { usePostForm } from "@entities/models/post/hooks";
 type IdLike = string | number;
 
 export default function PostManagerPage() {
-    const [editingPost, setEditingPost] = useState<PostType | null>(null);
-    const [editingId, setEditingId] = useState<string | null>(null);
+    const [postToEdit, setPostToEdit] = useState<PostType | null>(null);
+    const [postId, setPostId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
 
-    const manager = usePostForm(editingPost);
+    const manager = usePostForm(postToEdit);
     const {
         extras: { posts },
         listPosts,
@@ -34,8 +34,8 @@ export default function PostManagerPage() {
         (id: IdLike) => {
             const post = selectById(String(id));
             if (!post) return;
-            setEditingPost(post);
-            setEditingId(String(id));
+            setPostToEdit(post);
+            setPostId(String(id));
         },
         [selectById]
     );
@@ -49,13 +49,13 @@ export default function PostManagerPage() {
 
     const handleUpdate = useCallback(async () => {
         await listPosts();
-        setEditingPost(null);
-        setEditingId(null);
+        setPostToEdit(null);
+        setPostId(null);
     }, [listPosts]);
 
     const handleCancel = useCallback(() => {
-        setEditingPost(null);
-        setEditingId(null);
+        setPostToEdit(null);
+        setPostId(null);
     }, []);
 
     return (
@@ -66,13 +66,13 @@ export default function PostManagerPage() {
                     ref={formRef}
                     postFormManager={manager}
                     posts={posts}
-                    editingId={editingId}
+                    editingId={postId}
                     onSaveSuccess={handleUpdate}
                 />
                 <SectionHeader>Liste des articles</SectionHeader>
                 <PostList
                     posts={posts}
-                    editingId={editingId}
+                    postId={postId}
                     onEditById={handleEditById}
                     onUpdate={() => {
                         formRef.current?.requestSubmit();

--- a/src/components/Blog/manage/posts/PostList.tsx
+++ b/src/components/Blog/manage/posts/PostList.tsx
@@ -10,7 +10,7 @@ type IdLike = string | number;
 
 interface Props {
     posts: PostType[];
-    editingId: IdLike | null;
+    postId: IdLike | null;
     onEditById: (id: IdLike) => void;
     onUpdate: () => void;
     onCancel: () => void;
@@ -21,7 +21,7 @@ export default function PostList(props: Props) {
     return (
         <GenericList<PostType>
             items={props.posts}
-            editingId={props.editingId}
+            editingId={props.postId}
             getId={(p) => p.id}
             renderContent={(p) => (
                 <p className="self-center">

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -11,10 +11,10 @@ import { type SectionType, initialSectionForm, useSectionForm } from "@entities/
 type IdLike = string | number;
 
 export default function SectionManagerPage() {
-    const [editingSection, setEditingSection] = useState<SectionType | null>(null);
-    const [editingId, setEditingId] = useState<string | null>(null);
+    const [sectionToEdit, setSectionToEdit] = useState<SectionType | null>(null);
+    const [sectionId, setSectionId] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
-    const manager = useSectionForm(editingSection);
+    const manager = useSectionForm(sectionToEdit);
     const {
         extras: { sections },
         listSections,
@@ -32,8 +32,8 @@ export default function SectionManagerPage() {
         (id: IdLike) => {
             const section = selectById(String(id));
             if (!section) return;
-            setEditingSection(section);
-            setEditingId(String(id));
+            setSectionToEdit(section);
+            setSectionId(String(id));
         },
         [selectById]
     );
@@ -47,13 +47,13 @@ export default function SectionManagerPage() {
 
     const handleUpdate = useCallback(async () => {
         await listSections();
-        setEditingSection(null);
-        setEditingId(null);
+        setSectionToEdit(null);
+        setSectionId(null);
     }, [listSections]);
 
     const handleCancel = useCallback(() => {
-        setEditingSection(null);
-        setEditingId(null);
+        setSectionToEdit(null);
+        setSectionId(null);
         setMode("create");
         setForm(initialSectionForm);
     }, [setMode, setForm]);
@@ -65,13 +65,13 @@ export default function SectionManagerPage() {
                 <SectionForm
                     ref={formRef}
                     sectionFormManager={manager}
-                    editingId={editingId}
+                    sectionId={sectionId}
                     onSaveSuccess={handleUpdate}
                 />
                 <SectionHeader>Liste des sections</SectionHeader>
                 <SectionList
                     sections={sections}
-                    editingId={editingId}
+                    sectionId={sectionId}
                     onEditById={handleEditById}
                     onUpdate={() => {
                         formRef.current?.requestSubmit();

--- a/src/components/Blog/manage/sections/SectionList.tsx
+++ b/src/components/Blog/manage/sections/SectionList.tsx
@@ -9,7 +9,7 @@ type IdLike = string | number;
 
 interface Props {
     sections: SectionType[];
-    editingId: IdLike | null;
+    sectionId: IdLike | null;
     onEditById: (id: IdLike) => void;
     onUpdate: () => void;
     onCancel: () => void;
@@ -20,7 +20,7 @@ export default function SectionList(props: Props) {
     return (
         <GenericList<SectionType>
             items={props.sections}
-            editingId={props.editingId}
+            editingId={props.sectionId}
             getId={(s) => s.id}
             renderContent={(s) => (
                 <p className="self-center">

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -19,11 +19,11 @@ import {
 interface Props {
     sectionFormManager: ReturnType<typeof useSectionForm>;
     onSaveSuccess: () => void;
-    editingId: string | null;
+    sectionId: string | null;
 }
 
 const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
-    { sectionFormManager, onSaveSuccess, editingId },
+    { sectionFormManager, onSaveSuccess, sectionId },
     ref
 ) {
     const {
@@ -105,7 +105,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
             />
             <OrderSelector
                 items={sections}
-                editingId={editingId}
+                editingId={sectionId}
                 value={form.order ?? 1}
                 onReorder={(_, newOrder) => setFieldValue("order", newOrder)}
             />

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -18,7 +18,7 @@ type IdLike = string | number;
 export default function CreateTagPage() {
     const formRef = useRef<HTMLFormElement>(null);
     const manager: UseTagFormReturn = useTagForm();
-    const [editingId, setEditingId] = useState<string | null>(null);
+    const [tagId, setTagId] = useState<string | null>(null);
 
     const {
         extras: { tags, posts },
@@ -41,13 +41,13 @@ export default function CreateTagPage() {
 
     const handleUpdated = useCallback(async () => {
         await listTags();
-        setEditingId(null);
+        setTagId(null);
     }, [listTags]);
 
     const handleEditById = useCallback(
         (id: IdLike) => {
             void selectById(String(id));
-            setEditingId(String(id));
+            setTagId(String(id));
         },
         [selectById]
     );
@@ -61,7 +61,7 @@ export default function CreateTagPage() {
 
     const handleCancel = useCallback(() => {
         cancel();
-        setEditingId(null);
+        setTagId(null);
     }, [cancel]);
 
     return (
@@ -77,7 +77,7 @@ export default function CreateTagPage() {
                 <SectionHeader>Liste des tags</SectionHeader>
                 <TagList
                     tags={tags}
-                    editingId={editingId}
+                    tagId={tagId}
                     onEditById={handleEditById}
                     onUpdate={submitForm}
                     onCancel={handleCancel}

--- a/src/components/Blog/manage/tags/TagList.tsx
+++ b/src/components/Blog/manage/tags/TagList.tsx
@@ -9,7 +9,7 @@ type IdLike = string | number;
 
 interface Props {
     tags: TagType[];
-    editingId: IdLike | null;
+    tagId: IdLike | null;
     onEditById: (id: IdLike) => void;
     onUpdate: () => void;
     onCancel: () => void;
@@ -20,7 +20,7 @@ interface Props {
 
 function TagListInner({
     tags,
-    editingId,
+    tagId,
     onEditById,
     onUpdate,
     onCancel,
@@ -31,7 +31,7 @@ function TagListInner({
     return (
         <GenericList<TagType>
             items={tags}
-            editingId={editingId}
+            editingId={tagId}
             getId={(t) => t.id}
             renderContent={(t) => (
                 <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-blue-100 text-blue-800 text-sm font-semibold">

--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -19,10 +19,10 @@ const fields: (keyof UserNameFormType)[] = ["userName"];
 
 export default function UserNameManager() {
     const { user } = useAuthenticator();
-    const [editingProfile, setEditingProfile] = useState<UserNameType | null>(null);
-    const [editingId, setEditingId] = useState<string | null>(null);
+    const [userNameToEdit, setUserNameToEdit] = useState<UserNameType | null>(null);
+    const [userNameId, setUserNameId] = useState<string | null>(null);
 
-    const manager = useUserNameForm(editingProfile);
+    const manager = useUserNameForm(userNameToEdit);
     const { removeById, setForm, setMode, refresh } = manager;
 
     // 🔄 Charger/rafraîchir au montage et quand l'utilisateur change
@@ -41,8 +41,8 @@ export default function UserNameManager() {
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
             await removeById(String(id));
-            setEditingProfile(null);
-            setEditingId(null);
+            setUserNameToEdit(null);
+            setUserNameId(null);
             setMode("create");
             setForm(initialUserNameForm);
         },
@@ -76,7 +76,7 @@ export default function UserNameManager() {
             updateEntity={manager.updateEntity}
             clearField={manager.clearField}
             deleteEntity={async (id?: string) => {
-                const target = id ?? editingId ?? user?.userId ?? user?.username ?? undefined;
+                const target = id ?? userNameId ?? user?.userId ?? user?.username ?? undefined;
                 if (!target) return;
                 await handleDeleteById(target);
             }}

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -29,18 +29,18 @@ const fields: (keyof UserProfileFormType)[] = [
 
 export default function UserProfileManager() {
     const { user } = useAuthenticator();
-    const [editingProfile, setEditingProfile] = useState<UserProfileType | null>(null);
-    const [editingId, setEditingId] = useState<string | null>(null);
+    const [profileToEdit, setProfileToEdit] = useState<UserProfileType | null>(null);
+    const [profileId, setProfileId] = useState<string | null>(null);
 
     // ✅ même signature que les autres managers (ex: useAuthorForm)
-    const manager = useUserProfileForm(editingProfile);
+    const manager = useUserProfileForm(profileToEdit);
     const { removeById, setForm, setMode, form } = manager;
 
     const handleDeleteById = useCallback(
         async (id: IdLike) => {
             await removeById(String(id));
-            setEditingProfile(null);
-            setEditingId(null);
+            setProfileToEdit(null);
+            setProfileId(null);
             setMode("create");
             setForm(initialUserProfileForm);
         },
@@ -120,7 +120,7 @@ export default function UserProfileManager() {
                 clearField={manager.clearField}
                 // Wrapper “à la AuthorList.onDeleteById”
                 deleteEntity={async (id?: string) => {
-                    const target = id ?? editingId ?? user?.userId ?? user?.username ?? undefined;
+                    const target = id ?? profileId ?? user?.userId ?? user?.username ?? undefined;
                     if (!target) return;
                     await handleDeleteById(target);
                 }}

--- a/src/entities/models/author/hooks.tsx
+++ b/src/entities/models/author/hooks.tsx
@@ -10,7 +10,7 @@ interface Extras extends Record<string, unknown> {
 }
 
 export function useAuthorForm(author: AuthorType | null) {
-    const [editingId, setEditingId] = useState<string | null>(author?.id ?? null);
+    const [authorId, setAuthorId] = useState<string | null>(author?.id ?? null);
 
     const modelForm = useModelForm<AuthorFormType, Extras>({
         initialForm: initialAuthorForm,
@@ -20,19 +20,19 @@ export function useAuthorForm(author: AuthorType | null) {
             void postIds;
             const { data } = await authorService.create(authorInput);
             if (!data) throw new Error("Erreur lors de la création de l'auteur");
-            setEditingId(data.id);
+            setAuthorId(data.id);
             return data.id;
         },
         update: async (form) => {
-            if (!editingId) throw new Error("ID de l'auteur manquant pour la mise à jour");
+            if (!authorId) throw new Error("ID de l'auteur manquant pour la mise à jour");
             const { postIds, ...authorInput } = form;
             void postIds;
             const { data } = await authorService.update({
-                id: editingId,
+                id: authorId,
                 ...authorInput,
             });
             if (!data) throw new Error("Erreur lors de la mise à jour de l'auteur");
-            setEditingId(data.id);
+            setAuthorId(data.id);
             return data.id;
         },
     });
@@ -59,7 +59,7 @@ export function useAuthorForm(author: AuthorType | null) {
             if (authorItem) {
                 setForm(toAuthorForm(authorItem, []));
                 setMode("edit");
-                setEditingId(id);
+                setAuthorId(id);
             }
             return authorItem;
         },
@@ -71,12 +71,12 @@ export function useAuthorForm(author: AuthorType | null) {
             if (!window.confirm("Supprimer cet auteur ?")) return;
             await authorService.deleteCascade({ id });
             await listAuthors();
-            if (editingId === id) {
-                setEditingId(null);
+            if (authorId === id) {
+                setAuthorId(null);
                 reset();
             }
         },
-        [listAuthors, editingId, reset]
+        [listAuthors, authorId, reset]
     );
 
     useEffect(() => {
@@ -87,13 +87,13 @@ export function useAuthorForm(author: AuthorType | null) {
         if (author) {
             setForm(toAuthorForm(author, []));
             setMode("edit");
-            setEditingId(author.id);
+            setAuthorId(author.id);
         } else {
             setForm(initialAuthorForm);
             setMode("create");
-            setEditingId(null);
+            setAuthorId(null);
         }
     }, [author, setForm, setMode]);
 
-    return { ...modelForm, editingId, listAuthors, selectById, removeById };
+    return { ...modelForm, authorId, listAuthors, selectById, removeById };
 }

--- a/src/entities/models/post/hooks.tsx
+++ b/src/entities/models/post/hooks.tsx
@@ -23,7 +23,7 @@ interface Extras extends Record<string, unknown> {
 }
 
 export function usePostForm(post: PostType | null) {
-    const [editingId, setEditingId] = useState<string | null>(post?.id ?? null);
+    const [postId, setPostId] = useState<string | null>(post?.id ?? null);
 
     const modelForm = useModelForm<PostFormType, Extras>({
         initialForm: initialPostForm,
@@ -46,24 +46,24 @@ export function usePostForm(post: PostType | null) {
                 seo: form.seo,
             });
             if (!data) throw new Error("Erreur lors de la création de l'article");
-            setEditingId(data.id);
+            setPostId(data.id);
             setMessage("Nouvel article créé avec succès.");
             return data.id;
         },
         update: async (form) => {
-            if (!editingId) {
+            if (!postId) {
                 throw new Error("ID du post manquant pour la mise à jour");
             }
             const { tagIds, sectionIds, ...postInput } = form;
             void tagIds;
             void sectionIds;
             const { data } = await postService.update({
-                id: editingId,
+                id: postId,
                 ...postInput,
                 seo: form.seo,
             });
             if (!data) throw new Error("Erreur lors de la mise à jour de l'article");
-            setEditingId(data.id);
+            setPostId(data.id);
             setMessage("Article mis à jour avec succès.");
 
             return data.id;
@@ -109,11 +109,11 @@ export function usePostForm(post: PostType | null) {
                 ]);
                 setForm(toPostForm(post, tagIds, sectionIds));
                 setMode("edit");
-                setEditingId(post.id);
+                setPostId(post.id);
             } else {
                 setForm(initialPostForm);
                 setMode("create");
-                setEditingId(null);
+                setPostId(null);
             }
         })();
     }, [post, setForm, setMode]);
@@ -140,7 +140,7 @@ export function usePostForm(post: PostType | null) {
         (id: string) => {
             const postItem = extras.posts.find((p) => p.id === id) ?? null;
             if (postItem) {
-                setEditingId(id);
+                setPostId(id);
                 void (async () => {
                     const [tagIds, sectionIds] = await Promise.all([
                         postTagService.listByParent(id),
@@ -164,8 +164,8 @@ export function usePostForm(post: PostType | null) {
                 await postService.deleteCascade({ id });
                 await listPosts();
 
-                if (editingId === id) {
-                    setEditingId(null);
+                if (postId === id) {
+                    setPostId(null);
                 }
 
                 setMessage("Article supprimé avec succès.");
@@ -176,12 +176,12 @@ export function usePostForm(post: PostType | null) {
                 // pas de throw: l’UI affiche le message d’erreur
             }
         },
-        [listPosts, editingId, refresh]
+        [listPosts, postId, refresh]
     );
 
     return {
         ...modelForm,
-        editingId,
+        postId,
         listPosts,
         selectById,
         removeById,

--- a/src/entities/models/section/hooks.tsx
+++ b/src/entities/models/section/hooks.tsx
@@ -11,7 +11,7 @@ import { syncSection2Posts } from "@entities/relations/sectionPost";
 type Extras = { posts: PostType[]; sections: SectionType[] };
 
 export function useSectionForm(section: SectionType | null) {
-    const [editingId, setEditingId] = useState<string | null>(section?.id ?? null);
+    const [sectionId, setSectionId] = useState<string | null>(section?.id ?? null);
 
     const modelForm = useModelForm<SectionFormTypes, Extras>({
         initialForm: initialSectionForm,
@@ -21,21 +21,21 @@ export function useSectionForm(section: SectionType | null) {
             void postIds;
             const { data } = await sectionService.create(sectionInput);
             if (!data) throw new Error("Erreur lors de la création de la section");
-            setEditingId(data.id);
+            setSectionId(data.id);
             return data.id;
         },
         update: async (form) => {
-            if (!editingId) {
+            if (!sectionId) {
                 throw new Error("ID de la section manquant pour la mise à jour");
             }
             const { postIds, ...sectionInput } = form;
             void postIds;
             const { data } = await sectionService.update({
-                id: editingId,
+                id: sectionId,
                 ...sectionInput,
             });
             if (!data) throw new Error("Erreur lors de la mise à jour de la section");
-            setEditingId(data.id);
+            setSectionId(data.id);
             return data.id;
         },
         syncRelations: async (id, form) => {
@@ -65,11 +65,11 @@ export function useSectionForm(section: SectionType | null) {
                 const postIds = await sectionPostService.listByParent(section.id);
                 setForm(toSectionForm(section, postIds));
                 setMode("edit");
-                setEditingId(section.id);
+                setSectionId(section.id);
             } else {
                 setForm(initialSectionForm);
                 setMode("create");
-                setEditingId(null);
+                setSectionId(null);
             }
         })();
     }, [section, setForm, setMode]);
@@ -78,7 +78,7 @@ export function useSectionForm(section: SectionType | null) {
         (id: string) => {
             const sectionItem = extras.sections.find((s) => s.id === id) ?? null;
             if (sectionItem) {
-                setEditingId(id);
+                setSectionId(id);
                 void (async () => {
                     const postIds = await sectionPostService.listByParent(id);
                     setForm(toSectionForm(sectionItem, postIds));
@@ -97,13 +97,13 @@ export function useSectionForm(section: SectionType | null) {
             if (!window.confirm("Supprimer cette section ?")) return;
             await sectionService.deleteCascade({ id: sectionItem.id });
             await listSections();
-            if (editingId === id) {
-                setEditingId(null);
+            if (sectionId === id) {
+                setSectionId(null);
                 reset();
             }
         },
-        [selectById, listSections, editingId, reset]
+        [selectById, listSections, sectionId, reset]
     );
 
-    return { ...modelForm, editingId, listSections, selectById, removeById };
+    return { ...modelForm, sectionId, listSections, selectById, removeById };
 }

--- a/src/entities/models/tag/__tests__/hooks.test.tsx
+++ b/src/entities/models/tag/__tests__/hooks.test.tsx
@@ -81,7 +81,7 @@ describe("useTagForm", () => {
         expect(result.current.extras.postTags).not.toContainEqual({ postId: "p1", tagId: "t2" });
     });
 
-    it("selectById préremplit le formulaire et fixe editingId", async () => {
+    it("selectById préremplit le formulaire et fixe tagId", async () => {
         const { result } = renderHook(() => useTagForm());
         await act(async () => {
             await result.current.listTags();
@@ -90,7 +90,7 @@ describe("useTagForm", () => {
             await result.current.selectById("t1");
         });
         expect(result.current.form).toEqual({ name: "Tag1", postIds: ["p1"] });
-        expect(result.current.editingId).toBe("t1");
+        expect(result.current.tagId).toBe("t1");
     });
 
     it("reset réinitialise le formulaire et l'id", async () => {
@@ -105,10 +105,10 @@ describe("useTagForm", () => {
             result.current.reset();
         });
         expect(result.current.form).toEqual({ name: "", postIds: [] });
-        expect(result.current.editingId).toBeNull();
+        expect(result.current.tagId).toBeNull();
     });
 
-    it("removeById supprime le tag et réinitialise editingId", async () => {
+    it("removeById supprime le tag et réinitialise tagId", async () => {
         const deleteTagMock = tagService.deleteCascade as ReturnType<typeof vi.fn>;
         deleteTagMock.mockResolvedValue({});
         vi.spyOn(window, "confirm").mockReturnValue(true);
@@ -123,6 +123,6 @@ describe("useTagForm", () => {
             await result.current.removeById("t1");
         });
         expect(deleteTagMock).toHaveBeenCalledWith({ id: "t1" });
-        expect(result.current.editingId).toBeNull();
+        expect(result.current.tagId).toBeNull();
     });
 });

--- a/src/entities/models/tag/hooks.tsx
+++ b/src/entities/models/tag/hooks.tsx
@@ -25,7 +25,7 @@ const initialExtras: TagFormExtras = {
 };
 
 export function useTagForm() {
-    const [editingId, setEditingId] = useState<string | null>(null);
+    const [tagId, setTagId] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
 
     const modelForm = useModelForm<TagFormType, TagFormExtras>({
@@ -34,14 +34,14 @@ export function useTagForm() {
         create: async (form) => {
             const { data } = await tagService.create({ name: form.name });
             if (!data) throw new Error("Erreur lors de la création du tag");
-            setEditingId(data.id);
+            setTagId(data.id);
             return data.id;
         },
         update: async (form) => {
-            if (!editingId) throw new Error("ID du tag manquant pour la mise à jour");
-            const { data } = await tagService.update({ id: editingId, name: form.name });
+            if (!tagId) throw new Error("ID du tag manquant pour la mise à jour");
+            const { data } = await tagService.update({ id: tagId, name: form.name });
             if (!data) throw new Error("Erreur lors de la mise à jour du tag");
-            setEditingId(data.id);
+            setTagId(data.id);
             return data.id;
         },
         syncRelations: async (tagId, form) => {
@@ -83,13 +83,13 @@ export function useTagForm() {
             const postIds = await postTagService.listByChild(tag.id);
             setForm(toTagForm(tag, postIds));
             setMode("edit");
-            setEditingId(tag.id);
+            setTagId(tag.id);
         },
         [extras.tags, setForm, setMode]
     );
 
     const reset = useCallback(() => {
-        setEditingId(null);
+        setTagId(null);
         formReset();
     }, [formReset]);
 
@@ -100,11 +100,11 @@ export function useTagForm() {
             if (!window.confirm("Supprimer ce tag ?")) return;
             await tagService.deleteCascade({ id: tag.id });
             await listTags();
-            if (editingId === id) {
+            if (tagId === id) {
                 reset();
             }
         },
-        [extras.tags, listTags, editingId, reset]
+        [extras.tags, listTags, tagId, reset]
     );
 
     const toggle = useCallback(
@@ -157,7 +157,7 @@ export function useTagForm() {
         toggle,
         tagsForPost,
         isTagLinked,
-        editingId,
+        tagId,
     };
 }
 

--- a/src/entities/models/userName/hooks.tsx
+++ b/src/entities/models/userName/hooks.tsx
@@ -18,7 +18,7 @@ export function useUserNameForm(userName: UserNameType | null) {
     const { user } = useAuthenticator();
     const sub = user?.userId ?? user?.username ?? null;
 
-    const [editingId, setEditingId] = useState<string | null>(userName?.id ?? sub ?? null);
+    const [userNameId, setUserNameId] = useState<string | null>(userName?.id ?? sub ?? null);
 
     // Comparateur pour un dirty "propre"
     const isEqual = useCallback(
@@ -29,11 +29,11 @@ export function useUserNameForm(userName: UserNameType | null) {
 
     // Fournir load() pour que refresh() refonctionne partout
     const load = useCallback(async () => {
-        const id = editingId ?? sub;
+        const id = userNameId ?? sub;
         if (!id) return null;
         const { data } = await userNameService.get({ id });
         return data ? toUserNameForm(data, [], []) : null;
-    }, [editingId, sub]);
+    }, [userNameId, sub]);
 
     const modelForm = useModelForm<UserNameFormType, Extras>({
         initialForm: initialUserNameForm,
@@ -48,12 +48,12 @@ export function useUserNameForm(userName: UserNameType | null) {
             });
             if (!data)
                 throw new Error(errors?.[0]?.message ?? "Erreur lors de la création du pseudo");
-            setEditingId(data.id);
+            setUserNameId(data.id);
             emitUserNameUpdated();
             return data.id;
         },
         update: async (form) => {
-            const id = editingId ?? sub;
+            const id = userNameId ?? sub;
             if (!id) throw new Error("ID utilisateur introuvable");
             const { data, errors } = await userNameService.update({
                 id,
@@ -61,7 +61,7 @@ export function useUserNameForm(userName: UserNameType | null) {
             });
             if (!data)
                 throw new Error(errors?.[0]?.message ?? "Erreur lors de la mise à jour du pseudo");
-            setEditingId(data.id);
+            setUserNameId(data.id);
             emitUserNameUpdated();
             return data.id;
         },
@@ -87,18 +87,18 @@ export function useUserNameForm(userName: UserNameType | null) {
     useEffect(() => {
         void (async () => {
             if (userName) {
-                setEditingId(userName.id);
+                setUserNameId(userName.id);
                 adoptInitial(toUserNameForm(userName, [], []), "edit");
                 return;
             }
             if (!sub) {
                 setForm(initialUserNameForm);
                 setMode("create");
-                setEditingId(null);
+                setUserNameId(null);
                 return;
             }
             // autoLoad + load() s'occuperont de l’hydratation
-            setEditingId(sub);
+            setUserNameId(sub);
         })();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [userName?.id, sub]);
@@ -107,7 +107,7 @@ export function useUserNameForm(userName: UserNameType | null) {
         (id: string) => {
             const item = extras.userNames.find((u) => u.id === id) ?? null;
             if (item) {
-                setEditingId(item.id);
+                setUserNameId(item.id);
                 adoptInitial(toUserNameForm(item, [], []), "edit");
             }
             return item;
@@ -120,28 +120,28 @@ export function useUserNameForm(userName: UserNameType | null) {
             if (!window.confirm("Supprimer ce pseudo ?")) return;
             await userNameService.delete({ id });
             await fetchUserNames();
-            if (editingId === id) {
-                setEditingId(null);
+            if (userNameId === id) {
+                setUserNameId(null);
                 adoptInitial(initialUserNameForm, "create");
                 reset();
             }
             await refresh(); // 🔄 maintenant effectif
             emitUserNameUpdated();
         },
-        [editingId, reset, fetchUserNames, refresh, adoptInitial]
+        [userNameId, reset, fetchUserNames, refresh, adoptInitial]
     );
 
     // Helpers “champ par champ”
     const updateEntity = useCallback(
         async (field: keyof UserNameFormType, value: string) => {
-            const id = editingId ?? sub;
+            const id = userNameId ?? sub;
             if (!id) return;
             await userNameService.update({ id, [field]: value } as any);
             patchForm({ [field]: value } as Partial<UserNameFormType>); // optimiste
             await refresh(); // vérité serveur
             emitUserNameUpdated();
         },
-        [editingId, sub, patchForm, refresh]
+        [userNameId, sub, patchForm, refresh]
     );
 
     const clearField = useCallback(
@@ -153,7 +153,7 @@ export function useUserNameForm(userName: UserNameType | null) {
 
     return {
         ...modelForm,
-        editingId,
+        userNameId,
         fetchUserNames,
         selectById,
         removeById,

--- a/src/entities/models/userProfile/hooks.tsx
+++ b/src/entities/models/userProfile/hooks.tsx
@@ -13,7 +13,7 @@ export function useUserProfileForm(profile: UserProfileType | null) {
     const { user } = useAuthenticator();
     const sub = user?.userId ?? user?.username ?? null;
 
-    const [editingId, setEditingId] = useState<string | null>(profile?.id ?? sub ?? null);
+    const [profileId, setProfileId] = useState<string | null>(profile?.id ?? sub ?? null);
 
     const modelForm = useModelForm<UserProfileFormType, Extras>({
         initialForm: initialUserProfileForm,
@@ -23,15 +23,15 @@ export function useUserProfileForm(profile: UserProfileType | null) {
             if (!id) throw new Error("ID utilisateur introuvable");
             const { data } = await userProfileService.create({ id, ...form });
             if (!data) throw new Error("Erreur lors de la création du profil");
-            setEditingId(data.id);
+            setProfileId(data.id);
             return data.id;
         },
         update: async (form) => {
-            const id = editingId ?? sub;
+            const id = profileId ?? sub;
             if (!id) throw new Error("ID utilisateur introuvable");
             const { data } = await userProfileService.update({ id, ...form });
             if (!data) throw new Error("Erreur lors de la mise à jour du profil");
-            setEditingId(data.id);
+            setProfileId(data.id);
             return data.id;
         },
         autoLoad: false,
@@ -46,25 +46,25 @@ export function useUserProfileForm(profile: UserProfileType | null) {
             if (profile) {
                 setForm(toUserProfileForm(profile));
                 setMode("edit");
-                setEditingId(profile.id);
+                setProfileId(profile.id);
                 return;
             }
             const id = sub ?? null;
             if (!id) {
                 setForm(initialUserProfileForm);
                 setMode("create");
-                setEditingId(null);
+                setProfileId(null);
                 return;
             }
             const { data } = await userProfileService.get({ id });
             if (data) {
                 setForm(toUserProfileForm(data));
                 setMode("edit");
-                setEditingId(data.id);
+                setProfileId(data.id);
             } else {
                 setForm(initialUserProfileForm);
                 setMode("create");
-                setEditingId(id);
+                setProfileId(id);
             }
         })();
     }, [profile, sub, setForm, setMode]);
@@ -87,23 +87,23 @@ export function useUserProfileForm(profile: UserProfileType | null) {
         async (id: string) => {
             if (!window.confirm("Supprimer ce profil ?")) return;
             await userProfileService.delete({ id });
-            if (editingId === id) {
-                setEditingId(null);
+            if (profileId === id) {
+                setProfileId(null);
                 reset();
             }
         },
-        [editingId, reset]
+        [profileId, reset]
     );
 
     // Helpers champ par champ (même esprit que toggle/updateEntity ailleurs)
     const updateEntity = useCallback(
         async (field: keyof UserProfileFormType, value: string) => {
-            const id = editingId ?? sub;
+            const id = profileId ?? sub;
             if (!id) return;
             await userProfileService.update({ id, [field]: value } as any);
             patchForm({ [field]: value } as Partial<UserProfileFormType>);
         },
-        [editingId, sub, patchForm]
+        [profileId, sub, patchForm]
     );
 
     const clearField = useCallback(
@@ -118,7 +118,7 @@ export function useUserProfileForm(profile: UserProfileType | null) {
 
     return {
         ...modelForm,
-        editingId,
+        profileId,
         selectById,
         removeById,
         updateEntity,


### PR DESCRIPTION
## Résumé
- uniformise les pages de création et managers de profil/pseudo avec des IDs spécifiques à chaque entité
- renomme les props des listes pour refléter les nouveaux IDs
- adapte les hooks et tests unitaires à ces changements

## Tests
- `yarn lint`
- `yarn test` *(échoue : ReferenceError expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f721c1648324a2794bd4a57d11c3