### PR TITLE
feat: gérer autoComplete et aria-describedby dans EditableTextArea

### DIFF
--- a/src/components/ui/Form/EditableTextArea.tsx
+++ b/src/components/ui/Form/EditableTextArea.tsx
@@ -8,6 +8,8 @@ type EditableTextAreaProps = {
     name: string;
     onFocus?: (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
     onBlur?: (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+    autoComplete?: string;
+    ariaDescribedBy?: string;
 };
 
 const EditableTextArea = ({
@@ -18,6 +20,8 @@ const EditableTextArea = ({
     name,
     onFocus,
     onBlur,
+    autoComplete,
+    ariaDescribedBy,
 }: EditableTextAreaProps) => (
     <div style={{ marginBottom: "1rem" }}>
         <label htmlFor={name} style={{ display: "block", marginBottom: "0.5rem" }}>
@@ -31,6 +35,8 @@ const EditableTextArea = ({
             onFocus={onFocus}
             onBlur={onBlur}
             readOnly={readOnly}
+            autoComplete={autoComplete}
+            aria-describedby={ariaDescribedBy}
             style={{
                 width: "100%",
                 padding: "8px",


### PR DESCRIPTION
## Description
- ajoute les props `autoComplete` et `ariaDescribedBy` à `EditableTextArea`
- propage les attributs correspondants sur l'élément `<textarea>`

## Tests
- `yarn lint` *(échoue : Unexpected any et variables inutilisées)*
- `yarn tsc -noEmit` *(échoue : Cannot find module '@/amplify_outputs.json')*
- `yarn test` *(échoue : Invalid PostCSS Plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68b24583c52c8324b9a083901e7b886e