### PR TITLE
[Feat] ajouter glossaire de nommage

### DIFF
--- a/docs/glossaire-nommage.md
+++ b/docs/glossaire-nommage.md
@@ -1,0 +1,13 @@
+# Glossaire — Conventions de nommage
+
+## Callbacks normalisés
+
+| Nom             | Rôle                                                           |
+| --------------- | -------------------------------------------------------------- |
+| `cancelChanges` | Annule les modifications locales sans quitter le mode courant. |
+| `exitEditMode`  | Quitte le mode édition et repasse en mode création.            |
+| `onCancel`      | Callback UI lorsque l’utilisateur quitte le formulaire.        |
+| `onPostSaved`   | Callback métier déclenché après la persistance d’un Post.      |
+
+Les types doivent rester immuables (`readonly`), utiliser des unions discriminées et `Exact<T>` quand c’est nécessaire.  
+Aucun `any` n’est autorisé. `unknown` doit être justifié par un commentaire.


### PR DESCRIPTION
## Description
- ajouter un glossaire de conventions de nommage

## Tests effectués
- `yarn lint` *(échoue : unused imports et hooks)*
- `yarn build` *(interrompu : blocage lors de "Creating an optimized production build ...")*


------
https://chatgpt.com/codex/tasks/task_e_68aaa124b4ac8324bb4ebca0066362cb