### PR TITLE
feat(form): support field autocomplete tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ Des exemples d'utilisation du composant `EntityEditor` sont disponibles :
 - [UserProfileExample.tsx](src/examples/UserProfileExample.tsx)
 - [UserNameExample.tsx](src/examples/UserNameExample.tsx)
 
+### Autocomplétion des champs
+
+Le composant `EntityForm` accepte désormais la prop `fieldAutoComplete`,
+un objet qui associe à chaque champ un token d'autocomplétion HTML
+(`email`, `given-name`, `family-name`, etc.).
+Cela permet aux navigateurs de proposer des valeurs pertinentes lors de la saisie.
+
+```tsx
+<EntityEditor
+    fieldAutoComplete={{
+        email: "email",
+        firstName: "given-name",
+        familyName: "family-name",
+    }}
+    {...autresProps}
+/>
+```
+
 ## Deploying to AWS
 
 For detailed instructions on deploying your application, refer to the [deployment section](https://docs.amplify.aws/nextjs/start/quickstart/nextjs-app-router-client-components/#deploy-a-fullstack-app-to-aws) of our documentation.

--- a/src/components/Profile/UserNameManager.tsx
+++ b/src/components/Profile/UserNameManager.tsx
@@ -16,6 +16,9 @@ import {
 
 type IdLike = string | number;
 const fields: (keyof UserNameFormType)[] = ["userName"];
+const fieldAutoComplete: Partial<Record<keyof UserNameFormType, string>> = {
+    userName: "username",
+};
 
 export default function UserNameManager() {
     const { user } = useAuthenticator();
@@ -73,6 +76,7 @@ export default function UserNameManager() {
             setForm={manager.setForm}
             fields={fields}
             labels={fieldLabel as (field: keyof UserNameFormType) => string}
+            fieldAutoComplete={fieldAutoComplete}
             updateEntity={manager.updateEntity}
             clearField={manager.clearField}
             deleteEntity={async (id?: string) => {

--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -27,6 +27,16 @@ const fields: (keyof UserProfileFormType)[] = [
     "country",
 ];
 
+const fieldAutoComplete: Partial<Record<keyof UserProfileFormType, string>> = {
+    firstName: "given-name",
+    familyName: "family-name",
+    phoneNumber: "tel",
+    address: "street-address",
+    postalCode: "postal-code",
+    city: "address-level2",
+    country: "country",
+};
+
 export default function UserProfileManager() {
     const { user } = useAuthenticator();
     const [profileToEdit, setProfileToEdit] = useState<UserProfileType | null>(null);
@@ -116,6 +126,7 @@ export default function UserProfileManager() {
                 setForm={manager.setForm}
                 fields={fields}
                 labels={(f: keyof UserProfileFormType) => fieldLabel(f)}
+                fieldAutoComplete={fieldAutoComplete}
                 updateEntity={manager.updateEntity}
                 clearField={manager.clearField}
                 // Wrapper “à la AuthorList.onDeleteById”

--- a/src/components/ui/Form/EntityEditor.tsx
+++ b/src/components/ui/Form/EntityEditor.tsx
@@ -41,6 +41,11 @@ type EntityEditorProps<T extends Record<string, unknown>> = {
     fields: FieldKey<T>[];
     /** Libellés des champs */
     labels: (field: FieldKey<T>) => string;
+    /**
+     * Tokens d'autocomplétion pour chaque champ.
+     * Voir https://developer.mozilla.org/docs/Web/HTML/Attributes/autocomplete
+     */
+    fieldAutoComplete?: Partial<Record<FieldKey<T>, string>>;
     /** Sauvegarde d'un champ individuel */
     updateEntity?: (field: FieldKey<T>, value: string) => Promise<void>;
     /** Effacement d'un champ individuel */
@@ -68,6 +73,7 @@ export default function EntityEditor<T extends Record<string, unknown>>(
         reset,
         fields,
         labels,
+        fieldAutoComplete,
         updateEntity,
         clearField,
         deleteEntity,
@@ -138,6 +144,7 @@ export default function EntityEditor<T extends Record<string, unknown>>(
                     isEdit={false}
                     onCancel={handleCancel}
                     requiredFields={requiredFields}
+                    fieldAutoComplete={fieldAutoComplete}
                 />
             )}
 

--- a/src/components/ui/Form/EntityForm.tsx
+++ b/src/components/ui/Form/EntityForm.tsx
@@ -13,6 +13,11 @@ type Props<T extends Record<string, unknown>> = {
     isEdit: boolean;
     onCancel: () => void;
     requiredFields: FieldKey<T>[];
+    /**
+     * Tokens d'autocomplétion HTML pour chaque champ.
+     * Exemple : { email: "email", firstName: "given-name" }
+     */
+    fieldAutoComplete?: Partial<Record<FieldKey<T>, string>>;
 };
 
 export default function EntityForm<T extends Record<string, unknown>>({
@@ -24,6 +29,7 @@ export default function EntityForm<T extends Record<string, unknown>>({
     isEdit,
     onCancel,
     requiredFields,
+    fieldAutoComplete = {},
 }: Props<T>) {
     return (
         <form
@@ -45,6 +51,7 @@ export default function EntityForm<T extends Record<string, unknown>>({
                         value={String(formData[field] ?? "")}
                         onChange={(e) => setFieldValue(field, e.target.value)}
                         className="w-full p-2 border rounded"
+                        autoComplete={fieldAutoComplete[field] ?? "off"}
                         required={requiredFields.includes(field)}
                     />
                 </div>


### PR DESCRIPTION
## Description
- allow EntityForm to accept per-field autocomplete tokens
- document fieldAutoComplete API and update profile managers

## Checklist
- [ ] `yarn lint`
- [ ] `yarn tsc -noEmit`
- [ ] `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b2458956c08324acf191323df94967