### PR TITLE
[Fix] typage de BlogFormShell dans AuthorForm

### DIFF
--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -25,7 +25,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
     };
 
     return (
-        <BlogFormShell
+        <BlogFormShell<AuthorFormType>
             ref={ref}
             blogFormManager={authorFormManager}
             initialForm={initialAuthorForm}


### PR DESCRIPTION
## Objectif
- Spécifier le type générique `AuthorFormType` pour `BlogFormShell` dans `AuthorForm`.
- S'assurer que l'import de `AuthorFormType` est présent.

## Tests effectués
- `yarn lint --file src/components/Blog/manage/authors/AuthorForm.tsx`
- `yarn test` *(échec: tests existants)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf6b1cab083249d26c422db50d5ec