### PR TITLE
[Fix] gérer le flux nextStep lors de la connexion E2E

### DIFF
--- a/e2e/utils/auth.ts
+++ b/e2e/utils/auth.ts
@@ -12,7 +12,25 @@ export const requireCredentials = () => {
 
 export const signInUser = async () => {
     requireCredentials();
-    await signIn({ username: email!, password: password! });
+    const { isSignedIn, nextStep } = await signIn({
+        username: email!,
+        password: password!,
+    });
+
+    if (!isSignedIn) {
+        switch (nextStep.signInStep) {
+            case "CONFIRM_SIGN_UP":
+                throw new Error("Vérification de l'e-mail requise.");
+            case "RESET_PASSWORD":
+                throw new Error("Réinitialisation du mot de passe requise.");
+            case "CONTINUE_SIGN_IN_WITH_MFA_SELECTION":
+            case "CONTINUE_SIGN_IN_WITH_TOTP_SETUP":
+            case "CONFIRM_SIGN_IN_WITH_TOTP_CODE":
+                throw new Error("MFA requise pour la connexion.");
+            default:
+                throw new Error(`Étape de connexion non gérée : ${nextStep.signInStep}`);
+        }
+    }
 };
 
 export const signOutUser = async () => {


### PR DESCRIPTION
## Summary
- gérer les étapes de connexion renvoyées par `signIn`

## Testing
- `yarn lint`
- `yarn build` *(échoue : "Property 'onCancel' is missing in type...")*

------
https://chatgpt.com/codex/tasks/task_e_68ab0150e9908324a3c4d1d4f1411c25