### PR TITLE
feat(form): désactive l'autocomplétion des SelectField

### DIFF
--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -141,6 +141,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 name="status"
                 value={form.status ?? ""}
                 onChange={onChange}
+                autoComplete="off"
                 options={[
                     { value: "draft", label: "Brouillon" },
                     { value: "published", label: "Publié" },
@@ -151,6 +152,7 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                 name="authorId"
                 value={form.authorId}
                 onChange={onChange}
+                autoComplete="off"
                 options={[
                     { value: "", label: "Sélectionner un auteur" },
                     ...authors

--- a/src/components/ui/Form/OrderSelector.tsx
+++ b/src/components/ui/Form/OrderSelector.tsx
@@ -32,6 +32,7 @@ export default function OrderSelector({ items, editingId, value, onReorder }: Pr
             name="order"
             value={String(safeValue)}
             onChange={setFieldValue}
+            autoComplete="off"
             options={options}
         />
     );


### PR DESCRIPTION
## Description
- ajoute `autoComplete="off"` aux `SelectField` dans `PostForm`
- applique la même propriété dans `OrderSelector`

## Checklist de vérification
- [ ] Tous les tests unitaires passent ✅
- [ ] Tous les tests d’intégration passent ✅
- [ ] Tous les tests E2E passent ✅
- [ ] Les tests modifiés sont documentés et commentés si nécessaire
- [ ] La couverture de code reste satisfaisante

## Bénéfices
- Prévention de la complétion automatique indésirable dans les formulaires
- Uniformisation du comportement des composants `SelectField`


------
https://chatgpt.com/codex/tasks/task_e_68b24592d00883249c926ca4f540fd4c