### PR TITLE
[Fix] utilise import pour mock amplifyClient

### DIFF
--- a/src/entities/core/services/__tests__/crudService.test.ts
+++ b/src/entities/core/services/__tests__/crudService.test.ts
@@ -3,7 +3,7 @@ import { crudService } from "@entities/core/services";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 
-vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
+vi.mock("@entities/core/services/amplifyClient", () => import("@test/mocks/amplifyClient"));
 
 vi.mock("@entities/core/auth", () => ({
     canAccess: (_user: unknown, entity: any) => Boolean(entity.allow),

--- a/src/entities/core/utils/__tests__/syncManyToMany.test.ts
+++ b/src/entities/core/utils/__tests__/syncManyToMany.test.ts
@@ -4,7 +4,7 @@ import { relationService } from "@entities/core/services";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 
-vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
+vi.mock("@entities/core/services/amplifyClient", () => import("@test/mocks/amplifyClient"));
 
 describe("syncManyToMany", () => {
     it("appelle createFn et deleteFn avec les ID corrects", async () => {

--- a/src/entities/models/comment/__tests__/service.test.ts
+++ b/src/entities/models/comment/__tests__/service.test.ts
@@ -3,7 +3,7 @@ import { commentService } from "@entities/models/comment";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 
-vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
+vi.mock("@entities/core/services/amplifyClient", () => import("@test/mocks/amplifyClient"));
 
 vi.mock("@entities/core/auth", () => ({ canAccess: () => true }));
 

--- a/src/entities/models/todo/__tests__/service.test.ts
+++ b/src/entities/models/todo/__tests__/service.test.ts
@@ -3,7 +3,7 @@ import { todoService } from "@entities/models/todo";
 import { http, HttpResponse } from "msw";
 import { server } from "@test/setup";
 
-vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
+vi.mock("@entities/core/services/amplifyClient", () => import("@test/mocks/amplifyClient"));
 
 vi.mock("@entities/core/auth", () => ({ canAccess: () => true }));
 

--- a/src/entities/relations/postTag/__tests__/service.test.ts
+++ b/src/entities/relations/postTag/__tests__/service.test.ts
@@ -9,7 +9,7 @@ interface PostTagIds {
     tagId: string;
 }
 
-vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
+vi.mock("@entities/core/services/amplifyClient", () => import("@test/mocks/amplifyClient"));
 
 describe("postTagService", () => {
     it("listByParent retourne les IDs tag", async () => {

--- a/src/entities/relations/sectionPost/__tests__/service.test.ts
+++ b/src/entities/relations/sectionPost/__tests__/service.test.ts
@@ -9,7 +9,7 @@ interface SectionPostIds {
     postId: string;
 }
 
-vi.mock("@entities/core/services/amplifyClient", () => require("@test/mocks/amplifyClient"));
+vi.mock("@entities/core/services/amplifyClient", () => import("@test/mocks/amplifyClient"));
 
 describe("sectionPostService", () => {
     it("listByParent retourne les IDs post", async () => {


### PR DESCRIPTION
## Description
- remplace `require` par `import` lors du mock d'`amplifyClient` dans les tests

## Tests effectués
- `yarn prettier --write src/entities/core/services/__tests__/crudService.test.ts src/entities/core/utils/__tests__/syncManyToMany.test.ts src/entities/models/comment/__tests__/service.test.ts src/entities/models/todo/__tests__/service.test.ts src/entities/relations/postTag/__tests__/service.test.ts src/entities/relations/sectionPost/__tests__/service.test.ts`
- `yarn lint`
- `yarn test` *(échoue : plusieurs tests unitaires ne passent pas)*

------
https://chatgpt.com/codex/tasks/task_e_68ab12e10d008324bc5c0c0c3e814ec4