### PR TITLE
[Fix] Passer uniquement l'identifiant dans syncManyToMany

### DIFF
--- a/src/entities/core/utils/syncManyToMany.ts
+++ b/src/entities/core/utils/syncManyToMany.ts
@@ -15,7 +15,7 @@ export async function syncManyToMany(
 
     const run = async <T>(items: T[], fn: (x: T) => Promise<unknown>) => {
         for (let i = 0; i < items.length; i += concurrency) {
-            await Promise.all(items.slice(i, i + concurrency).map(fn));
+            await Promise.all(items.slice(i, i + concurrency).map((id) => fn(id)));
         }
     };
 


### PR DESCRIPTION
## Description
- appeler la fonction de synchronisation many-to-many uniquement avec l'identifiant

## Tests effectués
- `yarn lint`
- `yarn test src/entities/core/utils/__tests__/syncManyToMany.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab199719f48324a4c21c7dd74a737b