### PR TITLE
[Fix] Retrait des props inutilisées dans TagForm

### DIFF
--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -64,13 +64,7 @@ export default function CreateTagPage() {
                     <RefreshButton onRefresh={listTags} label="Rafraîchir" size="small" />
                 </div>
 
-                <TagForm
-                    ref={formRef}
-                    tagFormManager={manager}
-                    tags={tags}
-                    editingId={tagId}
-                    onSaveSuccess={handleSaved}
-                />
+                <TagForm ref={formRef} tagFormManager={manager} onSaveSuccess={handleSaved} />
 
                 <SectionHeader>Liste des tags</SectionHeader>
                 <TagList

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -5,7 +5,7 @@ import React, { forwardRef, type ChangeEvent } from "react";
 import BlogFormShell from "@components/Blog/manage/BlogFormShell";
 import { useTagForm } from "@entities/models/tag/hooks";
 import { initialTagForm } from "@entities/models/tag/form";
-import type { TagFormType, TagType } from "@entities/models/tag/types";
+import type { TagFormType } from "@entities/models/tag/types";
 import { EditableField } from "@components/ui/Form";
 
 type UseTagFormReturn = ReturnType<typeof useTagForm>;
@@ -13,12 +13,10 @@ type UseTagFormReturn = ReturnType<typeof useTagForm>;
 interface Props {
     tagFormManager: UseTagFormReturn;
     onSaveSuccess: () => void;
-    tags: TagType[];
-    editingId: string | null;
 }
 
 const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm(
-    { tagFormManager, onSaveSuccess, tags, editingId },
+    { tagFormManager, onSaveSuccess },
     ref
 ) {
     const { form, setFieldValue } = tagFormManager;


### PR DESCRIPTION
## Summary
- retire les props `tags` et `editingId` de `TagForm`
- met à jour l'appel à `TagForm` dans `CreateTag`

## Testing
- `yarn lint` *(avertissements existants dans d'autres modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0186dc3c83249f179766a3da048a