### PR TITLE
feat: typage labels génériques dans UserProfileManager

### DIFF
--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -115,7 +115,7 @@ export default function UserProfileManager() {
                 reset={manager.reset}
                 setForm={manager.setForm}
                 fields={fields}
-                labels={(f) => fieldLabel(f as any)}
+                labels={(f: keyof UserProfileFormType) => fieldLabel(f)}
                 updateEntity={manager.updateEntity}
                 clearField={manager.clearField}
                 // Wrapper “à la AuthorList.onDeleteById”


### PR DESCRIPTION
## Description
- typage générique pour la fonction `labels` dans `UserProfileManager`

## Checklist de vérification
- [ ] `yarn lint`
- [ ] `yarn tsc -noEmit`
- [ ] `yarn test`

## Bénéfices
- sécurise le typage des libellés du profil utilisateur

------
https://chatgpt.com/codex/tasks/task_e_68b2431b4bd88324b6c76f79038a2a93