### PR TITLE
[Feat] ADR forms-core-v2

### DIFF
--- a/docs/adr/adr-forms-core-v2.md
+++ b/docs/adr/adr-forms-core-v2.md
@@ -1,0 +1,18 @@
+# ADR — Refonte forms-core-v2
+
+## Contexte
+
+La première version de `useModelForm` mélangeait logique métier et UI.  
+Objectif : stabiliser un cœur générique réutilisable par toutes les entités.
+
+## Décision
+
+- Un hook générique `useModelForm` fournit l’état et les opérations (submit, cancel, exitEditMode…).
+- Les hooks métiers (`usePostForm`, `useTagForm`…) s’appuient sur ce core et se concentrent sur la persistance.
+- `BlogFormShell` devient le composant UI standard, recevant `onCancel` et éventuellement `cancelChanges`.
+
+## Conséquences
+
+- API uniforme (`cancelChanges`, `exitEditMode`, `onPostSaved`, etc.).
+- Migration progressive des entités : Post → Tag → Section → Author.
+- Nettoyage ultérieur des alias (`deleteEntity`…), mises à jour du glossaire et des tests.


### PR DESCRIPTION
## Summary
- ajouter l'ADR pour la refonte de forms-core-v2

## Testing
- `yarn install`
- `yarn prettier --write docs/adr/adr-forms-core-v2.md`
- `yarn lint` (échoue : unused imports, hooks)
- `yarn test` (échoue : expect is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68aaa341745883248b412a6c0b22f21a