### PR TITLE
chore: enrichir les cases à cocher du PostForm

### DIFF
--- a/src/components/Blog/manage/posts/PostForm.tsx
+++ b/src/components/Blog/manage/posts/PostForm.tsx
@@ -174,6 +174,10 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                         <label key={tag.id} className="block">
                             <input
                                 type="checkbox"
+                                name="tagIds"
+                                value={tag.id}
+                                id={`tag-${tag.id}`}
+                                autoComplete="off"
                                 checked={form.tagIds.includes(tag.id)}
                                 onChange={() => toggleTag(tag.id)}
                             />
@@ -190,6 +194,10 @@ const PostForm = forwardRef<HTMLFormElement, Props>(function PostForm(
                         <label key={section.id} className="block">
                             <input
                                 type="checkbox"
+                                name="sectionIds"
+                                value={section.id}
+                                id={`section-${section.id}`}
+                                autoComplete="off"
                                 checked={form.sectionIds.includes(section.id)}
                                 onChange={() => toggleSection(section.id)}
                             />


### PR DESCRIPTION
## Description
- ajoute `name`, `value` et `id` aux cases à cocher des tags et des sections
- désactive l'autocomplétion pour ces champs afin d'éviter des interférences du navigateur

## Checklist de vérification
- [ ] Tous les tests unitaires passent
- [ ] Tous les tests d’intégration passent
- [ ] Tous les tests E2E passent
- [ ] Les tests modifiés sont documentés et commentés si nécessaire
- [ ] La couverture de code reste satisfaisante

## Bénéfices
- identification explicite des tags et sections lors de la soumission du formulaire
- meilleure expérience utilisateur sans autocomplétion intempestive

------
https://chatgpt.com/codex/tasks/task_e_68b245908058832496d84838df67de84