### PR TITLE
[Fix] typage générique de BlogFormShell

### DIFF
--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -82,7 +82,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
     };
 
     return (
-        <BlogFormShell
+        <BlogFormShell<SectionFormType>
             ref={ref}
             blogFormManager={sectionFormManager}
             initialForm={initialSectionForm}


### PR DESCRIPTION
## Objectif
- typer l'appel à `BlogFormShell` dans `SectionsForm` avec `SectionFormType`.

## Tests effectués
- `yarn install`
- `yarn prettier src/components/Blog/manage/sections/SectionsForm.tsx --write`
- `yarn lint` *(échoue : imports inutilisés dans d'autres fichiers)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf6b38a148324a643b2677a3f2e27