### PR TITLE
[Fix] étend les tests de useModelForm

### DIFF
--- a/src/entities/core/hooks/__tests__/useModelForm.test.tsx
+++ b/src/entities/core/hooks/__tests__/useModelForm.test.tsx
@@ -81,4 +81,18 @@ describe("useModelForm", () => {
         act(() => result.current.setCreate());
         expect(result.current.message).toBeNull();
     });
+
+    it("met à jour partiellement et annule les modifications", () => {
+        const create = vi.fn();
+        const update = vi.fn();
+        const { result } = renderHook(() => useModelForm<Form>({ initialForm, create, update }));
+
+        act(() => result.current.patchForm({ title: "nouveau titre", tags: ["x"] }));
+        expect(result.current.form).toEqual({ title: "nouveau titre", tags: ["x"] });
+        expect(result.current.dirty).toBe(true);
+
+        act(() => result.current.cancelChanges());
+        expect(result.current.form).toEqual(initialForm);
+        expect(result.current.dirty).toBe(false);
+    });
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,12 +1,7 @@
-import { expect, beforeAll, afterEach, afterAll } from "vitest";
+import { beforeAll, afterEach, afterAll } from "vitest";
 import { setupServer } from "msw/node";
+import "@testing-library/jest-dom/vitest";
 import "whatwg-fetch";
-declare global {
-    var expect: (typeof import("vitest"))["expect"];
-}
-
-globalThis.expect = expect;
-import "@testing-library/jest-dom";
 
 export const server = setupServer();
 


### PR DESCRIPTION
## Description
- corrige l'initialisation de `jest-dom` avec Vitest
- ajoute un test pour `patchForm` et `cancelChanges`

## Tests effectués
- `yarn prettier --write test/setup.ts src/entities/core/hooks/__tests__/useModelForm.test.tsx`
- `yarn lint` *(échoue : unused imports dans d'autres fichiers)*
- `yarn test src/entities/core/hooks/__tests__/useModelForm.test.tsx`
- `yarn tsc --noEmit` *(échoue : erreurs de type dans d'autres fichiers)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa395ef088324919e720b48a38a15