### PR TITLE
[Fix] réinitialisation du mode édition sur annulation

### DIFF
--- a/src/components/Blog/manage/authors/CreateAuthor.tsx
+++ b/src/components/Blog/manage/authors/CreateAuthor.tsx
@@ -21,8 +21,7 @@ export default function AuthorManagerPage() {
         listAuthors,
         selectById,
         deleteEntity,
-        setForm,
-        setMode,
+        exitEditMode,
     } = manager;
 
     useEffect(() => {
@@ -50,8 +49,9 @@ export default function AuthorManagerPage() {
     }, [listAuthors]);
 
     const handleCancel = useCallback(() => {
+        exitEditMode();
         setAuthorToEdit(null);
-    }, [setMode, setForm]);
+    }, [exitEditMode]);
 
     return (
         <RequireAdmin>

--- a/src/components/Blog/manage/sections/CreateSection.tsx
+++ b/src/components/Blog/manage/sections/CreateSection.tsx
@@ -22,6 +22,7 @@ export default function SectionManagerPage() {
         listSections,
         selectById,
         deleteEntity,
+        exitEditMode,
     } = manager;
 
     useEffect(() => {
@@ -49,8 +50,9 @@ export default function SectionManagerPage() {
     }, [listSections]);
 
     const handleCancel = useCallback(() => {
+        exitEditMode();
         setSectionToEdit(null);
-    }, []);
+    }, [exitEditMode]);
 
     return (
         <RequireAdmin>

--- a/src/components/Blog/manage/tags/CreateTag.tsx
+++ b/src/components/Blog/manage/tags/CreateTag.tsx
@@ -27,6 +27,7 @@ export default function CreateTagPage() {
         listTags,
         selectById,
         deleteEntity,
+        exitEditMode,
         tagsForPost,
         isTagLinked,
         toggle,
@@ -57,8 +58,9 @@ export default function CreateTagPage() {
     }, [listTags]);
 
     const handleCancel = useCallback(() => {
+        exitEditMode();
         setTagToEdit(null);
-    }, []);
+    }, [exitEditMode]);
 
     return (
         <RequireAdmin>


### PR DESCRIPTION
## Description
- ajoute `exitEditMode` dans les gestionnaires d'auteurs, tags et sections
- appelle `exitEditMode()` puis réinitialise l'entité en cours lors de l'annulation

## Tests effectués
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ca16a4483249788ff3079bf4641