### PR TITLE
[Fix] typage generique de BlogFormShell

### DIFF
--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -25,7 +25,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
     };
 
     return (
-        <BlogFormShell
+        <BlogFormShell<AuthorFormType>
             ref={ref}
             blogFormManager={authorFormManager}
             initialForm={initialAuthorForm}

--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -6,7 +6,7 @@ import AuthorForm from "@components/Blog/manage/authors/AuthorForm";
 import AuthorList from "@components/Blog/manage/authors/AuthorList";
 import BlogEditorLayout from "@components/Blog/manage/BlogEditorLayout";
 import SectionHeader from "@components/Blog/manage/SectionHeader";
-import { type AuthorType, initialAuthorForm, useAuthorForm } from "@entities/models/author";
+import { type AuthorType, useAuthorForm } from "@entities/models/author";
 
 type IdLike = string | number;
 

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -82,7 +82,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
     };
 
     return (
-        <BlogFormShell
+        <BlogFormShell<SectionFormType>
             ref={ref}
             blogFormManager={sectionFormManager}
             initialForm={initialSectionForm}

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -9,7 +9,6 @@ import { RefreshButton } from "@components/ui/Button";
 
 import TagForm from "@components/Blog/manage/tags/TagForm";
 import TagList from "@components/Blog/manage/tags/TagList";
-import PostTagsRelationManager from "@components/Blog/manage/tags/PostTagsRelationManager";
 
 import { type TagType, useTagForm } from "@entities/models/tag/";
 

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import React, { forwardRef, type ChangeEvent } from "react";
-import BlogFormShell, { type BlogFormManager } from "@components/Blog/manage/BlogFormShell";
+import BlogFormShell from "@components/Blog/manage/BlogFormShell";
 import { useTagForm } from "@entities/models/tag/hooks";
 import { initialTagForm } from "@entities/models/tag/form";
 import type { TagFormType, TagType } from "@entities/models/tag/types";
@@ -30,7 +30,7 @@ const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm(
     };
 
     return (
-        <BlogFormShell
+        <BlogFormShell<TagFormType>
             ref={ref}
             blogFormManager={tagFormManager}
             initialForm={initialTagForm}


### PR DESCRIPTION
## Objectif
- typer explicitement `BlogFormShell` dans les formulaires d'auteur, de section et de tag
- nettoyer des imports inutilisés dans les pages de création associées

## Tests effectués
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaf64b32b083248451720447edac31