### PR TITLE
[Feat] centralisation du mock Amplify client

### DIFF
--- a/src/entities/core/services/__tests__/crudService.test.ts
+++ b/src/entities/core/services/__tests__/crudService.test.ts
@@ -3,32 +3,7 @@ import { crudService } from "@entities/core/services";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 
-vi.mock("@entities/core/services/amplifyClient", () => {
-    const baseFetch = (op: string, { authMode, body }: { authMode?: string; body?: unknown }) =>
-        fetch(`http://test.local/${op}`, {
-            method: "POST",
-            headers: { "x-auth-mode": authMode ?? "" },
-            body: body ? JSON.stringify(body) : undefined,
-        }).then(async (res) => {
-            if (!res.ok) throw new Error(res.statusText);
-            return res.json();
-        });
-
-    const models = {
-        Todo: {
-            list: (opts?: unknown) => baseFetch("list", opts as any),
-            get: (args: unknown, opts?: unknown) =>
-                baseFetch("get", { ...(opts as any), body: args }),
-            create: (data: unknown, opts?: unknown) =>
-                baseFetch("create", { ...(opts as any), body: data }),
-            update: (data: unknown, opts?: unknown) =>
-                baseFetch("update", { ...(opts as any), body: data }),
-            delete: (args: unknown, opts?: unknown) =>
-                baseFetch("delete", { ...(opts as any), body: args }),
-        },
-    };
-    return { client: { models }, Schema: { Todo: { type: {} as any } } };
-});
+vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
 
 vi.mock("@entities/core/auth", () => ({
     canAccess: (_user: unknown, entity: any) => Boolean(entity.allow),

--- a/src/entities/core/utils/__tests__/syncManyToMany.test.ts
+++ b/src/entities/core/utils/__tests__/syncManyToMany.test.ts
@@ -4,16 +4,7 @@ import { relationService } from "@entities/core/services";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 
-vi.mock("@entities/core/services/amplifyClient", () => {
-    const mockModel = {
-        list: (args?: unknown) =>
-            fetch("https://api.test/relation", {
-                method: "POST",
-                body: JSON.stringify(args),
-            }).then((res) => res.json()),
-    };
-    return { client: { models: { TestRelation: mockModel } } };
-});
+vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
 
 describe("syncManyToMany", () => {
     it("appelle createFn et deleteFn avec les ID corrects", async () => {

--- a/src/entities/models/comment/__tests__/service.test.ts
+++ b/src/entities/models/comment/__tests__/service.test.ts
@@ -2,34 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { commentService } from "@entities/models/comment";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
-import type { CommentCreateInput, CommentUpdateInput } from "@src/types/models/comment";
 
-vi.mock("@entities/core/services/amplifyClient", () => {
-    const baseFetch = (op: string, { authMode, body }: { authMode?: string; body?: unknown }) =>
-        fetch(`http://test.local/${op}`, {
-            method: "POST",
-            headers: { "x-auth-mode": authMode ?? "" },
-            body: body ? JSON.stringify(body) : undefined,
-        }).then(async (res) => {
-            if (!res.ok) throw new Error(res.statusText);
-            return res.json();
-        });
-
-    const models = {
-        Comment: {
-            get: (args: { id: string }, opts?: { authMode?: string }) =>
-                baseFetch("get", { ...opts, body: args }),
-            create: (data: CommentCreateInput, opts?: { authMode?: string }) =>
-                baseFetch("create", { ...opts, body: data }),
-            update: (data: CommentUpdateInput & { id: string }, opts?: { authMode?: string }) =>
-                baseFetch("update", { ...opts, body: data }),
-            delete: (args: { id: string }, opts?: { authMode?: string }) =>
-                baseFetch("delete", { ...opts, body: args }),
-        },
-    };
-
-    return { client: { models }, Schema: { Comment: { type: {} as Record<string, never> } } };
-});
+vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
 
 vi.mock("@entities/core/auth", () => ({ canAccess: () => true }));
 

--- a/src/entities/models/todo/__tests__/service.test.ts
+++ b/src/entities/models/todo/__tests__/service.test.ts
@@ -3,32 +3,7 @@ import { todoService } from "@entities/models/todo";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 
-vi.mock("@entities/core/services/amplifyClient", () => {
-    const baseFetch = (op: string, { authMode, body }: { authMode?: string; body?: unknown }) =>
-        fetch(`http://test.local/${op}`, {
-            method: "POST",
-            headers: { "x-auth-mode": authMode ?? "" },
-            body: body ? JSON.stringify(body) : undefined,
-        }).then(async (res) => {
-            if (!res.ok) throw new Error(res.statusText);
-            return res.json();
-        });
-
-    const models = {
-        Todo: {
-            get: (args: unknown, opts?: unknown) =>
-                baseFetch("get", { ...(opts as any), body: args }),
-            create: (data: unknown, opts?: unknown) =>
-                baseFetch("create", { ...(opts as any), body: data }),
-            update: (data: unknown, opts?: unknown) =>
-                baseFetch("update", { ...(opts as any), body: data }),
-            delete: (args: unknown, opts?: unknown) =>
-                baseFetch("delete", { ...(opts as any), body: args }),
-        },
-    };
-
-    return { client: { models }, Schema: { Todo: { type: {} as any } } };
-});
+vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
 
 vi.mock("@entities/core/auth", () => ({ canAccess: () => true }));
 

--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -9,26 +9,7 @@ interface PostTagIds {
     tagId: string;
 }
 
-vi.mock("@entities/core/services/amplifyClient", () => {
-    const mockModel = {
-        list: (args?: unknown, opts?: unknown) =>
-            fetch("https://api.test/postTag/list", {
-                method: "POST",
-                body: JSON.stringify({ args, opts }),
-            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("list error")))),
-        create: (data: unknown, opts?: unknown) =>
-            fetch("https://api.test/postTag/create", {
-                method: "POST",
-                body: JSON.stringify({ data, opts }),
-            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("create error")))),
-        delete: (where: unknown, opts?: unknown) =>
-            fetch("https://api.test/postTag/delete", {
-                method: "POST",
-                body: JSON.stringify({ where, opts }),
-            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("delete error")))),
-    };
-    return { client: { models: { PostTag: mockModel } } };
-});
+vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
 
 describe("postTagService", () => {
     it("listByParent retourne les IDs tag", async () => {

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -9,26 +9,7 @@ interface SectionPostIds {
     postId: string;
 }
 
-vi.mock("@entities/core/services/amplifyClient", () => {
-    const mockModel = {
-        list: (args?: unknown, opts?: unknown) =>
-            fetch("https://api.test/sectionPost/list", {
-                method: "POST",
-                body: JSON.stringify({ args, opts }),
-            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("list error")))),
-        create: (data: unknown, opts?: unknown) =>
-            fetch("https://api.test/sectionPost/create", {
-                method: "POST",
-                body: JSON.stringify({ data, opts }),
-            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("create error")))),
-        delete: (where: unknown, opts?: unknown) =>
-            fetch("https://api.test/sectionPost/delete", {
-                method: "POST",
-                body: JSON.stringify({ where, opts }),
-            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("delete error")))),
-    };
-    return { client: { models: { SectionPost: mockModel } } };
-});
+vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
 
 describe("sectionPostService", () => {
     it("listByParent retourne les IDs post", async () => {

--- a/test/mocks/amplifyClient.ts
+++ b/test/mocks/amplifyClient.ts
@@ -1,0 +1,85 @@
+const baseFetch = (url: string, { authMode, body }: { authMode?: string; body?: unknown } = {}) =>
+    fetch(url, {
+        method: "POST",
+        headers: { "x-auth-mode": authMode ?? "" },
+        body: body ? JSON.stringify(body) : undefined,
+    }).then(async (res) => {
+        if (!res.ok) throw new Error(res.statusText);
+        return res.json();
+    });
+
+const models = {
+    Todo: {
+        list: (opts?: unknown) => baseFetch("http://test.local/list", opts as any),
+        get: (args: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/get", { ...(opts as any), body: args }),
+        create: (data: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/create", { ...(opts as any), body: data }),
+        update: (data: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/update", { ...(opts as any), body: data }),
+        delete: (args: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/delete", { ...(opts as any), body: args }),
+    },
+    Comment: {
+        get: (args: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/get", { ...(opts as any), body: args }),
+        create: (data: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/create", { ...(opts as any), body: data }),
+        update: (data: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/update", { ...(opts as any), body: data }),
+        delete: (args: unknown, opts?: unknown) =>
+            baseFetch("http://test.local/delete", { ...(opts as any), body: args }),
+    },
+    SectionPost: {
+        list: (args?: unknown, opts?: unknown) =>
+            fetch("https://api.test/sectionPost/list", {
+                method: "POST",
+                body: JSON.stringify({ args, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("list error")))),
+        create: (data: unknown, opts?: unknown) =>
+            fetch("https://api.test/sectionPost/create", {
+                method: "POST",
+                body: JSON.stringify({ data, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("create error")))),
+        delete: (where: unknown, opts?: unknown) =>
+            fetch("https://api.test/sectionPost/delete", {
+                method: "POST",
+                body: JSON.stringify({ where, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("delete error")))),
+    },
+    PostTag: {
+        list: (args?: unknown, opts?: unknown) =>
+            fetch("https://api.test/postTag/list", {
+                method: "POST",
+                body: JSON.stringify({ args, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("list error")))),
+        create: (data: unknown, opts?: unknown) =>
+            fetch("https://api.test/postTag/create", {
+                method: "POST",
+                body: JSON.stringify({ data, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("create error")))),
+        delete: (where: unknown, opts?: unknown) =>
+            fetch("https://api.test/postTag/delete", {
+                method: "POST",
+                body: JSON.stringify({ where, opts }),
+            }).then((res) => (res.ok ? res.json() : Promise.reject(new Error("delete error")))),
+    },
+    TestRelation: {
+        list: (args?: unknown) =>
+            fetch("https://api.test/relation", {
+                method: "POST",
+                body: JSON.stringify(args),
+            }).then((res) => res.json()),
+    },
+};
+
+export const client = { models } as const;
+export const Schema = {
+    Todo: { type: {} as any },
+    Comment: { type: {} as any },
+    SectionPost: { type: {} as any },
+    PostTag: { type: {} as any },
+    TestRelation: { type: {} as any },
+} as const;
+
+export type Schema = typeof Schema;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,3 +1,4 @@
+import "tsconfig-paths/register";
 import { beforeAll, afterEach, afterAll } from "vitest";
 import { setupServer } from "msw/node";
 import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Objectif
- centraliser le mock `amplifyClient` pour les tests
- remplacer les mock inline par l'import du mock commun

## Tests effectués
- `yarn lint`
- `npx vitest run` *(échoue: Cannot find module '@test/mocks/amplifyClient')*


------
https://chatgpt.com/codex/tasks/task_e_68ab0140217c8324aa8bfeedd4ecc551