### PR TITLE
[Fix] remplacement de useModelForm et correctif syncManyToMany

### DIFF
--- a/src/entities/core/utils/syncManyToMany.ts
+++ b/src/entities/core/utils/syncManyToMany.ts
@@ -15,7 +15,7 @@ export async function syncManyToMany(
 
     const run = async <T>(items: T[], fn: (x: T) => Promise<unknown>) => {
         for (let i = 0; i < items.length; i += concurrency) {
-            await Promise.all(items.slice(i, i + concurrency).map(fn));
+            await Promise.all(items.slice(i, i + concurrency).map((item) => fn(item)));
         }
     };
 


### PR DESCRIPTION
## Description
- remplace complètement `useModelForm` par une version enrichie avec gestion d'état, messages et chargement
- corrige `syncManyToMany` pour ne passer que l'identifiant aux callbacks

## Tests effectués
- `yarn lint`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ab19cb0dd08324823c95de2a6c3689