### PR TITLE
feat: étendre EditableField avec nouveaux attributs

### DIFF
--- a/src/components/Blog/manage/authors/AuthorForm.tsx
+++ b/src/components/Blog/manage/authors/AuthorForm.tsx
@@ -40,6 +40,7 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
                 value={form.authorName ?? ""}
                 onChange={onChange}
                 readOnly={false}
+                autoComplete="name"
             />
 
             <EditableField
@@ -48,6 +49,8 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
                 value={form.avatar ?? ""}
                 onChange={onChange}
                 readOnly={false}
+                type="url"
+                autoComplete="url"
             />
 
             <EditableTextArea
@@ -64,6 +67,8 @@ const AuthorForm = forwardRef<HTMLFormElement, Props>(function AuthorForm(
                 value={form.email ?? ""}
                 onChange={onChange}
                 readOnly={false}
+                type="email"
+                autoComplete="email"
             />
 
             {/* Aligne avec PostForm → contrôle d'ordre */}

--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -98,6 +98,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 value={form.title}
                 onChange={onChange}
                 readOnly={false}
+                autoComplete="off"
             />
             <EditableTextArea
                 name="excerpt"
@@ -112,6 +113,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 value={form.slug}
                 onChange={onChange}
                 readOnly={false}
+                autoComplete="off"
             />
             <SeoFields
                 seo={{
@@ -128,6 +130,8 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 value={form.videoUrl ?? ""}
                 onChange={onChange}
                 readOnly={false}
+                type="url"
+                autoComplete="url"
             />
             <EditableTextArea
                 name="content"

--- a/src/components/Blog/manage/sections/SectionsForm.tsx
+++ b/src/components/Blog/manage/sections/SectionsForm.tsx
@@ -97,6 +97,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
                 value={form.title}
                 onChange={onChange}
                 readOnly={false}
+                autoComplete="off"
             />
 
             <EditableField
@@ -105,6 +106,7 @@ const SectionForm = forwardRef<HTMLFormElement, Props>(function SectionForm(
                 value={form.slug}
                 onChange={onChange}
                 readOnly={false}
+                autoComplete="off"
             />
 
             <EditableTextArea

--- a/src/components/Blog/manage/tags/TagForm.tsx
+++ b/src/components/Blog/manage/tags/TagForm.tsx
@@ -45,6 +45,7 @@ const TagForm = forwardRef<HTMLFormElement, Props>(function TagForm(
                 value={form.name ?? ""}
                 onChange={onChange}
                 readOnly={false}
+                autoComplete="off"
             />
         </BlogFormShell>
     );

--- a/src/components/ui/Form/EditableField.tsx
+++ b/src/components/ui/Form/EditableField.tsx
@@ -8,6 +8,9 @@ type EditableFieldProps = {
     name: string;
     onFocus?: (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
     onBlur?: (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+    type?: string;
+    autoComplete?: string;
+    ariaDescribedBy?: string;
 };
 
 const EditableField = ({
@@ -18,13 +21,16 @@ const EditableField = ({
     name,
     onFocus,
     onBlur,
+    type,
+    autoComplete,
+    ariaDescribedBy,
 }: EditableFieldProps) => (
     <div className="mb-4">
         <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor={name}>
             {label}
         </label>
         <input
-            type="text"
+            type={type ?? "text"}
             id={name}
             name={name}
             value={value ?? ""}
@@ -32,7 +38,9 @@ const EditableField = ({
             onFocus={onFocus}
             onBlur={onBlur}
             readOnly={readOnly}
-            className={`w-full px-3 py-2 rounded-md border text-sm shadow-sm transition 
+            autoComplete={autoComplete}
+            aria-describedby={ariaDescribedBy}
+            className={`w-full px-3 py-2 rounded-md border text-sm shadow-sm transition
                 ${
                     readOnly
                         ? "bg-gray-100 border-gray-300 text-gray-500 cursor-not-allowed"

--- a/src/components/ui/Form/SeoFields.tsx
+++ b/src/components/ui/Form/SeoFields.tsx
@@ -23,6 +23,7 @@ export default function SeoFields({ seo, readOnly, onChange }: SeoFieldsProps) {
                 value={seo.title}
                 onChange={onChange}
                 readOnly={readOnly}
+                autoComplete="off"
             />
             <EditableField
                 name="seo.description"
@@ -30,6 +31,7 @@ export default function SeoFields({ seo, readOnly, onChange }: SeoFieldsProps) {
                 value={seo.description}
                 onChange={onChange}
                 readOnly={readOnly}
+                autoComplete="off"
             />
             <EditableField
                 name="seo.image"
@@ -37,6 +39,8 @@ export default function SeoFields({ seo, readOnly, onChange }: SeoFieldsProps) {
                 value={seo.image}
                 onChange={onChange}
                 readOnly={readOnly}
+                type="url"
+                autoComplete="url"
             />
         </fieldset>
     );


### PR DESCRIPTION
## Description
- ajoute les props `type`, `autoComplete` et `ariaDescribedBy` à `EditableField`
- propage ces attributs à l'élément `<input>`
- met à jour les formulaires pour utiliser ces nouvelles options

## Vérifications
- [ ] `yarn lint`
- [ ] `yarn test`

## Bénéfices
- meilleure personnalisation des champs
- amélioration potentielle de l'accessibilité

------
https://chatgpt.com/codex/tasks/task_e_68b24580bedc83248b0e681de37dc872