### PR TITLE
[Fix] Ajouter le type TagFormType au BlogFormShell

### DIFF
--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import React, { forwardRef, type ChangeEvent } from "react";
-import BlogFormShell, { type BlogFormManager } from "@components/Blog/manage/BlogFormShell";
+import BlogFormShell from "@components/Blog/manage/BlogFormShell";
 import { useTagForm } from "@entities/models/tag/hooks";
 import { initialTagForm } from "@entities/models/tag/form";
 import type { TagFormType, TagType } from "@entities/models/tag/types";
@@ -30,7 +30,7 @@ const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm(
     };
 
     return (
-        <BlogFormShell
+        <BlogFormShell<TagFormType>
             ref={ref}
             blogFormManager={tagFormManager}
             initialForm={initialTagForm}


### PR DESCRIPTION
## Description
- ajoute l'argument générique `TagFormType` à `BlogFormShell`
- nettoie un import inutilisé dans `TagForm`

## Tests effectués
- `yarn install`
- `yarn prettier --write src/components/Blog/manage/tags/TagForm.tsx`
- `yarn lint` *(échoue: unused imports, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aaf6b4c3b48324938524e62b40dbbd